### PR TITLE
I suggest adding generators to com.google.common.collect.Iterators

### DIFF
--- a/guava-tests/test/com/google/common/collect/IteratorsTest.java
+++ b/guava-tests/test/com/google/common/collect/IteratorsTest.java
@@ -45,10 +45,21 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.Vector;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringReader;
-import java.util.*;
 
 /**
  * Unit test for {@code Iterators}.

--- a/guava/src/com/google/common/collect/Generator.java
+++ b/guava/src/com/google/common/collect/Generator.java
@@ -1,0 +1,28 @@
+package com.google.common.collect;
+
+/**
+ * Interface for implementation of Generator code that can yield() elements to the environment
+ * (i.e. the Iterator calling the Generator. Generators are presented to you program code wrapped
+ * in an UnmodifiableIterator that calls the Generator to generate new value as the iterator is iterated.
+ *
+ * @author  Eirik Maus
+ * @since 19.0
+ */
+public interface Generator<T, Y extends YieldTarget<T>> {
+
+    /**
+     * Produce new value(s) for the iterator to iterate over.
+     * This method gets called when ever someone calls the surrounding Iterator's next() or hasNext() methods,
+     * and all the previously yielded values have been consumed.
+     * If no values are yielded, the Iterators hasNext()-method will return false and the
+     * generator is finished. More than one value may be yielded. These will be kept in memory
+     * until they are consumed by the iterator.
+     *
+     * All code executes in the same thread as the surrounding iterator calling this method.
+     * Infinite generators must can not loop forever, but must return now and then.
+     * They will be called again in order to proceed, once the previously yielded elements are consumed.
+     *
+     * @param yieldTarget - the target containing the yield(t) method that must be called to yield values.
+     */
+    void yieldNextValues(Y yieldTarget);
+}

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -33,7 +33,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.sun.istack.internal.NotNull;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -1158,7 +1157,7 @@ public final class Iterators {
    *
    * @since 19.0
    */
-  public static <T> UnmodifiableIterator<T> generator(@NotNull final Generator<T,YieldTarget<T>> generator) {
+  public static <T> UnmodifiableIterator<T> generator(final Generator<T,YieldTarget<T>> generator) {
     checkNotNull(generator);
     return new UnmodifiableIterator<T>() {
 
@@ -1212,7 +1211,7 @@ public final class Iterators {
    * @since 19.0
    */
   public static <T, S> UnmodifiableIterator<T> generatorWithState(final S initialState,
-                                                                  @NotNull final
+                                                                  final
                                                                   Generator<T,StatefulYieldTarget<S, T>> generator) {
     checkNotNull(generator);
     class Holder<E> {

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -1210,7 +1210,7 @@ public final class Iterators {
    *
    * @since 19.0
    */
-  public static <T, S> UnmodifiableIterator<T> generatorWithState(final S initialState,
+  public static <T, S> UnmodifiableIterator<T> generatorWithState(@Nullable final S initialState,
                                                                   final
                                                                   Generator<T,StatefulYieldTarget<S, T>> generator) {
     checkNotNull(generator);

--- a/guava/src/com/google/common/collect/StatefulYieldTarget.java
+++ b/guava/src/com/google/common/collect/StatefulYieldTarget.java
@@ -1,0 +1,26 @@
+package com.google.common.collect;
+
+/**
+ * Extended interface for YieldTargets that can keep some state between invocations
+ * of the generator code, on behalf of the Generator. @see Generator .
+ *
+ * @author Eirik Maus
+ * @since 19.0
+ */
+public interface StatefulYieldTarget<S, T> extends YieldTarget<T> {
+
+    /** returns the last element yielded */
+    T previous();
+
+    /**
+     * Set some state that the Generator might want to keep between calls.
+     * @param state
+     */
+    void setState(S state);
+
+    /**
+     * Get the state that was saved using setState(S).
+     */
+    S getState();
+
+}

--- a/guava/src/com/google/common/collect/YieldTarget.java
+++ b/guava/src/com/google/common/collect/YieldTarget.java
@@ -1,0 +1,12 @@
+package com.google.common.collect;
+
+/**
+ * Interface that Generators call to yield new values that can be iterated over (or whatever).
+ * Only used inside the generator to output a value item.
+ *
+ * @author Eirik Maus
+ * @since 19.0
+ */
+public interface YieldTarget<T> {
+    void yield(T element);
+}


### PR DESCRIPTION
I suggest adding (possibly infinite) generators to the Iterators class. The idea is to have an Iterator presenting a possibly infinite sequence of values, generated on the fly a generator function so you don't have to keep all of that in memory at once. 

Two use cases are provided as unit tests: 
a) some kind of endless computation 
b) iterating over possibly infinite input. 
