### PR TITLE
Builder to create ThreadPoolExecutor and ScheduledThreadPoolExecutor

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/ExecutorBuilderTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ExecutorBuilderTest.java
@@ -1,0 +1,80 @@
+package com.google.common.util.concurrent;
+
+import java.util.concurrent.*;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class ExecutorBuilderTest {
+    @Test
+    public void testBuildThreadPoolExecutor() throws Exception {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder().corePoolSize(10).build("MyThread");
+        assertThat(executor.getCorePoolSize(), is(10));
+        Future<String> future = executor.submit(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return Thread.currentThread().getName();
+            }
+        });
+        assertTrue(future.get().contains("MyThread-"));
+        assertThat(executor.getKeepAliveTime(TimeUnit.SECONDS), is(0L));
+    }
+
+    @Test
+    public void test_simple_config() {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder().build();
+        assertThat(executor.getCorePoolSize(), is(Runtime.getRuntime().availableProcessors()));
+        assertThat(executor.getMaximumPoolSize(), is(Runtime.getRuntime().availableProcessors()));
+        assertThat(executor.getKeepAliveTime(TimeUnit.SECONDS), is(0L));
+        assertTrue(executor.getQueue() instanceof LinkedBlockingQueue);
+        assertTrue(executor.getRejectedExecutionHandler() instanceof ThreadPoolExecutor.AbortPolicy);
+    }
+
+    @Test
+    public void test_max_size() {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder().maxPoolSize(10).build();
+        assertThat(executor.getMaximumPoolSize(), is(10));
+    }
+
+    @Test
+    public void test_keep_alive() {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder().keepAliveSeconds(10).build();
+        assertThat(executor.getKeepAliveTime(TimeUnit.SECONDS), is(10L));
+    }
+
+    @Test
+    public void test_work_queue() {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder().workQueue(new ArrayBlockingQueue<Runnable>(100)).build();
+        assertTrue(executor.getQueue() instanceof ArrayBlockingQueue);
+    }
+
+    @Test
+    public void test_reject_exec_handler() {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) ExecutorBuilder.newBuilder()
+                .rejectHandler(new ThreadPoolExecutor.DiscardPolicy()).build();
+        assertTrue(executor.getRejectedExecutionHandler() instanceof ThreadPoolExecutor.DiscardPolicy);
+    }
+
+    @Test
+    public void test_simple_scheduled() {
+        ScheduledThreadPoolExecutor scheduler = (ScheduledThreadPoolExecutor) ExecutorBuilder.newBuilder().buildScheduled();
+        assertThat(scheduler.getCorePoolSize(), is(Runtime.getRuntime().availableProcessors()));
+    }
+
+    @Test
+    public void testBuildScheduleThreadPoolExecutor() throws Exception {
+        ScheduledExecutorService scheduler = ExecutorBuilder.newBuilder().corePoolSize(10).buildScheduled("MyThread");
+        assertThat(((ThreadPoolExecutor) scheduler).getCorePoolSize(), is(10));
+        Future<String> future = scheduler.submit(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return Thread.currentThread().getName();
+            }
+        });
+        assertTrue(future.get().contains("MyThread-"));
+        assertTrue(scheduler instanceof ScheduledThreadPoolExecutor);
+    }
+}

--- a/guava/src/com/google/common/util/concurrent/ExecutorBuilder.java
+++ b/guava/src/com/google/common/util/concurrent/ExecutorBuilder.java
@@ -1,0 +1,132 @@
+package com.google.common.util.concurrent;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public class ExecutorBuilder {
+    private int corePoolSize;
+    private int maxPoolSize;
+    private long keepAlive;
+    private BlockingQueue<Runnable> workQueue;
+    private InternalThreadFactory threadFactory;
+    private RejectedExecutionHandler handler;
+
+    public static ExecutorBuilder newBuilder() {
+        return new ExecutorBuilder();
+    }
+
+    public ExecutorBuilder corePoolSize(int corePoolSize) {
+        this.corePoolSize = corePoolSize;
+        return this;
+    }
+
+    public ExecutorBuilder maxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+        return this;
+    }
+
+    public ExecutorBuilder keepAliveSeconds(int keepAlive) {
+        this.keepAlive = keepAlive;
+        return this;
+    }
+
+    public ExecutorBuilder workQueue(BlockingQueue<Runnable> queue) {
+        this.workQueue = queue;
+        return this;
+    }
+
+    public ExecutorBuilder rejectHandler(RejectedExecutionHandler handler) {
+        this.handler = handler;
+        return this;
+    }
+
+    private void initThreadFactoryIfNecessary() {
+        if (threadFactory == null) {
+            threadFactory = new InternalThreadFactory();
+        }
+    }
+
+    public ThreadPoolExecutor buildExecutor(String name, Supplier<ThreadPoolExecutor> threadPoolExecutorSupplier) {
+        if (name != null) {
+            initThreadFactoryIfNecessary();
+            threadFactory.setThreadNamePrefix(name);
+        }
+
+        configurePoolSize();
+
+        if (workQueue == null) {
+            workQueue = new LinkedBlockingQueue<Runnable>();
+        }
+
+        ThreadPoolExecutor threadPoolExecutor = threadPoolExecutorSupplier.get();
+
+        if (threadFactory != null)
+            threadPoolExecutor.setThreadFactory(threadFactory);
+
+        if (keepAlive >= 0) {
+            threadPoolExecutor.setKeepAliveTime(keepAlive, TimeUnit.SECONDS);
+        }
+
+        if (handler != null) {
+            threadPoolExecutor.setRejectedExecutionHandler(handler);
+        }
+
+        return threadPoolExecutor;
+    }
+
+    private void configurePoolSize() {
+        if (corePoolSize == 0)
+            corePoolSize = Runtime.getRuntime().availableProcessors();
+
+        maxPoolSize = maxPoolSize == 0 ? corePoolSize : maxPoolSize;
+    }
+
+    public ExecutorService build() {
+        return build(null);
+    }
+
+    public ExecutorService build(String name) {
+        return buildExecutor(name, new Supplier<ThreadPoolExecutor>() {
+            @Override
+            public ThreadPoolExecutor get() {
+                return new ThreadPoolExecutor(corePoolSize, maxPoolSize, 0, TimeUnit.SECONDS, workQueue);
+            }
+        });
+    }
+
+    public ScheduledExecutorService buildScheduled() {
+        return buildScheduled(null);
+    }
+
+    public ScheduledExecutorService buildScheduled(String name) {
+        return (ScheduledExecutorService) buildExecutor(name, new Supplier<ThreadPoolExecutor>() {
+            @Override
+            public ThreadPoolExecutor get() {
+                return new ScheduledThreadPoolExecutor(corePoolSize);
+            }
+        });
+    }
+
+    private class InternalThreadFactory implements ThreadFactory {
+        private ThreadFactory baseThreadFactory = Executors.defaultThreadFactory();
+        private AtomicInteger threadCount = new AtomicInteger(1);
+
+        private String threadNamePrefix;
+
+        public InternalThreadFactory() {
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = baseThreadFactory.newThread(r);
+            if (threadNamePrefix != null)
+                thread.setName(threadNamePrefix + "-" + threadCount.getAndIncrement());
+            return thread;
+        }
+
+        public void setThreadNamePrefix(String threadNamePrefix) {
+            this.threadNamePrefix = threadNamePrefix;
+        }
+    }
+}


### PR DESCRIPTION
JDK `Executors` provides several tool methods to create `ThreadPoolExecutor` and `ScheduledThreadPoolExecutor`. But these methods are not flexible. But if build up `ThreadPoolExecutor` and `ScheduledThreadPoolExecutor` from nothing, it will be a little complex. 

Apache Camel has a `ThreadPoolBuilder` but it is complex since bind with `CamelContext`.

So I create a simple builder to create `ThreadPoolExecutor` and `ScheduledThreadPoolExecutor`.
