### PR TITLE
Removed unnecessary null check from io.BaseEncoding.encode(bytes)

### DIFF
--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -146,7 +146,7 @@ public abstract class BaseEncoding {
    * Encodes the specified byte array, and returns the encoded {@code String}.
    */
   public String encode(byte[] bytes) {
-    return encode(checkNotNull(bytes), 0, bytes.length);
+    return encode(bytes, 0, bytes.length);
   }
 
   /**


### PR DESCRIPTION
The check is done on line 166, so the first check is redundant.