### PR TITLE
Jdk5 backport v17.0 compatibility

### DIFF
--- a/guava-bootstrap/pom.xml
+++ b/guava-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc2</version>
+    <version>17.0</version>
   </parent>
   <artifactId>guava-bootstrap-jdk5</artifactId>
   <name>Guava Compilation Bootstrap Classes (JDK5 Backport)</name>

--- a/guava-bootstrap/pom.xml
+++ b/guava-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc1</version>
+    <version>17.0-rc2</version>
   </parent>
   <artifactId>guava-bootstrap-jdk5</artifactId>
   <name>Guava Compilation Bootstrap Classes (JDK5 Backport)</name>

--- a/guava-bootstrap/pom.xml
+++ b/guava-bootstrap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-SNAPSHOT</version>
+    <version>17.0-rc1</version>
   </parent>
   <artifactId>guava-bootstrap-jdk5</artifactId>
   <name>Guava Compilation Bootstrap Classes (JDK5 Backport)</name>

--- a/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Stopwatch.java
+++ b/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Stopwatch.java
@@ -122,10 +122,11 @@ public final class Stopwatch {
    * Creates (but does not start) a new stopwatch using {@link System#nanoTime}
    * as its time source.
    *
-   * @deprecated Use {@link Stopwatch#createUnstarted()} instead.
+   * @deprecated Use {@link Stopwatch#createUnstarted()} instead. This
+   *     constructor is scheduled to be removed in Guava release 17.0.
    */
   @Deprecated
-  Stopwatch() {
+  public Stopwatch() {
     this(Ticker.systemTicker());
   }
 
@@ -133,10 +134,11 @@ public final class Stopwatch {
    * Creates (but does not start) a new stopwatch, using the specified time
    * source.
    *
-   * @deprecated Use {@link Stopwatch#createUnstarted(Ticker)} instead.
+   * @deprecated Use {@link Stopwatch#createUnstarted(Ticker)} instead. This
+   *     constructor is scheduled to be removed in Guava release 17.0.
    */
   @Deprecated
-  Stopwatch(Ticker ticker) {
+  public Stopwatch(Ticker ticker) {
     this.ticker = checkNotNull(ticker, "ticker");
   }
 
@@ -250,3 +252,4 @@ public final class Stopwatch {
     }
   }
 }
+

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/FluentIterable.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/FluentIterable.java
@@ -413,6 +413,64 @@ public abstract class FluentIterable<E> implements Iterable<E> {
   }
 
   /**
+   * Returns an {@code ImmutableList} containing all of the elements from this
+   * fluent iterable in proper sequence.
+   *
+   * @deprecated Use {@link #toList()} instead. This method is scheduled for removal in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableList<E> toImmutableList() {
+    return toList();
+  }
+
+  /**
+   * Returns an {@code ImmutableList} containing all of the elements from this
+   * {@code FluentIterable} in the order specified by {@code comparator}.  To produce an
+   * {@code ImmutableList} sorted by its natural ordering, use
+   * {@code toSortedImmutableList(Ordering.natural())}.
+   *
+   * @param comparator the function by which to sort list elements
+   * @throws NullPointerException if any element is null
+   * @since 13.0
+   * @deprecated Use {@link #toSortedList(Comparator)} instead. This method is scheduled for removal
+   *     in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableList<E> toSortedImmutableList(
+      Comparator<? super E> comparator) {
+    return toSortedList(comparator);
+  }
+
+  /**
+   * Returns an {@code ImmutableSet} containing all of the elements from this
+   * fluent iterable with duplicates removed.
+   *
+   * @deprecated Use {@link #toSet()} instead. This method is scheduled for removal in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableSet<E> toImmutableSet() {
+    return toSet();
+  }
+
+  /**
+   * Returns an {@code ImmutableSortedSet} containing all of the elements from this
+   * {@code FluentIterable} in the order specified by {@code comparator}, with duplicates
+   * (determined by {@code comparator.compare(x, y) == 0}) removed. To produce an
+   * {@code ImmutableSortedSet} sorted by its natural ordering, use
+   * {@code toImmutableSortedSet(Ordering.natural())}.
+   *
+   * @param comparator the function by which to sort set elements
+   * @throws NullPointerException if any element is null
+   * @deprecated Use {@link #toSortedSet(Comparator)} instead. This method is scheduled for removal
+   *     in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableSortedSet<E> toImmutableSortedSet(
+      Comparator<? super E> comparator) {
+    return toSortedSet(comparator);
+  }
+
+  /**
    * Copies all the elements from this fluent iterable to {@code collection}. This is equivalent to
    * calling {@code Iterables.addAll(collection, this)}.
    *

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/GenericMapMaker.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/GenericMapMaker.java
@@ -37,12 +37,12 @@ import java.util.concurrent.TimeUnit;
  *     "Generic" equivalent; simple use {@code CacheBuilder} naturally. For general migration
  *     instructions, see the <a
  *     href="http://code.google.com/p/guava-libraries/wiki/MapMakerMigration">MapMaker Migration
- *     Guide</a>.
+ *     Guide</a>. This class is scheduled for removal in Guava 16.0.
  */
 @Beta
 @Deprecated
 @GwtCompatible(emulated = true)
-abstract class GenericMapMaker<K0, V0> {
+public abstract class GenericMapMaker<K0, V0> {
 
   // Set by MapMaker, but sits in this class to preserve the type relationship
 

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/GenericMapMaker.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/GenericMapMaker.java
@@ -83,6 +83,6 @@ abstract class GenericMapMaker<K0, V0> {
    * See {@link MapMaker#makeComputingMap}.
    */
   @Deprecated
-  abstract <K extends K0, V extends V0> ConcurrentMap<K, V> makeComputingMap(
+  public abstract <K extends K0, V extends V0> ConcurrentMap<K, V> makeComputingMap(
       Function<? super K, ? extends V> computingFunction);
 }

--- a/guava-gwt/test-super/com/google/common/collect/super/com/google/common/collect/ConstraintsTest.java
+++ b/guava-gwt/test-super/com/google/common/collect/super/com/google/common/collect/ConstraintsTest.java
@@ -20,8 +20,6 @@ import static java.util.Arrays.asList;
 import static org.truth0.Truth.ASSERT;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
-import com.google.common.testing.SerializableTester;
 
 import junit.framework.TestCase;
 
@@ -344,11 +342,5 @@ public class ConstraintsTest extends TestCase {
       }
     };
   }
-
-  @GwtIncompatible("SerializableTester")
-  public void testSerialization() {
-    // TODO: Test serialization of constrained collections.
-    assertSame(Constraints.notNull(),
-        SerializableTester.reserialize(Constraints.notNull()));
-  }
 }
+

--- a/guava-gwt/test/com/google/common/collect/ConstraintsTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/ConstraintsTest_gwt.java
@@ -43,6 +43,16 @@ public void testConstrainedListRandomAccessFalse() throws Exception {
   testCase.testConstrainedListRandomAccessFalse();
 }
 
+public void testConstrainedMultisetIllegal() throws Exception {
+  com.google.common.collect.ConstraintsTest testCase = new com.google.common.collect.ConstraintsTest();
+  testCase.testConstrainedMultisetIllegal();
+}
+
+public void testConstrainedMultisetLegal() throws Exception {
+  com.google.common.collect.ConstraintsTest testCase = new com.google.common.collect.ConstraintsTest();
+  testCase.testConstrainedMultisetLegal();
+}
+
 public void testConstrainedSetIllegal() throws Exception {
   com.google.common.collect.ConstraintsTest testCase = new com.google.common.collect.ConstraintsTest();
   testCase.testConstrainedSetIllegal();
@@ -66,5 +76,10 @@ public void testConstrainedSortedSetLegal() throws Exception {
 public void testNefariousAddAll() throws Exception {
   com.google.common.collect.ConstraintsTest testCase = new com.google.common.collect.ConstraintsTest();
   testCase.testNefariousAddAll();
+}
+
+public void testNotNull() throws Exception {
+  com.google.common.collect.ConstraintsTest testCase = new com.google.common.collect.ConstraintsTest();
+  testCase.testNotNull();
 }
 }

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc1</version>
+    <version>17.0-rc2</version>
   </parent>
   <artifactId>guava-testlib-jdk5</artifactId>
   <name>Guava Testing Library (JDK5 Backport)</name>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-SNAPSHOT</version>
+    <version>17.0-rc1</version>
   </parent>
   <artifactId>guava-testlib-jdk5</artifactId>
   <name>Guava Testing Library (JDK5 Backport)</name>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc2</version>
+    <version>17.0</version>
   </parent>
   <artifactId>guava-testlib-jdk5</artifactId>
   <name>Guava Testing Library (JDK5 Backport)</name>

--- a/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -128,6 +128,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
@@ -163,6 +164,17 @@ public final class ArbitraryInstances {
     }
   };
 
+  /**
+   * Returns a new {@code MatchResult} that corresponds to a successful match. Apache Harmony (used
+   * in Android) requires a successful match in order to generate a {@code MatchResult}:
+   * http://goo.gl/5VQFmC
+   */
+  private static MatchResult newMatchResult() {
+    Matcher matcher = Pattern.compile(".").matcher("X");
+    matcher.find();
+    return matcher.toMatchResult();
+  }
+
   private static final ClassToInstanceMap<Object> DEFAULTS = ImmutableClassToInstanceMap.builder()
       // primitives
       .put(Object.class, "")
@@ -174,7 +186,7 @@ public final class ArbitraryInstances {
       .put(CharSequence.class, "")
       .put(String.class, "")
       .put(Pattern.class, Pattern.compile(""))
-      .put(MatchResult.class, Pattern.compile("").matcher("").toMatchResult())
+      .put(MatchResult.class, newMatchResult())
       .put(TimeUnit.class, TimeUnit.SECONDS)
       .put(Charset.class, Charsets.UTF_8)
       .put(Currency.class, Currency.getInstance(Locale.US))

--- a/guava-testlib/src/com/google/common/testing/NullPointerTester.java
+++ b/guava-testlib/src/com/google/common/testing/NullPointerTester.java
@@ -354,6 +354,17 @@ public final class NullPointerTester {
     }
   }
 
+  private static String bestAvailableString(
+      TypeToken type, int position, Invokable<?, ?> invokable) {
+    checkNotNull(type);
+    try {
+      return type.toString();
+    } catch (NullPointerException androidBug6636) {
+      // http://stackoverflow.com/a/8169250/28465
+      return String.format("unknown (arg %s of %s)", position, invokable);
+    }
+  }
+
   private Object[] buildParamList(Invokable<?, ?> invokable, int indexOfParamToSetToNull) {
     ImmutableList<Parameter> params = invokable.getParameters();
     Object[] args = new Object[params.size()];
@@ -364,7 +375,7 @@ public final class NullPointerTester {
         args[i] = getDefaultValue(param.getType());
         Assert.assertTrue(
             "Can't find or create a sample instance for type '"
-                + param.getType()
+                + bestAvailableString(param.getType(), i, invokable)
                 + "'; please provide one using NullPointerTester.setDefault()",
             args[i] != null || isNullable(param));
       }

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-SNAPSHOT</version>
+    <version>17.0-rc1</version>
   </parent>
   <artifactId>guava-tests-jdk5</artifactId>
   <name>Guava Unit Tests (JDK5 Backport)</name>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc1</version>
+    <version>17.0-rc2</version>
   </parent>
   <artifactId>guava-tests-jdk5</artifactId>
   <name>Guava Unit Tests (JDK5 Backport)</name>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc2</version>
+    <version>17.0</version>
   </parent>
   <artifactId>guava-tests-jdk5</artifactId>
   <name>Guava Unit Tests (JDK5 Backport)</name>

--- a/guava-tests/test/com/google/common/hash/AbstractByteHasherTest.java
+++ b/guava-tests/test/com/google/common/hash/AbstractByteHasherTest.java
@@ -72,10 +72,10 @@ public class AbstractByteHasherTest extends TestCase {
       random.nextBytes(bytes);
       String s = new String(bytes, UTF_16LE.name()); // so all random strings are valid
       assertEquals(
-          new TestHasher().putUnencodedChars(s).hash(),
+          new TestHasher().putString(s).hash(),
           new TestHasher().putBytes(s.getBytes(UTF_16LE.name())).hash());
       assertEquals(
-          new TestHasher().putUnencodedChars(s).hash(),
+          new TestHasher().putString(s).hash(),
           new TestHasher().putString(s, UTF_16LE).hash());
     }
   }

--- a/guava-tests/test/com/google/common/hash/AbstractNonStreamingHashFunctionTest.java
+++ b/guava-tests/test/com/google/common/hash/AbstractNonStreamingHashFunctionTest.java
@@ -142,6 +142,11 @@ public class AbstractNonStreamingHashFunctionTest extends TestCase {
     }
 
     @Override
+    public HashCode hashString(CharSequence input) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public HashCode hashString(CharSequence input, Charset charset) {
       throw new UnsupportedOperationException();
     }

--- a/guava-tests/test/com/google/common/hash/AbstractStreamingHasherTest.java
+++ b/guava-tests/test/com/google/common/hash/AbstractStreamingHasherTest.java
@@ -93,10 +93,10 @@ public class AbstractStreamingHasherTest extends TestCase {
       random.nextBytes(bytes);
       String s = new String(bytes, UTF_16LE.name()); // so all random strings are valid
       assertEquals(
-          new Sink(4).putUnencodedChars(s).hash(),
+          new Sink(4).putString(s).hash(),
           new Sink(4).putBytes(s.getBytes(UTF_16LE.name())).hash());
       assertEquals(
-          new Sink(4).putUnencodedChars(s).hash(),
+          new Sink(4).putString(s).hash(),
           new Sink(4).putString(s, UTF_16LE).hash());
     }
   }
@@ -261,6 +261,11 @@ public class AbstractStreamingHasherTest extends TestCase {
 
     @Override
     public int bits() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HashCode hashString(CharSequence input) {
       throw new UnsupportedOperationException();
     }
 

--- a/guava-tests/test/com/google/common/hash/HashCodeTest.java
+++ b/guava-tests/test/com/google/common/hash/HashCodeTest.java
@@ -18,7 +18,6 @@ package com.google.common.hash;
 
 import static com.google.common.io.BaseEncoding.base16;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import com.google.common.jdk5backport.Arrays;
@@ -169,7 +168,7 @@ public class HashCodeTest extends TestCase {
   }
 
   public void testRoundTripHashCodeUsingBaseEncoding() {
-    HashCode hash1 = Hashing.sha1().hashString("foo", Charsets.US_ASCII);
+    HashCode hash1 = Hashing.sha1().hashString("foo");
     HashCode hash2 =
         HashCode.fromBytes(BaseEncoding.base16().lowerCase().decode(hash1.toString()));
     assertEquals(hash1, hash2);
@@ -202,18 +201,18 @@ public class HashCodeTest extends TestCase {
   }
 
   public void testRoundTripHashCodeUsingFromString() {
-    HashCode hash1 = Hashing.sha1().hashString("foo", Charsets.US_ASCII);
+    HashCode hash1 = Hashing.sha1().hashString("foo");
     HashCode hash2 = HashCode.fromString(hash1.toString());
     assertEquals(hash1, hash2);
   }
 
   public void testRoundTrip() {
     for (ExpectedHashCode expected : expectedHashCodes) {
-      String string = HashCode.fromBytes(expected.bytes).toString();
+      String string = HashCodes.fromBytes(expected.bytes).toString();
       assertEquals(expected.toString, string);
       assertEquals(
           expected.toString,
-          HashCode.fromBytes(
+          HashCodes.fromBytes(
               BaseEncoding.base16().lowerCase().decode(string)).toString());
     }
   }
@@ -227,7 +226,7 @@ public class HashCodeTest extends TestCase {
   }
 
   public void testFromStringFailsWithUpperCaseString() {
-    String string = Hashing.sha1().hashString("foo", Charsets.US_ASCII).toString().toUpperCase();
+    String string = Hashing.sha1().hashString("foo").toString().toUpperCase();
     try {
       HashCode.fromString(string);
       fail();
@@ -259,17 +258,17 @@ public class HashCodeTest extends TestCase {
 
   public void testIntWriteBytesTo() {
     byte[] dest = new byte[4];
-    HashCode.fromInt(42).writeBytesTo(dest, 0, 4);
+    HashCodes.fromInt(42).writeBytesTo(dest, 0, 4);
     assertTrue(Arrays.equals(
-        HashCode.fromInt(42).asBytes(),
+        HashCodes.fromInt(42).asBytes(),
         dest));
   }
 
   public void testLongWriteBytesTo() {
     byte[] dest = new byte[8];
-    HashCode.fromLong(42).writeBytesTo(dest, 0, 8);
+    HashCodes.fromLong(42).writeBytesTo(dest, 0, 8);
     assertTrue(Arrays.equals(
-        HashCode.fromLong(42).asBytes(),
+        HashCodes.fromLong(42).asBytes(),
         dest));
   }
 

--- a/guava-tests/test/com/google/common/hash/HashingTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingTest.java
@@ -150,6 +150,13 @@ public class HashingTest extends TestCase {
     HashTestUtils.assertInvariants(Hashing.goodFastHash(256));
   }
 
+  public void testPadToLong() {
+    assertEquals(0x1111111111111111L, Hashing.padToLong(HashCodes.fromLong(0x1111111111111111L)));
+    assertEquals(0x9999999999999999L, Hashing.padToLong(HashCodes.fromLong(0x9999999999999999L)));
+    assertEquals(0x0000000011111111L, Hashing.padToLong(HashCodes.fromInt(0x11111111)));
+    assertEquals(0x0000000099999999L, Hashing.padToLong(HashCodes.fromInt(0x99999999)));
+  }
+
   public void testConsistentHash_correctness() {
     long[] interestingValues = { -1, 0, 1, 2, Long.MAX_VALUE, Long.MIN_VALUE };
     for (long h : interestingValues) {

--- a/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -31,6 +31,8 @@ import java.io.UnsupportedEncodingException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
 
 /**
  * Unit test for {@link ByteStreams}.
@@ -382,6 +384,21 @@ public class ByteStreamsTest extends IoTestCase {
     out.writeFloat(Float.intBitsToFloat(0x12345678));
     out.writeFloat(Float.intBitsToFloat(0x76543210));
     assertEquals(bytes, out.toByteArray());
+  }
+
+  public void testChecksum() throws IOException {
+    InputSupplier<ByteArrayInputStream> asciiBytes =
+        ByteStreams.newInputStreamSupplier(ASCII.getBytes(Charsets.US_ASCII));
+    InputSupplier<ByteArrayInputStream> i18nBytes =
+        ByteStreams.newInputStreamSupplier(I18N.getBytes(Charsets.UTF_8));
+
+    Checksum checksum = new CRC32();
+    assertEquals(0L, checksum.getValue());
+    assertEquals(3145994718L, ByteStreams.getChecksum(asciiBytes, checksum));
+    assertEquals(0L, checksum.getValue());
+    assertEquals(3145994718L, ByteStreams.getChecksum(asciiBytes, checksum));
+    assertEquals(1138302340L, ByteStreams.getChecksum(i18nBytes, checksum));
+    assertEquals(0L, checksum.getValue());
   }
 
   public void testNewDataOutput_BAOS() {

--- a/guava-tests/test/com/google/common/io/CloseablesTest.java
+++ b/guava-tests/test/com/google/common/io/CloseablesTest.java
@@ -67,6 +67,14 @@ public class CloseablesTest extends TestCase {
     doClose(mockCloseable, false);
   }
 
+  public void testCloseQuietly_closeableWithEatenException()
+      throws IOException {
+    // make sure that no exception is thrown by CloseQuietly when the mock does
+    // throw an exception on close
+    setupCloseable(true);
+    Closeables.closeQuietly(mockCloseable);
+  }
+
   public void testCloseQuietly_inputStreamWithEatenException() throws IOException {
     TestInputStream in = new TestInputStream(
         new ByteArrayInputStream(new byte[1]), TestOption.CLOSE_THROWS);
@@ -83,6 +91,7 @@ public class CloseablesTest extends TestCase {
   public void testCloseNull() throws IOException {
     Closeables.close(null, true);
     Closeables.close(null, false);
+    Closeables.closeQuietly((Closeable) null);
   }
 
   public void testCloseQuietlyNull_inputStream() {

--- a/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -433,6 +433,22 @@ public class ServiceManagerTest extends TestCase {
         return delegate.stopAsync();
       }
 
+      @Override public final ListenableFuture<State> start() {
+        return delegate.start();
+      }
+
+      @Override public final ListenableFuture<State> stop() {
+        return delegate.stop();
+      }
+
+      @Override public State startAndWait() {
+        return delegate.startAndWait();
+      }
+
+      @Override public State stopAndWait() {
+        return delegate.stopAndWait();
+      }
+
       @Override public final void awaitRunning() {
         delegate.awaitRunning();
       }

--- a/guava-tests/test/com/google/common/xml/XmlEscapersTest.java
+++ b/guava-tests/test/com/google/common/xml/XmlEscapersTest.java
@@ -82,8 +82,8 @@ public class XmlEscapersTest extends TestCase {
           assertUnescaped(xmlEscaper, ch);
         }
       } else {
-        // and everything else is removed.
-        assertEscaping(xmlEscaper, "", ch);
+        // and everything else is replaced with FFFD.
+        assertEscaping(xmlEscaper, "\uFFFD", ch);
       }
     }
 
@@ -109,18 +109,13 @@ public class XmlEscapersTest extends TestCase {
       }
     }
 
-    // TODO(user): Change once this escaper forbids \uFFFE and \uFFFF.
+    // Test that 0xFFFE and 0xFFFF are replaced with 0xFFFD
+    assertEscaping(xmlEscaper, "\uFFFD", '\uFFFE');
+    assertEscaping(xmlEscaper, "\uFFFD", '\uFFFF');
 
-    assertUnescaped(xmlEscaper, '\uFFFE');
-    assertUnescaped(xmlEscaper, '\uFFFF');
-
-    // Test that 0xFFFE and 0xFFFF are removed
-    // assertEscaping(xmlEscaper, "", '\uFFFE');
-    // assertEscaping(xmlEscaper, "", '\uFFFF');
-
-    // assertEquals("0xFFFE is forbidden and should be removed during escaping",
-    //     "[]", XmlEscapers.xmlEscaper().escape("[\ufffe]"));
-    // assertEquals("0xFFFF is forbidden and should be removed during escaping",
-    //     "[]", XmlEscapers.xmlEscaper().escape("[\uffff]"));
+    assertEquals("0xFFFE is forbidden and should be replaced during escaping",
+        "[\uFFFD]", xmlEscaper.escape("[\ufffe]"));
+    assertEquals("0xFFFF is forbidden and should be replaced during escaping",
+        "[\uFFFD]", xmlEscaper.escape("[\uffff]"));
   }
 }

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc1</version>
+    <version>17.0-rc2</version>
   </parent>
   <artifactId>guava-jdk5</artifactId>
   <name>Guava: Google Core Libraries for Java (JDK5 Backport)</name>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-rc2</version>
+    <version>17.0</version>
   </parent>
   <artifactId>guava-jdk5</artifactId>
   <name>Guava: Google Core Libraries for Java (JDK5 Backport)</name>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent-jdk5</artifactId>
-    <version>17.0-SNAPSHOT</version>
+    <version>17.0-rc1</version>
   </parent>
   <artifactId>guava-jdk5</artifactId>
   <name>Guava: Google Core Libraries for Java (JDK5 Backport)</name>

--- a/guava/src/com/google/common/base/Stopwatch.java
+++ b/guava/src/com/google/common/base/Stopwatch.java
@@ -120,10 +120,11 @@ public final class Stopwatch {
    * Creates (but does not start) a new stopwatch using {@link System#nanoTime}
    * as its time source.
    *
-   * @deprecated Use {@link Stopwatch#createUnstarted()} instead.
+   * @deprecated Use {@link Stopwatch#createUnstarted()} instead. This
+   *     constructor is scheduled to be removed in Guava release 17.0.
    */
   @Deprecated
-  Stopwatch() {
+  public Stopwatch() {
     this(Ticker.systemTicker());
   }
 
@@ -131,10 +132,11 @@ public final class Stopwatch {
    * Creates (but does not start) a new stopwatch, using the specified time
    * source.
    *
-   * @deprecated Use {@link Stopwatch#createUnstarted(Ticker)} instead.
+   * @deprecated Use {@link Stopwatch#createUnstarted(Ticker)} instead. This
+   *     constructor is scheduled to be removed in Guava release 17.0.
    */
   @Deprecated
-  Stopwatch(Ticker ticker) {
+  public Stopwatch(Ticker ticker) {
     this.ticker = checkNotNull(ticker, "ticker");
   }
 

--- a/guava/src/com/google/common/collect/Constraint.java
+++ b/guava/src/com/google/common/collect/Constraint.java
@@ -16,7 +16,9 @@
 
 package com.google.common.collect;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Preconditions;
 
 /**
  * A constraint that an element must satisfy in order to be added to a
@@ -38,9 +40,21 @@ import com.google.common.annotations.GwtCompatible;
  * that all the collection's elements meet the constraint, since the constraint
  * is only enforced when elements are added.
  *
+ * @see Constraints
+ * @see MapConstraint
  * @author Mike Bostock
+ * @since 3.0
+ * @deprecated Use {@link Preconditions} for basic checks. In place of
+ *     constrained collections, we encourage you to check your preconditions
+ *     explicitly instead of leaving that work to the collection implementation.
+ *     For the specific case of rejecting null, consider the immutable
+ *     collections.
+ *     This interface is scheduled for removal in Guava 16.0.
  */
+@Beta
+@Deprecated
 @GwtCompatible
+public
 interface Constraint<E> {
   /**
    * Throws a suitable {@code RuntimeException} if the specified element is

--- a/guava/src/com/google/common/collect/Constraints.java
+++ b/guava/src/com/google/common/collect/Constraints.java
@@ -18,7 +18,9 @@ package com.google.common.collect;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Preconditions;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,12 +32,46 @@ import java.util.SortedSet;
 /**
  * Factories and utilities pertaining to the {@link Constraint} interface.
  *
+ * @see MapConstraints
  * @author Mike Bostock
  * @author Jared Levy
+ * @since 3.0
+ * @deprecated Use {@link Preconditions} for basic checks. In place of
+ *     constrained collections, we encourage you to check your preconditions
+ *     explicitly instead of leaving that work to the collection implementation.
+ *     For the specific case of rejecting null, consider the immutable
+ *     collections.
+ *     This class is scheduled for removal in Guava 16.0.
  */
+@Beta
+@Deprecated
 @GwtCompatible
-final class Constraints {
+public final class Constraints {
   private Constraints() {}
+
+  // enum singleton pattern
+  private enum NotNullConstraint implements Constraint<Object> {
+    INSTANCE;
+
+    @Override
+    public Object checkElement(Object element) {
+      return checkNotNull(element);
+    }
+
+    @Override public String toString() {
+      return "Not null";
+    }
+  }
+
+  /**
+   * Returns a constraint that verifies that the element is not null. If the
+   * element is null, a {@link NullPointerException} is thrown.
+   */
+  // safe to narrow the type since checkElement returns its argument directly
+  @SuppressWarnings("unchecked")
+  public static <E> Constraint<E> notNull() {
+    return (Constraint<E>) NotNullConstraint.INSTANCE;
+  }
 
   /**
    * Returns a constrained view of the specified collection, using the specified
@@ -285,6 +321,56 @@ final class Constraints {
       return constrainedList((List<E>) collection, constraint);
     } else {
       return constrainedCollection(collection, constraint);
+    }
+  }
+
+  /**
+   * Returns a constrained view of the specified multiset, using the specified
+   * constraint. Any operations that add new elements to the multiset will call
+   * the provided constraint. However, this method does not verify that
+   * existing elements satisfy the constraint.
+   *
+   * <p>The returned multiset is not serializable.
+   *
+   * @param multiset the multiset to constrain
+   * @param constraint the constraint that validates added elements
+   * @return a constrained view of the multiset
+   */
+  public static <E> Multiset<E> constrainedMultiset(
+      Multiset<E> multiset, Constraint<? super E> constraint) {
+    return new ConstrainedMultiset<E>(multiset, constraint);
+  }
+
+  /** @see Constraints#constrainedMultiset */
+  static class ConstrainedMultiset<E> extends ForwardingMultiset<E> {
+    private Multiset<E> delegate;
+    private final Constraint<? super E> constraint;
+
+    public ConstrainedMultiset(
+        Multiset<E> delegate, Constraint<? super E> constraint) {
+      this.delegate = checkNotNull(delegate);
+      this.constraint = checkNotNull(constraint);
+    }
+    @Override protected Multiset<E> delegate() {
+      return delegate;
+    }
+    @Override public boolean add(E element) {
+      return standardAdd(element);
+    }
+    @Override public boolean addAll(Collection<? extends E> elements) {
+      return delegate.addAll(checkElements(elements, constraint));
+    }
+    @Override public int add(E element, int occurrences) {
+      constraint.checkElement(element);
+      return delegate.add(element, occurrences);
+    }
+    @Override public int setCount(E element, int count) {
+      constraint.checkElement(element);
+      return delegate.setCount(element, count);
+    }
+    @Override public boolean setCount(E element, int oldCount, int newCount) {
+      constraint.checkElement(element);
+      return delegate.setCount(element, oldCount, newCount);
     }
   }
 

--- a/guava/src/com/google/common/collect/FluentIterable.java
+++ b/guava/src/com/google/common/collect/FluentIterable.java
@@ -425,6 +425,64 @@ public abstract class FluentIterable<E> implements Iterable<E> {
   }
 
   /**
+   * Returns an {@code ImmutableList} containing all of the elements from this
+   * fluent iterable in proper sequence.
+   *
+   * @deprecated Use {@link #toList()} instead. This method is scheduled for removal in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableList<E> toImmutableList() {
+    return toList();
+  }
+
+  /**
+   * Returns an {@code ImmutableList} containing all of the elements from this
+   * {@code FluentIterable} in the order specified by {@code comparator}.  To produce an
+   * {@code ImmutableList} sorted by its natural ordering, use
+   * {@code toSortedImmutableList(Ordering.natural())}.
+   *
+   * @param comparator the function by which to sort list elements
+   * @throws NullPointerException if any element is null
+   * @since 13.0
+   * @deprecated Use {@link #toSortedList(Comparator)} instead. This method is scheduled for removal
+   *     in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableList<E> toSortedImmutableList(
+      Comparator<? super E> comparator) {
+    return toSortedList(comparator);
+  }
+
+  /**
+   * Returns an {@code ImmutableSet} containing all of the elements from this
+   * fluent iterable with duplicates removed.
+   *
+   * @deprecated Use {@link #toSet()} instead. This method is scheduled for removal in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableSet<E> toImmutableSet() {
+    return toSet();
+  }
+
+  /**
+   * Returns an {@code ImmutableSortedSet} containing all of the elements from this
+   * {@code FluentIterable} in the order specified by {@code comparator}, with duplicates
+   * (determined by {@code comparator.compare(x, y) == 0}) removed. To produce an
+   * {@code ImmutableSortedSet} sorted by its natural ordering, use
+   * {@code toImmutableSortedSet(Ordering.natural())}.
+   *
+   * @param comparator the function by which to sort set elements
+   * @throws NullPointerException if any element is null
+   * @deprecated Use {@link #toSortedSet(Comparator)} instead. This method is scheduled for removal
+   *     in Guava 15.0.
+   */
+  @Deprecated
+  public final ImmutableSortedSet<E> toImmutableSortedSet(
+      Comparator<? super E> comparator) {
+    return toSortedSet(comparator);
+  }
+
+  /**
    * Returns an array containing all of the elements from this fluent iterable in iteration order.
    *
    * @param type the type of the elements

--- a/guava/src/com/google/common/collect/ForwardingSortedMap.java
+++ b/guava/src/com/google/common/collect/ForwardingSortedMap.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.SortedMap;
 
@@ -140,6 +141,43 @@ public abstract class ForwardingSortedMap<K, V> extends ForwardingMap<K, V>
     } catch (NullPointerException e) {
       return false;
     }
+  }
+
+  /**
+   * A sensible definition of {@link #remove} in terms of the {@code
+   * iterator()} of the {@code entrySet()} of {@link #tailMap}. If you override
+   * {@link #tailMap}, you may wish to override {@link #remove} to forward
+   * to this implementation.
+   *
+   * @since 7.0
+   * @deprecated This implementation is extremely awkward, is rarely worthwhile,
+   * and has been discovered to interact badly with
+   * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6467933 in Java 6
+   * when used with certain null-friendly comparators.  It is scheduled for
+   * deletion in Guava 16.0.
+   */
+  @Deprecated
+  @Override @Beta protected V standardRemove(@Nullable Object key) {
+    try {
+      // any CCE will be caught
+      @SuppressWarnings("unchecked")
+      SortedMap<Object, V> self = (SortedMap<Object, V>) this;
+      Iterator<Entry<Object, V>> entryIterator =
+          self.tailMap(key).entrySet().iterator();
+      if (entryIterator.hasNext()) {
+        Entry<Object, V> ceilingEntry = entryIterator.next();
+        if (unsafeCompare(ceilingEntry.getKey(), key) == 0) {
+          V value = ceilingEntry.getValue();
+          entryIterator.remove();
+          return value;
+        }
+      }
+    } catch (ClassCastException e) {
+      return null;
+    } catch (NullPointerException e) {
+      return null;
+    }
+    return null;
   }
 
   /**

--- a/guava/src/com/google/common/collect/GenericMapMaker.java
+++ b/guava/src/com/google/common/collect/GenericMapMaker.java
@@ -146,6 +146,6 @@ abstract class GenericMapMaker<K0, V0> {
    * See {@link MapMaker#makeComputingMap}.
    */
   @Deprecated
-  abstract <K extends K0, V extends V0> ConcurrentMap<K, V> makeComputingMap(
+  public abstract <K extends K0, V extends V0> ConcurrentMap<K, V> makeComputingMap(
       Function<? super K, ? extends V> computingFunction);
 }

--- a/guava/src/com/google/common/collect/GenericMapMaker.java
+++ b/guava/src/com/google/common/collect/GenericMapMaker.java
@@ -42,12 +42,12 @@ import java.util.concurrent.TimeUnit;
  *     "Generic" equivalent; simple use {@code CacheBuilder} naturally. For general migration
  *     instructions, see the <a
  *     href="http://code.google.com/p/guava-libraries/wiki/MapMakerMigration">MapMaker Migration
- *     Guide</a>.
+ *     Guide</a>. This class is scheduled for removal in Guava 16.0.
  */
 @Beta
 @Deprecated
 @GwtCompatible(emulated = true)
-abstract class GenericMapMaker<K0, V0> {
+public abstract class GenericMapMaker<K0, V0> {
   @GwtIncompatible("To be supported")
   enum NullListener implements RemovalListener<Object, Object> {
     INSTANCE;

--- a/guava/src/com/google/common/collect/MapMaker.java
+++ b/guava/src/com/google/common/collect/MapMaker.java
@@ -578,10 +578,11 @@ public final class MapMaker extends GenericMapMaker<Object, Object> {
    *     by {@link com.google.common.cache.CacheBuilder#build}. See the
    *     <a href="http://code.google.com/p/guava-libraries/wiki/MapMakerMigration">MapMaker
    *     Migration Guide</a> for more details.
+   *     <b>This method is scheduled for deletion after upgrading Android to Guava 17.0.</b>
    */
   @Deprecated
   @Override
-  <K, V> ConcurrentMap<K, V> makeComputingMap(
+  public <K, V> ConcurrentMap<K, V> makeComputingMap(
       Function<? super K, ? extends V> computingFunction) {
     return (nullRemovalCause == null)
         ? new MapMaker.ComputingMapAdapter<K, V>(this, computingFunction)

--- a/guava/src/com/google/common/collect/Range.java
+++ b/guava/src/com/google/common/collect/Range.java
@@ -18,15 +18,18 @@ package com.google.common.collect;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Equivalence;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.SortedSet;
 
 import javax.annotation.Nullable;
@@ -428,7 +431,7 @@ public final class Range<C extends Comparable> implements Predicate<C>, Serializ
    * can't be constructed at all.)
    *
    * <p>Note that certain discrete ranges such as the integer range {@code (3..4)} are <b>not</b>
-   * considered empty, even though they contain no actual values.  In these cases, it may be 
+   * considered empty, even though they contain no actual values.  In these cases, it may be
    * helpful to preprocess ranges with {@link #canonical(DiscreteDomain)}.
    */
   public boolean isEmpty() {
@@ -529,9 +532,9 @@ public final class Range<C extends Comparable> implements Predicate<C>, Serializ
    *
    * <p>The connectedness relation is both reflexive and symmetric, but does not form an {@linkplain
    * Equivalence equivalence relation} as it is not transitive.
-   * 
+   *
    * <p>Note that certain discrete ranges are not considered connected, even though there are no
-   * elements "between them."  For example, {@code [3, 5]} is not considered connected to {@code 
+   * elements "between them."  For example, {@code [3, 5]} is not considered connected to {@code
    * [6, 10]}.  In these cases, it may be desirable for both input ranges to be preprocessed with
    * {@link #canonical(DiscreteDomain)} before testing for connectedness.
    */
@@ -593,6 +596,33 @@ public final class Range<C extends Comparable> implements Predicate<C>, Serializ
       Cut<C> newUpper = (upperCmp >= 0) ? upperBound : other.upperBound;
       return create(newLower, newUpper);
     }
+  }
+
+  /**
+   * Returns an {@link ContiguousSet} containing the same values in the given domain
+   * {@linkplain Range#contains contained} by this range.
+   *
+   * <p><b>Note:</b> {@code a.asSet(d).equals(b.asSet(d))} does not imply {@code a.equals(b)}! For
+   * example, {@code a} and {@code b} could be {@code [2..4]} and {@code (1..5)}, or the empty
+   * ranges {@code [3..3)} and {@code [4..4)}.
+   *
+   * <p><b>Warning:</b> Be extremely careful what you do with the {@code asSet} view of a large
+   * range (such as {@code Range.greaterThan(0)}). Certain operations on such a set can be
+   * performed efficiently, but others (such as {@link Set#hashCode} or {@link
+   * Collections#frequency}) can cause major performance problems.
+   *
+   * <p>The returned set's {@link Object#toString} method returns a short-hand form of the set's
+   * contents, such as {@code "[1..100]}"}.
+   *
+   * @throws IllegalArgumentException if neither this range nor the domain has a lower bound, or if
+   *     neither has an upper bound
+   * @deprecated Use {@code ContiguousSet.create(range, domain)}. To be removed in Guava 16.0.
+   */
+  @Beta
+  @GwtCompatible(serializable = false)
+  @Deprecated
+  public ContiguousSet<C> asSet(DiscreteDomain<C> domain) {
+    return ContiguousSet.create(this, domain);
   }
 
   /**

--- a/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
+++ b/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
@@ -122,6 +122,14 @@ abstract class AbstractCompositeHashFunction extends AbstractStreamingHashFuncti
         return this;
       }
 
+      /**
+       * @deprecated Use {@link Hasher#putUnencodedChars} instead.
+       */
+      @Deprecated
+      @Override public Hasher putString(CharSequence chars) {
+        return putUnencodedChars(chars);
+      }
+
       @Override public Hasher putUnencodedChars(CharSequence chars) {
         for (Hasher hasher : hashers) {
           hasher.putUnencodedChars(chars);

--- a/guava/src/com/google/common/hash/AbstractHasher.java
+++ b/guava/src/com/google/common/hash/AbstractHasher.java
@@ -37,6 +37,14 @@ abstract class AbstractHasher implements Hasher {
     return putInt(Float.floatToRawIntBits(f));
   }
 
+  /**
+   * @deprecated Use {@link AbstractHasher#putUnencodedChars} instead.
+   */
+  @Deprecated
+  @Override public Hasher putString(CharSequence charSequence) {
+    return putUnencodedChars(charSequence);
+  }
+
   @Override public Hasher putUnencodedChars(CharSequence charSequence) {
     for (int i = 0, len = charSequence.length(); i < len; i++) {
       putChar(charSequence.charAt(i));

--- a/guava/src/com/google/common/hash/AbstractNonStreamingHashFunction.java
+++ b/guava/src/com/google/common/hash/AbstractNonStreamingHashFunction.java
@@ -46,6 +46,14 @@ abstract class AbstractNonStreamingHashFunction implements HashFunction {
     return newHasher().putObject(instance, funnel).hash();
   }
 
+  /**
+   * @deprecated Use {@link AbstractNonStreamingHashFunction#hashUnencodedChars} instead.
+   */
+  @Deprecated
+  @Override public HashCode hashString(CharSequence input) {
+    return hashUnencodedChars(input);
+  }
+
   @Override public HashCode hashUnencodedChars(CharSequence input) {
     int len = input.length();
     Hasher hasher = newHasher(len * 2);

--- a/guava/src/com/google/common/hash/AbstractStreamingHashFunction.java
+++ b/guava/src/com/google/common/hash/AbstractStreamingHashFunction.java
@@ -37,6 +37,14 @@ abstract class AbstractStreamingHashFunction implements HashFunction {
     return newHasher().putObject(instance, funnel).hash();
   }
 
+  /**
+   * @deprecated Use {@link AbstractStreamingHashFunction#hashUnencodedChars} instead.
+   */
+  @Deprecated
+  @Override public HashCode hashString(CharSequence input) {
+    return hashUnencodedChars(input);
+  }
+
   @Override public HashCode hashUnencodedChars(CharSequence input) {
     return newHasher().putUnencodedChars(input).hash();
   }
@@ -173,6 +181,15 @@ abstract class AbstractStreamingHashFunction implements HashFunction {
       // Finally stick the remainder back in our usual buffer
       buffer.put(readBuffer);
       return this;
+    }
+
+    /**
+     * @deprecated Use {@link AbstractStreamingHasher#putUnencodedChars} instead.
+     */
+    @Deprecated
+    @Override
+    public final Hasher putString(CharSequence charSequence) {
+      return putUnencodedChars(charSequence);
     }
 
     @Override

--- a/guava/src/com/google/common/hash/Funnels.java
+++ b/guava/src/com/google/common/hash/Funnels.java
@@ -63,6 +63,17 @@ public final class Funnels {
     return UnencodedCharsFunnel.INSTANCE;
   }
 
+  /**
+   * Returns a funnel that extracts the characters from a {@code CharSequence}.
+   *
+   * @deprecated Use {@link Funnels#unencodedCharsFunnel} instead. This method is scheduled for
+   *     removal in Guava 16.0.
+   */
+  @Deprecated
+  public static Funnel<CharSequence> stringFunnel() {
+    return unencodedCharsFunnel();
+  }
+
   private enum UnencodedCharsFunnel implements Funnel<CharSequence> {
     INSTANCE;
 
@@ -126,7 +137,7 @@ public final class Funnels {
       private Object readResolve() {
         return stringFunnel(Charset.forName(charsetCanonicalName));
       }
-    
+
       private static final long serialVersionUID = 0;
     }
   }
@@ -194,45 +205,45 @@ public final class Funnels {
 
   /**
    * Returns a funnel for longs.
-   * 
+   *
    * @since 13.0
    */
   public static Funnel<Long> longFunnel() {
     return LongFunnel.INSTANCE;
   }
-  
+
   private enum LongFunnel implements Funnel<Long> {
     INSTANCE;
-    
+
     public void funnel(Long from, PrimitiveSink into) {
       into.putLong(from);
     }
-    
+
     @Override public String toString() {
       return "Funnels.longFunnel()";
     }
   }
-  
+
   /**
    * Wraps a {@code PrimitiveSink} as an {@link OutputStream}, so it is easy to
    * {@link Funnel#funnel funnel} an object to a {@code PrimitiveSink}
-   * if there is already a way to write the contents of the object to an {@code OutputStream}.  
-   * 
+   * if there is already a way to write the contents of the object to an {@code OutputStream}.
+   *
    * <p>The {@code close} and {@code flush} methods of the returned {@code OutputStream}
    * do nothing, and no method throws {@code IOException}.
-   * 
+   *
    * @since 13.0
    */
   public static OutputStream asOutputStream(PrimitiveSink sink) {
     return new SinkAsStream(sink);
   }
-  
+
   private static class SinkAsStream extends OutputStream {
     final PrimitiveSink sink;
     SinkAsStream(PrimitiveSink sink) {
       this.sink = Preconditions.checkNotNull(sink);
     }
-    
+
     @Override public void write(int b) {
       sink.putByte((byte) b);
     }
@@ -244,7 +255,7 @@ public final class Funnels {
     @Override public void write(byte[] bytes, int off, int len) {
       sink.putBytes(bytes, off, len);
     }
-    
+
     @Override public String toString() {
       return "Funnels.asOutputStream(" + sink + ")";
     }

--- a/guava/src/com/google/common/hash/HashCodes.java
+++ b/guava/src/com/google/common/hash/HashCodes.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.hash;
+
+import com.google.common.annotations.Beta;
+
+import java.io.Serializable;
+
+/**
+ * Static factories for creating {@link HashCode} instances; most users should never have to use
+ * this. All returned instances are {@link Serializable}.
+ *
+ * @author Dimitris Andreou
+ * @since 12.0
+ * @deprecated Use the duplicated methods in {@link HashCode} instead. This class is scheduled
+ *     to be removed in Guava 16.0.
+ */
+@Beta
+@Deprecated
+public final class HashCodes {
+  private HashCodes() {}
+
+  /**
+   * Creates a 32-bit {@code HashCode}, of which the bytes will form the passed int, interpreted
+   * in little endian order.
+   *
+   * @deprecated Use {@link HashCode#fromInt} instead. This method is scheduled to be removed in
+   *     Guava 16.0.
+   */
+  @Deprecated
+  public static HashCode fromInt(int hash) {
+    return HashCode.fromInt(hash);
+  }
+
+  /**
+   * Creates a 64-bit {@code HashCode}, of which the bytes will form the passed long, interpreted
+   * in little endian order.
+   *
+   * @deprecated Use {@link HashCode#fromLong} instead. This method is scheduled to be removed in
+   *     Guava 16.0.
+   */
+  @Deprecated
+  public static HashCode fromLong(long hash) {
+    return HashCode.fromLong(hash);
+  }
+
+  /**
+   * Creates a {@code HashCode} from a byte array. The array is defensively copied to preserve
+   * the immutability contract of {@code HashCode}. The array cannot be empty.
+   *
+   * @deprecated Use {@link HashCode#fromBytes} instead. This method is scheduled to be removed in
+   *     Guava 16.0.
+   */
+  @Deprecated
+  public static HashCode fromBytes(byte[] bytes) {
+    return HashCode.fromBytes(bytes);
+  }
+}

--- a/guava/src/com/google/common/hash/HashFunction.java
+++ b/guava/src/com/google/common/hash/HashFunction.java
@@ -194,6 +194,18 @@ public interface HashFunction {
   HashCode hashUnencodedChars(CharSequence input);
 
   /**
+   * Shortcut for {@code newHasher().putUnencodedChars(input).hash()}. The implementation
+   * <i>might</i> perform better than its longhand equivalent, but should not perform worse.
+   * Note that no character encoding is performed; the low byte and high byte of each {@code char}
+   * are hashed directly (in that order).
+   *
+   * @deprecated Use {@link HashFunction#hashUnencodedChars} instead. This method is scheduled for
+   *     removal in Guava 16.0.
+   */
+  @Deprecated
+  HashCode hashString(CharSequence input);
+
+  /**
    * Shortcut for {@code newHasher().putString(input, charset).hash()}. Characters are encoded
    * using the given {@link Charset}. The implementation <i>might</i> perform better than its
    * longhand equivalent, but should not perform worse.

--- a/guava/src/com/google/common/hash/Hasher.java
+++ b/guava/src/com/google/common/hash/Hasher.java
@@ -83,6 +83,16 @@ public interface Hasher extends PrimitiveSink {
   @Override Hasher putUnencodedChars(CharSequence charSequence);
 
   /**
+   * Equivalent to processing each {@code char} value in the {@code CharSequence}, in order.
+   * The input must not be updated while this method is in progress.
+   *
+   * @deprecated Use {@link Hasher#putUnencodedChars} instead. This method is scheduled for
+   *     removal in Guava 16.0.
+   */
+  @Deprecated
+  @Override Hasher putString(CharSequence charSequence);
+
+  /**
    * Equivalent to {@code putBytes(charSequence.toString().getBytes(charset))}.
    */
   @Override Hasher putString(CharSequence charSequence, Charset charset);

--- a/guava/src/com/google/common/hash/Hashing.java
+++ b/guava/src/com/google/common/hash/Hashing.java
@@ -290,6 +290,19 @@ public final class Hashing {
   }
 
   /**
+   * If {@code hashCode} has enough bits, returns {@code hashCode.asLong()}, otherwise
+   * returns a {@code long} value with {@code hashCode.asInt()} as the least-significant
+   * four bytes and {@code 0x00} as each of the most-significant four bytes.
+   *
+   * @deprecated Use {@code HashCode.padToLong()} instead. This method is scheduled to be
+   *     removed in Guava 15.0.
+   */
+  @Deprecated
+  public static long padToLong(HashCode hashCode) {
+    return hashCode.padToLong();
+  }
+
+  /**
    * Assigns to {@code hashCode} a "bucket" in the range {@code [0, buckets)}, in a uniform
    * manner that minimizes the need for remapping as {@code buckets} grows. That is,
    * {@code consistentHash(h, n)} equals:

--- a/guava/src/com/google/common/hash/Murmur3_32HashFunction.java
+++ b/guava/src/com/google/common/hash/Murmur3_32HashFunction.java
@@ -102,7 +102,7 @@ final class Murmur3_32HashFunction extends AbstractStreamingHashFunction impleme
   }
 
   // TODO(user): Maybe implement #hashBytes instead?
-  @Override public HashCode hashUnencodedChars(CharSequence input) {
+  @Override public HashCode hashString(CharSequence input) {
     int h1 = seed;
 
     // step through the CharSequence 2 chars at a time

--- a/guava/src/com/google/common/hash/PrimitiveSink.java
+++ b/guava/src/com/google/common/hash/PrimitiveSink.java
@@ -20,7 +20,7 @@ import java.nio.charset.Charset;
 
 /**
  * An object which can receive a stream of primitive values.
- *
+ * 
  * @author Kevin Bourrillion
  * @since 12.0 (in 11.0 as {@code Sink})
  */
@@ -41,15 +41,15 @@ public interface PrimitiveSink {
    * @return this instance
    */
   PrimitiveSink putBytes(byte[] bytes);
-
+  
   /**
    * Puts a chunk of an array of bytes into this sink. {@code bytes[off]} is the first byte written,
-   * {@code bytes[off + len - 1]} is the last.
-   *
+   * {@code bytes[off + len - 1]} is the last. 
+   * 
    * @param bytes a byte array
    * @param off the start offset in the array
    * @param len the number of bytes to write
-   * @return this instance
+   * @return this instance 
    * @throws IndexOutOfBoundsException if {@code off < 0} or {@code off + len > bytes.length} or
    *   {@code len < 0}
    */
@@ -89,6 +89,15 @@ public interface PrimitiveSink {
    * Puts a character into this sink.
    */
   PrimitiveSink putChar(char c);
+
+  /**
+   * Puts a string into this sink.
+   *
+   * @deprecated Use {PrimitiveSink#putUnencodedChars} instead. This method is scheduled for
+   *     removal in Guava 16.0.
+   */
+  @Deprecated
+  PrimitiveSink putString(CharSequence charSequence);
 
   /**
    * Puts each 16-bit code unit from the {@link CharSequence} into this sink.

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -189,6 +189,26 @@ public abstract class BaseEncoding {
   }
 
   /**
+   * Returns an {@code OutputSupplier} that supplies streams that encode bytes using this encoding
+   * into writers from the specified {@code OutputSupplier}.
+   *
+   * @deprecated Use {@link #encodingSink(CharSink)} instead. This method is scheduled to be
+   *     removed in Guava 16.0.
+   */
+  @Deprecated
+  @GwtIncompatible("Writer,OutputStream")
+  public final OutputSupplier<OutputStream> encodingStream(
+      final OutputSupplier<? extends Writer> writerSupplier) {
+    checkNotNull(writerSupplier);
+    return new OutputSupplier<OutputStream>() {
+      @Override
+      public OutputStream getOutput() throws IOException {
+        return encodingStream(writerSupplier.getOutput());
+      }
+    };
+  }
+
+  /**
    * Returns a {@code ByteSink} that writes base-encoded bytes to the specified {@code CharSink}.
    */
   @GwtIncompatible("ByteSink,CharSink")
@@ -261,6 +281,26 @@ public abstract class BaseEncoding {
   @GwtIncompatible("Reader,InputStream")
   public final InputStream decodingStream(Reader reader) {
     return asInputStream(decodingStream(asCharInput(reader)));
+  }
+
+  /**
+   * Returns an {@code InputSupplier} that supplies input streams that decode base-encoded input
+   * from readers from the specified supplier.
+   *
+   * @deprecated Use {@link #decodingSource(CharSource)} instead. This method is scheduled to be
+   *     removed in Guava 16.0.
+   */
+  @Deprecated
+  @GwtIncompatible("Reader,InputStream")
+  public final InputSupplier<InputStream> decodingStream(
+      final InputSupplier<? extends Reader> readerSupplier) {
+    checkNotNull(readerSupplier);
+    return new InputSupplier<InputStream>() {
+      @Override
+      public InputStream getInput() throws IOException {
+        return decodingStream(readerSupplier.getInput());
+      }
+    };
   }
 
   /**

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -41,6 +41,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
+import java.util.zip.Checksum;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -873,6 +874,39 @@ public final class ByteStreams {
       read = input.read(buf);
     } while (read != -1 && processor.processBytes(buf, 0, read));
     return processor.getResult();
+  }
+
+  /**
+   * Computes and returns the checksum value for a supplied input stream.
+   * The checksum object is reset when this method returns successfully.
+   *
+   * @param supplier the input stream factory
+   * @param checksum the checksum object
+   * @return the result of {@link Checksum#getValue} after updating the
+   *     checksum object with all of the bytes in the stream
+   * @throws IOException if an I/O error occurs
+   * @deprecated Use {@code hash} with the {@code Hashing.crc32()} or
+   *     {@code Hashing.adler32()} hash functions instead. This method is
+   *     scheduled to be removed in Guava 15.0.
+   */
+  @Deprecated
+  public static long getChecksum(
+      InputSupplier<? extends InputStream> supplier, final Checksum checksum)
+      throws IOException {
+    checkNotNull(checksum);
+    return readBytes(supplier, new ByteProcessor<Long>() {
+      @Override
+      public boolean processBytes(byte[] buf, int off, int len) {
+        checksum.update(buf, off, len);
+        return true;
+      }
+      @Override
+      public Long getResult() {
+        long result = checksum.getValue();
+        checksum.reset();
+        return result;
+      }
+    });
   }
 
   /**

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -89,6 +89,18 @@ public final class ByteStreams {
   }
 
   /**
+   * Returns a new {@link ByteSource} that reads bytes from the given byte array.
+   *
+   * @since 14.0
+   * @deprecated Use {@link ByteSource#wrap(byte[])} instead. This method is
+   *     scheduled to be removed in Guava 16.0.
+   */
+  @Deprecated
+  public static ByteSource asByteSource(byte[] b) {
+    return ByteSource.wrap(b);
+  }
+
+  /**
    * Writes a byte array to an output stream from the given supplier.
    *
    * @param from the bytes to write

--- a/guava/src/com/google/common/io/CharStreams.java
+++ b/guava/src/com/google/common/io/CharStreams.java
@@ -77,6 +77,18 @@ public final class CharStreams {
   }
 
   /**
+   * Returns a {@link CharSource} that reads the given string value.
+   *
+   * @since 14.0
+   * @deprecated Use {@link CharSource#wrap(CharSequence)} instead. This method
+   *     is scheduled to be removed in Guava 16.0.
+   */
+  @Deprecated
+  public static CharSource asCharSource(String string) {
+    return CharSource.wrap(string);
+  }
+
+  /**
    * Returns a factory that will supply instances of {@link InputStreamReader},
    * using the given {@link InputStream} factory and character set.
    *

--- a/guava/src/com/google/common/io/Closeables.java
+++ b/guava/src/com/google/common/io/Closeables.java
@@ -88,6 +88,32 @@ public final class Closeables {
   }
 
   /**
+   * Equivalent to calling {@code close(closeable, true)}, but with no IOException in the signature.
+   *
+   * @param closeable the {@code Closeable} object to be closed, or null, in which case this method
+   *     does nothing
+   * @deprecated Where possible, use the
+   *     <a href="http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html">
+   *     try-with-resources</a> statement if using JDK7 or {@link Closer} on JDK6 to close one or
+   *     more {@code Closeable} objects. This method is deprecated because it is easy to misuse and
+   *     may swallow IO exceptions that really should be thrown and handled. See
+   *     <a href="https://code.google.com/p/guava-libraries/issues/detail?id=1118">Guava issue
+   *     1118</a> for a more detailed explanation of the reasons for deprecation and see
+   *     <a href="https://code.google.com/p/guava-libraries/wiki/ClosingResourcesExplained">
+   *     Closing Resources</a> for more information on the problems with closing {@code Closeable}
+   *     objects and some of the preferred solutions for handling it correctly. This method is
+   *     scheduled to be removed after upgrading Android to Guava 17.0.
+   */
+  @Deprecated
+  public static void closeQuietly(@Nullable Closeable closeable) {
+    try {
+      close(closeable, true);
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "IOException should not have been thrown.", e);
+    }
+  }
+
+  /**
    * Closes the given {@link InputStream}, logging any {@code IOException} that's thrown rather
    * than propagating it.
    *

--- a/guava/src/com/google/common/io/FileBackedOutputStream.java
+++ b/guava/src/com/google/common/io/FileBackedOutputStream.java
@@ -119,6 +119,19 @@ public final class FileBackedOutputStream extends OutputStream {
   }
 
   /**
+   * Returns a supplier that may be used to retrieve the data buffered
+   * by this stream. This method returns the same object as
+   * {@link #asByteSource()}.
+   *
+   * @deprecated Use {@link #asByteSource()} instead. This method is scheduled
+   *     to be removed in Guava 16.0.
+   */
+  @Deprecated
+  public InputSupplier<InputStream> getSupplier() {
+    return asByteSource();
+  }
+
+  /**
    * Returns a readable {@link ByteSource} view of the data that has been
    * written to this stream.
    *

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.zip.Checksum;
 
 /**
  * Provides utility methods for working with files.
@@ -755,6 +756,25 @@ public final class Files {
   public static <T> T readBytes(File file, ByteProcessor<T> processor)
       throws IOException {
     return ByteStreams.readBytes(newInputStreamSupplier(file), processor);
+  }
+
+  /**
+   * Computes and returns the checksum value for a file.
+   * The checksum object is reset when this method returns successfully.
+   *
+   * @param file the file to read
+   * @param checksum the checksum object
+   * @return the result of {@link Checksum#getValue} after updating the
+   *     checksum object with all of the bytes in the file
+   * @throws IOException if an I/O error occurs
+   * @deprecated Use {@code hash} with the {@code Hashing.crc32()} or
+   *     {@code Hashing.adler32()} hash functions. This method is scheduled
+   *     to be removed in Guava 15.0.
+   */
+  @Deprecated
+  public static long getChecksum(File file, Checksum checksum)
+      throws IOException {
+    return ByteStreams.getChecksum(newInputStreamSupplier(file), checksum);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
@@ -152,12 +152,38 @@ public abstract class AbstractExecutionThreadService implements Service {
     return serviceName() + " [" + state() + "]";
   }
 
+  // We override instead of using ForwardingService so that these can be final.
+
+  @Deprecated
+  @Override
+  public final ListenableFuture<State> start() {
+    return delegate.start();
+  }
+
+  @Deprecated
+  @Override
+   public final State startAndWait() {
+    return delegate.startAndWait();
+  }
+
   @Override public final boolean isRunning() {
     return delegate.isRunning();
   }
 
   @Override public final State state() {
     return delegate.state();
+  }
+
+  @Deprecated
+  @Override
+   public final ListenableFuture<State> stop() {
+    return delegate.stop();
+  }
+
+  @Deprecated
+  @Override
+   public final State stopAndWait() {
+    return delegate.stopAndWait();
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
@@ -106,12 +106,38 @@ public abstract class AbstractIdleService implements Service {
     return serviceName() + " [" + state() + "]";
   }
 
+  // We override instead of using ForwardingService so that these can be final.
+
+  @Deprecated
+  @Override
+   public final ListenableFuture<State> start() {
+    return delegate.start();
+  }
+
+  @Deprecated
+  @Override
+   public final State startAndWait() {
+    return delegate.startAndWait();
+  }
+
   @Override public final boolean isRunning() {
     return delegate.isRunning();
   }
 
   @Override public final State state() {
     return delegate.state();
+  }
+
+  @Deprecated
+  @Override
+  public final ListenableFuture<State> stop() {
+    return delegate.stop();
+  }
+
+  @Deprecated
+  @Override
+  public final State stopAndWait() {
+    return delegate.stopAndWait();
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -317,12 +317,38 @@ public abstract class AbstractScheduledService implements Service {
     return serviceName() + " [" + state() + "]";
   }
 
+  // We override instead of using ForwardingService so that these can be final.
+
+  @Deprecated
+  @Override
+   public final ListenableFuture<State> start() {
+    return delegate.start();
+  }
+
+  @Deprecated
+  @Override
+   public final State startAndWait() {
+    return delegate.startAndWait();
+  }
+
   @Override public final boolean isRunning() {
     return delegate.isRunning();
   }
 
   @Override public final State state() {
     return delegate.state();
+  }
+
+  @Deprecated
+  @Override
+   public final ListenableFuture<State> stop() {
+    return delegate.stop();
+  }
+
+  @Deprecated
+  @Override
+   public final State stopAndWait() {
+    return delegate.stopAndWait();
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/ListenerCallQueue.java
+++ b/guava/src/com/google/common/util/concurrent/ListenerCallQueue.java
@@ -19,7 +19,7 @@ package com.google.common.util.concurrent;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Queues;
+import com.google.common.collect.Lists;
 
 import java.util.Queue;
 import java.util.concurrent.Executor;
@@ -59,7 +59,7 @@ final class ListenerCallQueue<L> implements Runnable {
   private final L listener;
   private final Executor executor;
 
-  @GuardedBy("this") private final Queue<Callback<L>> waitQueue = Queues.newArrayDeque();
+  @GuardedBy("this") private final Queue<Callback<L>> waitQueue = Lists.newLinkedList();
   @GuardedBy("this") private boolean isThreadScheduled;
 
   ListenerCallQueue(L listener, Executor executor) {

--- a/guava/src/com/google/common/util/concurrent/Service.java
+++ b/guava/src/com/google/common/util/concurrent/Service.java
@@ -55,6 +55,40 @@ import java.util.concurrent.TimeoutException;
 public interface Service {
   /**
    * If the service state is {@link State#NEW}, this initiates service startup and returns
+   * immediately. If the service has already been started, this method returns immediately without
+   * taking action. A stopped service may not be restarted.
+   *
+   * @deprecated Use {@link #startAsync()} instead of this method to start the {@link Service} or
+   * use a {@link Listener} to asynchronously wait for service startup.
+   *
+   * @return a future for the startup result, regardless of whether this call initiated startup.
+   *         Calling {@link ListenableFuture#get} will block until the service has finished
+   *         starting, and returns one of {@link State#RUNNING}, {@link State#STOPPING} or
+   *         {@link State#TERMINATED}. If the service fails to start, {@link ListenableFuture#get}
+   *         will throw an {@link ExecutionException}, and the service's state will be
+   *         {@link State#FAILED}. If it has already finished starting, {@link ListenableFuture#get}
+   *         returns immediately. Cancelling this future has no effect on the service.
+   */
+
+  @Deprecated
+  ListenableFuture<State> start();
+
+  /**
+   * Initiates service startup (if necessary), returning once the service has finished starting.
+   * Unlike calling {@code start().get()}, this method throws no checked exceptions, and it cannot
+   * be {@linkplain Thread#interrupt interrupted}.
+   *
+   * @deprecated Use {@link #startAsync()} and {@link #awaitRunning} instead of this method.
+   *
+   * @throws UncheckedExecutionException if startup failed
+   * @return the state of the service when startup finished.
+   */
+
+  @Deprecated
+  State startAndWait();
+
+  /**
+   * If the service state is {@link State#NEW}, this initiates service startup and returns
    * immediately. A stopped service may not be restarted.
    * 
    * @return this
@@ -73,6 +107,42 @@ public interface Service {
    * Returns the lifecycle state of the service.
    */
   State state();
+
+  /**
+   * If the service is {@linkplain State#STARTING starting} or {@linkplain State#RUNNING running},
+   * this initiates service shutdown and returns immediately. If the service is
+   * {@linkplain State#NEW new}, it is {@linkplain State#TERMINATED terminated} without having been
+   * started nor stopped. If the service has already been stopped, this method returns immediately
+   * without taking action.
+   *
+   * @deprecated Use {@link #stopAsync} instead of this method to initiate service shutdown or use a
+   * service {@link Listener} to asynchronously wait for service shutdown.
+   *
+   * @return a future for the shutdown result, regardless of whether this call initiated shutdown.
+   *         Calling {@link ListenableFuture#get} will block until the service has finished shutting
+   *         down, and either returns {@link State#TERMINATED} or throws an
+   *         {@link ExecutionException}. If it has already finished stopping,
+   *         {@link ListenableFuture#get} returns immediately. Cancelling this future has no effect
+   *         on the service.
+   */
+
+  @Deprecated
+  ListenableFuture<State> stop();
+
+  /**
+   * Initiates service shutdown (if necessary), returning once the service has finished stopping. If
+   * this is {@link State#STARTING}, startup will be cancelled. If this is {@link State#NEW}, it is
+   * {@link State#TERMINATED terminated} without having been started nor stopped. Unlike calling
+   * {@code stop().get()}, this method throws no checked exceptions.
+   *
+   * @deprecated Use {@link #stopAsync} and {@link #awaitTerminated} instead of this method.
+   *
+   * @throws UncheckedExecutionException if the service has failed or fails during shutdown
+   * @return the state of the service when shutdown finished.
+   */
+
+  @Deprecated
+  State stopAndWait();
 
   /**
    * If the service is {@linkplain State#STARTING starting} or {@linkplain State#RUNNING running},

--- a/guava/src/com/google/common/xml/XmlEscapers.java
+++ b/guava/src/com/google/common/xml/XmlEscapers.java
@@ -55,13 +55,6 @@ public class XmlEscapers {
   // For each xxxEscaper() method, please add links to external reference pages
   // that are considered authoritative for the behavior of that escaper.
 
-  // TODO(user): When this escaper strips \uFFFE & \uFFFF, add this doc.
-  // <p>This escaper also silently removes non-whitespace control characters and
-  // the character values {@code 0xFFFE} and {@code 0xFFFF} which are not
-  // permitted in XML. For more detail see section
-  // <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">2.2</a> of
-  // the XML specification.
-
   /**
    * Returns an {@link Escaper} instance that escapes special characters in a
    * string so it can safely be included in an XML document as element content.
@@ -73,6 +66,12 @@ public class XmlEscapers {
    * safe</b> to use this escaper to escape attribute values. Use
    * {@link #xmlContentEscaper} if the output can appear in element content or
    * {@link #xmlAttributeEscaper} in attribute values.
+   *
+   * <p>This escaper substitutes {@code 0xFFFD} for non-whitespace control
+   * characters and the character values {@code 0xFFFE} and {@code 0xFFFF} which
+   * are not permitted in XML. For more detail see section <a
+   * href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">2.2</a> of the
+   * XML specification.
    *
    * <p>This escaper does not escape non-ASCII characters to their numeric
    * character references (NCR). Any non-ASCII characters appearing in the input
@@ -93,6 +92,12 @@ public class XmlEscapers {
    * See section
    * <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize">3.3.3</a>
    * of the XML specification.
+   *
+   * <p>This escaper substitutes {@code 0xFFFD} for non-whitespace control
+   * characters and the character values {@code 0xFFFE} and {@code 0xFFFF} which
+   * are not permitted in XML. For more detail see section <a
+   * href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">2.2</a> of the
+   * XML specification.
    *
    * <p>This escaper does not escape non-ASCII characters to their numeric
    * character references (NCR). However, horizontal tab {@code '\t'}, line feed
@@ -116,19 +121,23 @@ public class XmlEscapers {
     // The char values \uFFFE and \uFFFF are explicitly not allowed in XML
     // (Unicode code points above \uFFFF are represented via surrogate pairs
     // which means they are treated as pairs of safe characters).
-    // TODO(user): When refactoring done change the \uFFFF below to \uFFFD
-    builder.setSafeRange(Character.MIN_VALUE, '\uFFFF');
-    // Unsafe characters are removed.
-    builder.setUnsafeReplacement("");
+    builder.setSafeRange(Character.MIN_VALUE, '\uFFFD');
+    // Unsafe characters are replaced with the Unicode replacement character.
+    builder.setUnsafeReplacement("\uFFFD");
 
-    // Except for '\n', '\t' and '\r' we remove all ASCII control characters.
-    // An alternative to this would be to make a map that simply replaces the
-    // allowed ASCII whitespace characters with themselves and set the minimum
-    // safe character to 0x20. However this would slow down the escaping of
-    // simple strings that contain '\t','\n' or '\r'.
+    /*
+     * Except for \n, \t, and \r, all ASCII control characters are replaced with
+     * the Unicode replacement character.
+     *
+     * Implementation note: An alternative to the following would be to make a
+     * map that simply replaces the allowed ASCII whitespace characters with
+     * themselves and to set the minimum safe character to 0x20. However this
+     * would slow down the escaping of simple strings that contain \t, \n, or
+     * \r.
+     */
     for (char c = MIN_ASCII_CONTROL_CHAR; c <= MAX_ASCII_CONTROL_CHAR; c++) {
       if (c != '\t' && c != '\n' && c != '\r') {
-        builder.addEscape(c, "");
+        builder.addEscape(c, "\uFFFD");
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent-jdk5</artifactId>
-  <version>17.0-SNAPSHOT</version>
+  <version>17.0-rc1</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent (JDK5 Backport)</name>
   <url>http://code.google.com/p/guava-libraries</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent-jdk5</artifactId>
-  <version>17.0-rc2</version>
+  <version>17.0</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent (JDK5 Backport)</name>
   <url>http://code.google.com/p/guava-libraries</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent-jdk5</artifactId>
-  <version>17.0-rc1</version>
+  <version>17.0-rc2</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent (JDK5 Backport)</name>
   <url>http://code.google.com/p/guava-libraries</url>


### PR DESCRIPTION
Reverts (at least in part) a number of changes made to jdk5-backport-v17.0-post to make it more compatible with code built against jdk5-backport-v14.0.1-post, specifically AOSP code. The reverted changes added back methods that had been present in v14 (deprecated and not) and since been removed. The intent is to allow AOSP code that built against v14.0.1 to also build against the compatibility version of v17.0 without modification (or with minimal atomic modifications). That will make upgrading itself easier and will allow other changes such as removing usages of deprecated methods to be done in stages.