### PR TITLE
NullPointerTester: allow to override the exception type policy

### DIFF
--- a/guava-testlib/src/com/google/common/testing/NullPointerTester.java
+++ b/guava-testlib/src/com/google/common/testing/NullPointerTester.java
@@ -75,6 +75,15 @@ public final class NullPointerTester {
   private ExceptionTypePolicy policy = ExceptionTypePolicy.NPE_OR_UOE;
 
   /**
+   * Accept {@link java.lang.IllegalArgumentException} instead of
+   * {@link java.lang.NullPointerException}
+   */
+  public NullPointerTester allowIllegalArgumentExceptionOnNullViolations() {
+    policy = ExceptionTypePolicy.NPE_IAE_OR_UOE;
+    return this;
+  }
+
+  /**
    * Sets a default value that can be used for any parameter of type
    * {@code type}. Returns this object.
    */

--- a/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
@@ -1277,4 +1277,151 @@ public class NullPointerTesterTest extends TestCase {
   private static String rootLocaleFormat(String format, Object... args) {
     return String.format(Locale.ROOT, format, args);
   }
+
+  private static class ReportsNullViolationsByThrowingNullpointerException {
+
+    public ReportsNullViolationsByThrowingNullpointerException(String arg) {
+      checkNotNull(arg);
+    }
+
+    public static void failWithNullpointerException__static(String arg) {
+      checkNotNull(arg);
+    }
+
+    public void failWithNullpointerException__nonStatic(String arg) {
+      checkNotNull(arg);
+    }
+
+  }
+
+  private static class ReportsNullViolationsByThrowingIllegalArgumentException {
+
+    public ReportsNullViolationsByThrowingIllegalArgumentException(String arg) {
+      if (arg == null) {
+        throw new IllegalArgumentException();
+      }
+    }
+
+    public static void failWithIllegalArgumentException__static(String arg) {
+      if (arg == null) {
+        throw new IllegalArgumentException();
+      }
+    }
+
+    public void failWithIllegalArgumentException__nonStatic(String arg) {
+      if (arg == null) {
+        throw new IllegalArgumentException();
+      }
+    }
+  }
+
+  private static class ThrowUnsupportedOperations {
+
+    public ThrowUnsupportedOperations() {
+    }
+
+    public ThrowUnsupportedOperations(String arg) {
+      throw new UnsupportedOperationException();
+    }
+
+    public static void unsupportedOperation__static(String arg) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void unsupportedOperation__nonStatic(String arg) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // default policy: NullpointerException or UnsupportedOperationException
+
+  public void testDefaultPolicy__NullPointerExceptionIsOk() {
+    new NullPointerTester()
+            .testAllPublicConstructors(ReportsNullViolationsByThrowingNullpointerException.class);
+    new NullPointerTester()
+            .testAllPublicStaticMethods(ReportsNullViolationsByThrowingNullpointerException.class);
+    new NullPointerTester()
+            .testAllPublicInstanceMethods(new ReportsNullViolationsByThrowingNullpointerException(
+                    "dummy string"));
+  }
+
+  public void testDefaultPolicy__IllegalArgumentExceptionMustFail__constructor() {
+    try {
+      new NullPointerTester()
+              .testAllPublicConstructors(ReportsNullViolationsByThrowingIllegalArgumentException.class);
+      fail();
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  public void testDefaultPolicy__IllegalArgumentExceptionMustFail__staticMethod() {
+    try {
+      new NullPointerTester()
+              .testAllPublicStaticMethods(ReportsNullViolationsByThrowingNullpointerException.class);
+      fail();
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  public void testDefaultPolicy__IllegalArgumentExceptionMustFail__nonStaticMethod() {
+    try {
+      new NullPointerTester()
+              .testAllPublicInstanceMethods(new ReportsNullViolationsByThrowingIllegalArgumentException(
+                      "dummy string"));
+      fail();
+    } catch (AssertionError e) {
+      // expected
+    }
+  }
+
+  public void testDefaultPolicy__UnsupportedOperationExceptionIsOk() {
+    new NullPointerTester().testAllPublicConstructors(ThrowUnsupportedOperations.class);
+    new NullPointerTester().testAllPublicStaticMethods(ThrowUnsupportedOperations.class);
+    new NullPointerTester().testAllPublicInstanceMethods(new ThrowUnsupportedOperations());
+  }
+
+  // custom policy: NullpointerException, IllegalArgumentException or UnsupportedOperationException
+
+  public void testAllowIllegalArgumentOnNullViolations__NullPointerExceptionIsOk() {
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicConstructors(
+                    ReportsNullViolationsByThrowingNullpointerException.class);
+
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicStaticMethods(
+                    ReportsNullViolationsByThrowingNullpointerException.class);
+
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicInstanceMethods(
+                    new ReportsNullViolationsByThrowingNullpointerException("dummy string"));
+  }
+
+  public void testAllowIllegalArgumentOnNullViolations__IllegalArgumentExceptionIsOk() {
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicConstructors(
+                    ReportsNullViolationsByThrowingIllegalArgumentException.class);
+
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicStaticMethods(
+                    ReportsNullViolationsByThrowingIllegalArgumentException.class);
+
+    new NullPointerTester()
+            .allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicInstanceMethods(
+                    new ReportsNullViolationsByThrowingIllegalArgumentException("dummy string"));
+  }
+
+  public void testAllowIllegalArgumentOnNullViolations__UnsupportedOperationExceptionIsOk() {
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicConstructors(ThrowUnsupportedOperations.class);
+
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicStaticMethods(ThrowUnsupportedOperations.class);
+
+    new NullPointerTester().allowIllegalArgumentExceptionOnNullViolations()
+            .testAllPublicInstanceMethods(new ThrowUnsupportedOperations());
+  }
+
 }


### PR DESCRIPTION
NullPointerTester already knows the concept of a ExceptionTypePolicy.
However, the field "policy" is always set to a default value.

This patch adds an option to overwrite the policy to
allow IllegalArgumentExceptions. It also adds some unit tests.
