### PR TITLE
Added missing @throws tag to ConcurrentHashMultiset.removeExactly

### DIFF
--- a/guava/src/com/google/common/collect/ConcurrentHashMultiset.java
+++ b/guava/src/com/google/common/collect/ConcurrentHashMultiset.java
@@ -319,6 +319,7 @@ public final class ConcurrentHashMultiset<E> extends AbstractMultiset<E> impleme
    * @param element the element to remove
    * @param occurrences the number of occurrences of {@code element} to remove
    * @return {@code true} if the removal was possible (including if {@code occurrences} is zero)
+   * @throws IllegalArgumentException if {@code occurrences} is negative
    */
   public boolean removeExactly(@Nullable Object element, int occurrences) {
     if (occurrences == 0) {


### PR DESCRIPTION
When the method `removeExactly` from the class `ConcurrentHashMultiset` is invoked with a negative number as second parameter, the method correctly throws `IllegalArgumentException`. This behavior is not documented in the javadoc comment of the method, since the `@throws` tag is missing. I added the missing tag.