### PR TITLE
Fix ByteArrayDataInput Javadoc

### DIFF
--- a/guava/src/com/google/common/io/ByteArrayDataInput.java
+++ b/guava/src/com/google/common/io/ByteArrayDataInput.java
@@ -23,7 +23,7 @@ import java.io.IOException;
  * An extension of {@code DataInput} for reading from in-memory byte arrays; its
  * methods offer identical functionality but do not throw {@link IOException}.
  *
- * <p><b>Warning:<b> The caller is responsible for not attempting to read past
+ * <p><b>Warning:</b> The caller is responsible for not attempting to read past
  * the end of the array. If any method encounters the end of the array
  * prematurely, it throws {@link IllegalStateException} to signify <i>programmer
  * error</i>. This behavior is a technical violation of the supertype's


### PR DESCRIPTION
So Guava moved to Github! This is my first (and very small) fix: I spotted improperly closed tag in [ByteArrayDataInput's Javadoc](http://docs.guava-libraries.googlecode.com/git-history/v18.0/javadoc/com/google/common/io/ByteArrayDataInput.html). Should be OK now.
