### PR TITLE
Iterables.get() alternative returning Optional.absent()

### DIFF
--- a/guava-tests/test/com/google/common/collect/IterablesTest.java
+++ b/guava-tests/test/com/google/common/collect/IterablesTest.java
@@ -746,6 +746,23 @@ public class IterablesTest extends TestCase {
     } catch (IndexOutOfBoundsException expected) {}
   }
 
+  private void testOptionalGetOnAbc(Iterable<String> iterable) {
+    try {
+      Iterables.optionalGet(iterable, -1);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {}
+
+    assertEquals("a", Iterables.optionalGet(iterable, 0).get());
+    assertEquals("b", Iterables.optionalGet(iterable, 1).get());
+    assertEquals("c", Iterables.optionalGet(iterable, 2).get());
+
+    assertFalse(Iterables.optionalGet(iterable, Iterables.size(iterable) + 1).isPresent());
+  }
+
+  private void testOptionalGetOnEmpty(Iterable<String> iterable) {
+    assertFalse(Iterables.optionalGet(iterable, 0).isPresent());
+  }
+
   public void testGet_list() {
     testGetOnAbc(newArrayList("a", "b", "c"));
   }
@@ -803,6 +820,73 @@ public class IterablesTest extends TestCase {
     List<String> list = new DiesOnIteratorArrayList();
     list.add("a");
     assertEquals("a", Iterables.get(list, 0, "b"));
+  }
+
+  public void testOptionalGet_list() {
+    testOptionalGetOnAbc(newArrayList("a", "b", "c"));
+  }
+
+  public void testOptionalGet_emptyList() {
+    testOptionalGetOnEmpty(Collections.<String>emptyList());
+  }
+
+  public void testOptionalGet_sortedSet() {
+    testOptionalGetOnAbc(ImmutableSortedSet.of("b", "c", "a"));
+  }
+
+  public void testOptionalGet_emptySortedSet() {
+    testOptionalGetOnEmpty(ImmutableSortedSet.<String>of());
+  }
+
+  public void testOptionalGet_iterable() {
+    testOptionalGetOnAbc(ImmutableSet.of("a", "b", "c"));
+  }
+
+  public void testOptionalGet_emptyIterable() {
+    testOptionalGetOnEmpty(Sets.<String>newHashSet());
+  }
+
+  public void testOptionalGet_nullValue() {
+    assertFalse(Iterables.optionalGet(Lists.newArrayList("a", null, "c"), 1).isPresent());
+  }
+
+  public void testOptionalGet_withDefault_negativePosition() {
+    try {
+      Iterables.optionalGet(newArrayList("a", "b", "c"), -1, "d");
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+      // pass
+    }
+  }
+
+  public void testOptionalGet_withDefault_simple() {
+    ArrayList<String> list = newArrayList("a", "b", "c");
+    assertEquals("b", Iterables.optionalGet(list, 1, "d").get());
+  }
+
+  public void testOptionalGet_withDefault_iterable() {
+    Set<String> set = ImmutableSet.of("a", "b", "c");
+    assertEquals("b", Iterables.optionalGet(set, 1, "d").get());
+  }
+
+  public void testOptionalGet_withDefault_last() {
+    ArrayList<String> list = newArrayList("a", "b", "c");
+    assertEquals("c", Iterables.optionalGet(list, 2, "d").get());
+  }
+
+  public void testOptionalGet_withDefault_lastPlusOne() {
+    ArrayList<String> list = newArrayList("a", "b", "c");
+    assertEquals("d", Iterables.optionalGet(list, 3, "d").get());
+  }
+
+  public void testOptionalGet_withDefault_doesntIterate() {
+    List<String> list = new DiesOnIteratorArrayList();
+    list.add("a");
+    assertEquals("a", Iterables.optionalGet(list, 0, "b").get());
+  }
+
+  public void testOptionalGet_withDefault_nullValue() {
+    assertFalse(Iterables.optionalGet(Lists.newArrayList("a", null, "c"), 1, "d").isPresent());
   }
 
   public void testGetFirst_withDefault_singleton() {

--- a/guava/src/com/google/common/collect/Iterables.java
+++ b/guava/src/com/google/common/collect/Iterables.java
@@ -38,6 +38,7 @@ import java.util.RandomAccess;
 import java.util.Set;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -764,6 +765,39 @@ public final class Iterables {
       Iterators.advance(iterator, position);
       return Iterators.getNext(iterator, defaultValue);
     }
+  }
+
+  /**
+   * Returns an optional {@link Optional} of the element at the specified position in an iterable.
+   *
+   * @param position position of the element to return
+   * @return if the element at the specified position in {@code iterable} is non-null
+   * returns an optional of that element, else returns {@link Optional#absent}.
+   * @throws IndexOutOfBoundsException if {@code position} is negative or
+   *     greater than or equal to the size of {@code iterable}
+   */
+  @Nonnull
+  public static <T> Optional<T> optionalGet(Iterable<T> iterable, int position) {
+    return optionalGet(iterable, position, null);
+  }
+
+  /**
+   * Returns an optional {@link Optional} of the element at the specified position in an iterable or a default
+   * value otherwise.
+   *
+   * @param position position of the element to return
+   * @param defaultValue the default value to return if {@code position} is
+   *     greater than or equal to the size of the iterable
+   * @return an optional the element at the specified position in {@code iterable} or
+   *     {@code defaultValue} if {@code iterable} contains fewer than
+   *     {@code position + 1} elements;
+   *     In any case, if the value is null returns an {@link Optional#absent}.
+   * @throws IndexOutOfBoundsException if {@code position} is negative
+   * @since 4.0
+   */
+  @Nonnull
+  public static <T> Optional<T> optionalGet(Iterable<? extends T> iterable, int position, @Nullable T defaultValue) {
+    return Optional.fromNullable(get(iterable, position, defaultValue));
   }
 
   /**


### PR DESCRIPTION
Hi, decided it will be nice to have an Optional version to the get methods of Iterables.
Also as suggested here https://github.com/google/guava/issues/1742 but with a minor difference:

Both methods will return Optional.absent if the position is grater then the requested index and will also return Optional.absent if the value in the requested index is null.

thoughts ?
