### PR TITLE
Add missing serialVersionUID field to Converter and VerifyException classes.

### DIFF
--- a/guava/src/com/google/common/base/Converter.java
+++ b/guava/src/com/google/common/base/Converter.java
@@ -446,6 +446,8 @@ public abstract class Converter<A, B> implements Function<A, B> {
     public String toString() {
       return "Converter.from(" + forwardFunction + ", " + backwardFunction + ")";
     }
+
+    private static final long serialVersionUID = 0L;
   }
 
   /**

--- a/guava/src/com/google/common/base/Predicates.java
+++ b/guava/src/com/google/common/base/Predicates.java
@@ -609,7 +609,7 @@ public final class Predicates {
     }
 
     @Override public String toString() {
-      String patternString = Objects.toStringHelper(pattern)
+      String patternString = MoreObjects.toStringHelper(pattern)
           .add("pattern", pattern.pattern())
           .add("pattern.flags", pattern.flags())
           .toString();

--- a/guava/src/com/google/common/base/VerifyException.java
+++ b/guava/src/com/google/common/base/VerifyException.java
@@ -56,4 +56,6 @@ public class VerifyException extends RuntimeException {
   public VerifyException(@Nullable String message, @Nullable Throwable cause) {
     super(message, cause);
   }
+
+  private static final long serialVersionUID = 0L;
 }


### PR DESCRIPTION
Both Converter and VerifyException implement Serializable interface, so they should declare a static final serialVersionUID field.