### PR TITLE
Splitter fails with empty matches at the end of a String

### DIFF
--- a/guava-tests/test/com/google/common/base/SplitterTest.java
+++ b/guava-tests/test/com/google/common/base/SplitterTest.java
@@ -782,4 +782,10 @@ public class SplitterTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
   }
+
+  public void testSplit_emptyMatchAtEndOfString() {
+    assertThat(Splitter.onPattern("(?=\\d)").split("abc82"))
+        .containsExactly("abc", "8", "2")
+        .inOrder();
+  }
 }

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -600,7 +600,7 @@ public final class Splitter {
            * of the next returned substring -- so nextStart stays the same.
            */
           offset++;
-          if (offset >= toSplit.length()) {
+          if (offset > toSplit.length()) {
             offset = -1;
           }
           continue;


### PR DESCRIPTION
If you try to split "abc82" with the pattern "(?=\d)" you get [abc, 8].
The last number will be left out of the result.

http://stackoverflow.com/q/30941743/758280
