### PR TITLE
Add missing @throws tags to methods of the class Verify

### DIFF
--- a/guava/src/com/google/common/base/Verify.java
+++ b/guava/src/com/google/common/base/Verify.java
@@ -92,6 +92,8 @@ public final class Verify {
   /**
    * Ensures that {@code expression} is {@code true}, throwing a {@code VerifyException} with no
    * message otherwise.
+   *
+   * @throws VerifyException if {@code expression} is {@code false}
    */
   public static void verify(boolean expression) {
     if (!expression) {
@@ -129,6 +131,7 @@ public final class Verify {
    * message otherwise.
    *
    * @return {@code reference}, guaranteed to be non-null, for convenience
+   * @throws VerifyException if {@code reference} is {@code null}
    */
   public static <T> T verifyNotNull(@Nullable T reference) {
     return verifyNotNull(reference, "expected a non-null reference");
@@ -148,6 +151,7 @@ public final class Verify {
    *     template. Arguments are converted to strings using
    *     {@link String#valueOf(Object)}.
    * @return {@code reference}, guaranteed to be non-null, for convenience
+   * @throws VerifyException if {@code reference} is {@code null}
    */
   public static <T> T verifyNotNull(
       @Nullable T reference,


### PR DESCRIPTION
Some methods of the class `Verify` miss the proper `@throws` tag. To be consistent with the method `Verify.verify(boolean, String, Object...)`, which already contains the proper `@throws` comment, I added the `@throws` tag where missing.