### PR TITLE
Alternative way to get AssertionError instance in

### DIFF
--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableMultiset.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableMultiset.java
@@ -363,7 +363,8 @@ public abstract class ImmutableMultiset<E> extends ImmutableCollection<E>
   }
 
   static class EntrySetSerializedForm<E> implements Serializable {
-    final ImmutableMultiset<E> multiset;
+	private static final long serialVersionUID = 0L;
+	final ImmutableMultiset<E> multiset;
 
     EntrySetSerializedForm(ImmutableMultiset<E> multiset) {
       this.multiset = multiset;

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/TreeMultiset.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/TreeMultiset.java
@@ -945,5 +945,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
    * calls the comparator to compare the two keys. If that change is made,
    * AbstractMultiset.equals() can simply check whether two multisets have equal entry sets.
    */
+  
+  private static final long serialVersionUID = 0L;
 }
 

--- a/guava-gwt/src/com/google/common/collect/GwtSerializationDependencies.java
+++ b/guava-gwt/src/com/google/common/collect/GwtSerializationDependencies.java
@@ -122,6 +122,8 @@ final class GwtSerializationDependencies {
    */
   static final class ImmutableTableDependencies<R, C, V>
       extends SingletonImmutableTable<R, C, V> implements Serializable {
+	private static final long serialVersionUID = 0L;
+	  
     R rowKey;
     C columnKey;
     V value;

--- a/guava-gwt/test-super/com/google/common/collect/super/com/google/common/collect/SimpleAbstractMultisetTest.java
+++ b/guava-gwt/test-super/com/google/common/collect/super/com/google/common/collect/SimpleAbstractMultisetTest.java
@@ -112,6 +112,8 @@ public class SimpleAbstractMultisetTest extends TestCase {
     int distinctElements() {
       return backingMap.size();
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 }
 

--- a/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -459,6 +459,8 @@ public final class ArbitraryInstances {
     @Override public OutputStream openStream() {
       return ByteStreams.nullOutputStream();
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   // Compare by toString() to satisfy 2 properties:
@@ -495,6 +497,8 @@ public final class ArbitraryInstances {
     private Object readResolve() {
       return INSTANCE;
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   private ArbitraryInstances() {}

--- a/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
+++ b/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
@@ -820,5 +820,7 @@ public final class ClassSanityTester {
     @Override public int hashCode() {
       return 0;
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 }

--- a/guava-testlib/src/com/google/common/testing/DummyProxy.java
+++ b/guava-testlib/src/com/google/common/testing/DummyProxy.java
@@ -61,6 +61,8 @@ abstract class DummyProxy {
   abstract <R> R dummyReturnValue(TypeToken<R> returnType);
 
   private class DummyHandler extends AbstractInvocationHandler implements Serializable {
+    private static final long serialVersionUID = 0L;    
+    
     private final TypeToken<?> interfaceType;
 
     DummyHandler(TypeToken<?> interfaceType) {

--- a/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
@@ -622,6 +622,8 @@ public class ClassSanityTesterTest extends TestCase {
     @Override public int hashCode() {
       return i.hashCode();
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   static class InstantiableFactoryMethodChosen {

--- a/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
@@ -121,6 +121,8 @@ public class SerializableTesterTest extends TestCase {
       public int hashCode() {
         return 1;
       }
+      
+      private static final long serialVersionUID = 0L;
     }
   }
 

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -2766,6 +2766,8 @@ public class LocalCacheTest extends TestCase {
     public boolean equals(Object o) {
       return (o instanceof SerializableCacheLoader);
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   private static class SerializableRemovalListener<K, V>
@@ -2782,6 +2784,8 @@ public class LocalCacheTest extends TestCase {
     public boolean equals(Object o) {
       return (o instanceof SerializableRemovalListener);
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   private static class SerializableTicker extends Ticker implements Serializable {
@@ -2799,6 +2803,8 @@ public class LocalCacheTest extends TestCase {
     public boolean equals(Object o) {
       return (o instanceof SerializableTicker);
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   private static class SerializableWeigher<K, V> implements Weigher<K, V>, Serializable {
@@ -2816,6 +2822,8 @@ public class LocalCacheTest extends TestCase {
     public boolean equals(Object o) {
       return (o instanceof SerializableWeigher);
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
 }

--- a/guava-tests/test/com/google/common/collect/SimpleAbstractMultisetTest.java
+++ b/guava-tests/test/com/google/common/collect/SimpleAbstractMultisetTest.java
@@ -138,5 +138,7 @@ public class SimpleAbstractMultisetTest extends TestCase {
     int distinctElements() {
       return backingMap.size();
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 }

--- a/guava-tests/test/com/google/common/reflect/AbstractInvocationHandlerTest.java
+++ b/guava-tests/test/com/google/common/reflect/AbstractInvocationHandlerTest.java
@@ -127,6 +127,8 @@ public class AbstractInvocationHandlerTest extends TestCase {
     @Override public String toString() {
       return "some arbitrary string";
     }
+    
+    private static final long serialVersionUID = 0L;
   }
 
   private static class DelegatingInvocationHandlerWithEquals extends DelegatingInvocationHandler {

--- a/guava-tests/test/com/google/common/util/concurrent/GeneratedMonitorTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/GeneratedMonitorTest.java
@@ -664,10 +664,10 @@ public class GeneratedMonitorTest extends TestCase {
       if (actualException instanceof InterruptedException) {
         return Outcome.INTERRUPT;
       } else {
-        throw new AssertionError("unexpected exception", targetException);
+        throw newAssertionError("unexpected exception", targetException);
       }
     } catch (IllegalAccessException e) {
-      throw new AssertionError("unexpected exception", e);
+      throw newAssertionError("unexpected exception", e);
     }
   }
 
@@ -775,6 +775,13 @@ public class GeneratedMonitorTest extends TestCase {
         }
       }
     };
+  }
+  
+  /** Alternative to AssertionError(String, Throwable), which doesn't exist in Java 1.6 */
+  private static AssertionError newAssertionError(String message, Throwable cause) {
+    AssertionError e = new AssertionError(message);
+    e.initCause(cause);
+    return e;
   }
 
 }

--- a/guava/src/com/google/common/collect/Count.java
+++ b/guava/src/com/google/common/collect/Count.java
@@ -71,4 +71,6 @@ final class Count implements Serializable {
   public String toString() {
     return Integer.toString(value);
   }
+  
+  private static final long serialVersionUID = 0L;
 }

--- a/guava/src/com/google/common/collect/GeneralRange.java
+++ b/guava/src/com/google/common/collect/GeneralRange.java
@@ -38,6 +38,8 @@ import javax.annotation.Nullable;
  */
 @GwtCompatible(serializable = true)
 final class GeneralRange<T> implements Serializable {
+  private static final long serialVersionUID = 0L;
+	
   /**
    * Converts a Range to a GeneralRange.
    */

--- a/guava/src/com/google/common/collect/ImmutableMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableMultiset.java
@@ -375,6 +375,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableCollection<E>
   }
 
   static class EntrySetSerializedForm<E> implements Serializable {
+	private static final long serialVersionUID = 0L;
     final ImmutableMultiset<E> multiset;
 
     EntrySetSerializedForm(ImmutableMultiset<E> multiset) {

--- a/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -42,6 +42,8 @@ import javax.annotation.Nullable;
 @Beta
 public final class ImmutableRangeSet<C extends Comparable> extends AbstractRangeSet<C>
     implements Serializable {
+  private static final long serialVersionUID = 0L;
+	
 
   private static final ImmutableRangeSet<Comparable<?>> EMPTY =
       new ImmutableRangeSet<Comparable<?>>(ImmutableList.<Range<Comparable<?>>>of());
@@ -509,6 +511,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
   }
 
   private static class AsSetSerializedForm<C extends Comparable> implements Serializable {
+	private static final long serialVersionUID = 0L;
     private final ImmutableList<Range<C>> ranges;
     private final DiscreteDomain<C> domain;
 
@@ -591,6 +594,8 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
   }
 
   private static final class SerializedForm<C extends Comparable> implements Serializable {
+	private static final long serialVersionUID = 0L;
+	  
     private final ImmutableList<Range<C>> ranges;
 
     SerializedForm(ImmutableList<Range<C>> ranges) {

--- a/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -540,6 +540,8 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableSortedMultiset
   }
 
   private static final class SerializedForm<E> implements Serializable {
+	private static final long serialVersionUID = 0L;
+	  
     Comparator<? super E> comparator;
     E[] elements;
     int[] counts;

--- a/guava/src/com/google/common/collect/MapConstraints.java
+++ b/guava/src/com/google/common/collect/MapConstraints.java
@@ -397,6 +397,8 @@ public final class MapConstraints {
   /** @see MapConstraints#constrainedMultimap */
   private static class ConstrainedMultimap<K, V>
       extends ForwardingMultimap<K, V> implements Serializable {
+	private static final long serialVersionUID = 0L;
+	  
     final MapConstraint<? super K, ? super V> constraint;
     final Multimap<K, V> delegate;
     transient Collection<Entry<K, V>> entries;

--- a/guava/src/com/google/common/hash/MessageDigestHashFunction.java
+++ b/guava/src/com/google/common/hash/MessageDigestHashFunction.java
@@ -156,4 +156,6 @@ final class MessageDigestHashFunction extends AbstractStreamingHashFunction
           : HashCode.fromBytesNoCopy(Arrays.copyOf(digest.digest(), bytes));
     }
   }
+  
+  private static final long serialVersionUID = 0L;
 }


### PR DESCRIPTION
Alternative way to get AssertionError instance in com.google.common.util.concurrent.GeneratedMonitorTest, since 
public AssertionError(String message, Throwable cause) 
does not exist in Java 6 yet.