### PR TITLE
Add a weight() method to Cache

### DIFF
--- a/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
+++ b/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
@@ -403,6 +403,11 @@ public class LocalCache<K, V> implements ConcurrentMap<K, V> {
     }
 
     @Override
+    public long weight() {
+      return localCache.weight();
+    }
+
+    @Override
     public ConcurrentMap<K, V> asMap() {
       return localCache;
     }

--- a/guava-tests/test/com/google/common/cache/CacheEvictionTest.java
+++ b/guava-tests/test/com/google/common/cache/CacheEvictionTest.java
@@ -77,15 +77,18 @@ public class CacheEvictionTest extends TestCase {
   }
 
   public void testEviction_maxWeightOneSegment() {
+    int maxWeight = 2 * MAX_SIZE;
+
     IdentityLoader<Integer> loader = identityLoader();
     LoadingCache<Integer, Integer> cache = CacheBuilder.newBuilder()
         .concurrencyLevel(1)
-        .maximumWeight(2 * MAX_SIZE)
+        .maximumWeight(maxWeight)
         .weigher(constantWeigher(2))
         .build(loader);
     for (int i = 0; i < 2 * MAX_SIZE; i++) {
       cache.getUnchecked(i);
       assertEquals(Math.min(i + 1, MAX_SIZE), cache.size());
+      assertEquals(Math.min((i + 1) * 2, maxWeight), cache.weight());
     }
 
     assertEquals(MAX_SIZE, cache.size());
@@ -112,16 +115,19 @@ public class CacheEvictionTest extends TestCase {
   }
 
   public void testEviction_maxWeight() {
+    int maxWeight = 2 * MAX_SIZE;
+
     CountingRemovalListener<Integer, Integer> removalListener = countingRemovalListener();
     IdentityLoader<Integer> loader = identityLoader();
     LoadingCache<Integer, Integer> cache = CacheBuilder.newBuilder()
-        .maximumWeight(2 * MAX_SIZE)
+        .maximumWeight(maxWeight)
         .weigher(constantWeigher(2))
         .removalListener(removalListener)
         .build(loader);
     for (int i = 0; i < 2 * MAX_SIZE; i++) {
       cache.getUnchecked(i);
       assertTrue(cache.size() <= MAX_SIZE);
+      assertTrue(cache.weight() <= maxWeight);
     }
 
     assertEquals(MAX_SIZE, CacheTesting.accessQueueSize(cache));
@@ -218,36 +224,43 @@ public class CacheEvictionTest extends TestCase {
     CacheTesting.warmUp(cache, 0, 10);
     Set<Integer> keySet = cache.asMap().keySet();
     assertThat(keySet).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    assertEquals(cache.weight(), 45);
 
     // re-order
     getAll(cache, asList(0, 1, 2));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(3, 4, 5, 6, 7, 8, 9, 0, 1, 2);
+    assertEquals(cache.weight(), 45);
 
     // evict 3, 4, 5
     getAll(cache, asList(10));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(6, 7, 8, 9, 0, 1, 2, 10);
+    assertEquals(cache.weight(), 43);
 
     // re-order
     getAll(cache, asList(6, 7, 8));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(9, 0, 1, 2, 10, 6, 7, 8);
+    assertEquals(cache.weight(), 43);
 
     // evict 9, 1, 2, 10
     getAll(cache, asList(15));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(0, 6, 7, 8, 15);
+    assertEquals(cache.weight(), 36);
 
     // fill empty space
     getAll(cache, asList(9));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(0, 6, 7, 8, 15, 9);
+    assertEquals(cache.weight(), 45);
 
     // evict 6
     getAll(cache, asList(1));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(0, 7, 8, 15, 9, 1);
+    assertEquals(cache.weight(), 40);
   }
 
   public void testEviction_overweight() {
@@ -261,16 +274,19 @@ public class CacheEvictionTest extends TestCase {
     CacheTesting.warmUp(cache, 0, 10);
     Set<Integer> keySet = cache.asMap().keySet();
     assertThat(keySet).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    assertEquals(cache.weight(), 45);
 
     // add an at-the-maximum-weight entry
     getAll(cache, asList(45));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).containsExactly(0, 45);
+    assertEquals(cache.weight(), 45);
 
     // add an over-the-maximum-weight entry
     getAll(cache, asList(46));
     CacheTesting.drainRecencyQueues(cache);
     assertThat(keySet).contains(0);
+    assertEquals(cache.weight(), 0);
   }
 
   public void testEviction_invalidateAll() {

--- a/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -446,6 +446,7 @@ class CacheTesting {
   }
   static void checkEmpty(Cache<?, ?> cache) {
     assertEquals(0, cache.size());
+    assertEquals(0, cache.weight());
     assertFalse(cache.asMap().containsKey(null));
     assertFalse(cache.asMap().containsKey(6));
     assertFalse(cache.asMap().containsValue(null));

--- a/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
@@ -97,6 +97,13 @@ public class ForwardingCacheTest extends TestCase {
     verify(mock);
   }
 
+  public void testWeight() {
+    expect(mock.weight()).andReturn(0L);
+    replay(mock);
+    forward.weight();
+    verify(mock);
+  }
+
   public void testStats() {
     expect(mock.stats()).andReturn(null);
     replay(mock);

--- a/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
@@ -109,6 +109,13 @@ public class ForwardingLoadingCacheTest extends TestCase {
     verify(mock);
   }
 
+  public void testWeight() {
+    expect(mock.weight()).andReturn(0L);
+    replay(mock);
+    forward.weight();
+    verify(mock);
+  }
+
   public void testStats() {
     expect(mock.stats()).andReturn(null);
     replay(mock);

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -2250,6 +2250,7 @@ public class LocalCacheTest extends TestCase {
     }
     segment.evictEntries();
     assertEquals(maxSize, map.size());
+    assertEquals(maxSize, map.weight()); // Weight is equal to size when not using a weigher
     assertEquals(originalMap, map);
   }
 

--- a/guava/src/com/google/common/cache/AbstractCache.java
+++ b/guava/src/com/google/common/cache/AbstractCache.java
@@ -107,6 +107,11 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
   }
 
   @Override
+  public long weight() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void invalidate(Object key) {
     throw new UnsupportedOperationException();
   }

--- a/guava/src/com/google/common/cache/Cache.java
+++ b/guava/src/com/google/common/cache/Cache.java
@@ -128,6 +128,11 @@ public interface Cache<K, V> {
   long size();
 
   /**
+   * Returns the approximate weight of this cache.
+   */
+  long weight();
+
+  /**
    * Returns a current snapshot of this cache's cumulative statistics. All stats are initialized
    * to zero, and are monotonically increasing over the lifetime of the cache.
    *

--- a/guava/src/com/google/common/cache/ForwardingCache.java
+++ b/guava/src/com/google/common/cache/ForwardingCache.java
@@ -110,6 +110,11 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
   }
 
   @Override
+  public long weight() {
+    return delegate().weight();
+  }
+
+  @Override
   public CacheStats stats() {
     return delegate().stats();
   }

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -3911,6 +3911,17 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     return Ints.saturatedCast(longSize());
   }
 
+  public long weight() {
+    Segment<K, V>[] segments = this.segments;
+    long sum = 0;
+    for (int i = 0; i < segments.length; ++i) {
+      segments[i].lock();
+      sum += segments[i].totalWeight;
+      segments[i].unlock();
+    }
+    return sum;
+  }
+
   @Override
   @Nullable
   public V get(@Nullable Object key) {
@@ -4779,6 +4790,11 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     public long size() {
       return localCache.longSize();
+    }
+
+    @Override
+    public long weight() {
+      return localCache.weight();
     }
 
     @Override


### PR DESCRIPTION
Cache objects currently do not have a method of introspecting on the current "weight" value.  I am replacing an implementation of a cache that is just a synchronized LinkedHashMap.  In my current implementation of the cache, I'm keeping track of the weights of things being stored and exposing that as a metric about my cache.  This is the _only_ feature of my current implementation that is not covered by Guava's Cache.

From looking at the code, it seemed relatively easy to just create another method parallel to `size()` to handle this case so I just went ahead and did it.  The guidelines do state that API changes should start as an issue, but I didn't realize that until I had already done this and it is such a simple fix, it doesn't bother me if it gets thrown away (as long as I do get some method of introspecting on the current weight value ;) ).

I do realize that this is a public API change, it is only an addition, but it does mean that if anyone else is implementing the Cache interface from scratch, their code will have to be updated before it can work with this.  I'm not sure what level of API compatibility is maintained with Guava, but as long as people are only using Guava-built cache objects, it should be a forward-compatible change.

Also, I updated unit tests as I could find ones that seemed relevant, but I will admit that I didn't read and comprehend all tests, so I might've missed a good place to add some more verification of the weight computation.  Let me know if there are other tests to update and I'll be happy to.

If you think this is going to work, let me know and I'll make sure to get a CLA.
