### PR TITLE
Use thread-local buffers to avoid memory allocation and improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,38 @@ concurrency libraries, common annotations, string processing, I/O, and so forth.
 
 Requires JDK 1.6 or higher (as of 12.0).
 
+Latest release
+--------------
+
+The most recent release is [Guava 18.0][], released August 25, 2014.
+
+- [18.0 API Docs][Release API Docs]
+- [18.0 API Diffs from 17.0][Release API Diffs]
+
+To add a dependency on Guava using Maven, use the following:
+
+```xml
+<dependency>
+  <groupId>com.google.guava</groupId>
+  <artifactId>guava</artifactId>
+  <version>18.0</version>
+</dependency>
+```
+
+Snapshots
+---------
+
+Snapshots of Guava built from the `master` branch are available through Maven
+using version `19.0-SNAPSHOT`. API documentation and diffs from version 18.0
+are available here:
+
+- [Snapshot API Docs][]
+- [Snapshot API Diffs from 18.0][Snapshot API Diffs]
+
 Learn about Guava
 ------------------
 
-- Our users' guide, [Guava Explained](https://github.com/google/guava/wiki/Home)
-- Browse [API docs for the most recent release](http://google.github.io/guava/releases/18.0/api/docs/)
-- Browse [API diffs for the most recent release](http://google.github.io/guava/releases/18.0/api/diffs/)
+- Our users' guide, [Guava Explained][]
 - [Presentation slides focusing on base, primitives, and io](http://guava-libraries.googlecode.com/files/Guava_for_Netflix_.pdf)
 - [Presentation slides focusing on cache]( http://guava-libraries.googlecode.com/files/JavaCachingwithGuava.pdf)
 - [Presentation slides focusing on util.concurrent](http://guava-libraries.googlecode.com/files/guava-concurrent-slides.pdf)
@@ -53,3 +79,10 @@ untrusted code.
 5. We unit-test and benchmark the libraries using only OpenJDK 1.7 on
 Linux. Some features, especially in `com.google.common.io`, may not work
 correctly in other environments.
+
+[Guava 18.0]: https://github.com/google/guava/wiki/Release18
+[Release API Docs]: http://google.github.io/guava/releases/18.0/api/docs/
+[Release API Diffs]: http://google.github.io/guava/releases/18.0/api/diffs/
+[Snapshot API Docs]: http://google.github.io/guava/releases/snapshot/api/docs/
+[Snapshot API Diffs]: http://google.github.io/guava/releases/snapshot/api/diffs/
+[Guava Explained]: https://github.com/google/guava/wiki/Home

--- a/guava-gwt/test-super/com/google/common/collect/testing/super/com/google/common/collect/testing/GwtPlatform.java
+++ b/guava-gwt/test-super/com/google/common/collect/testing/super/com/google/common/collect/testing/GwtPlatform.java
@@ -17,7 +17,8 @@
 package com.google.common.collect.testing;
 
 import com.google.gwt.core.client.GwtScriptOnly;
-import com.google.gwt.lang.Array;
+
+import java.util.Arrays;
 
 /**
  * Version of {@link GwtPlatform} used in web-mode.  It includes methods in
@@ -33,6 +34,6 @@ public final class GwtPlatform {
   private GwtPlatform() {}
 
   public static <T> T[] clone(T[] array) {
-    return (T[]) Array.clone(array);
+    return (T[]) Arrays.copyOfRange(array, 0, array.length);
   }
 }

--- a/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapPutIfAbsentTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapPutIfAbsentTester.java
@@ -84,8 +84,7 @@ public class ConcurrentMapPutIfAbsentTester<K, V> extends AbstractMapTester<K, V
   public void testPutIfAbsent_unsupportedPresentDifferentValue() {
     try {
       getMap().putIfAbsent(k0(), v3());
-      fail("putIfAbsent(present, differentValue) should throw");
-    } catch (UnsupportedOperationException expected) {
+    } catch (UnsupportedOperationException tolerated) {
     }
     expectUnchanged();
   }

--- a/guava-tests/benchmark/com/google/common/io/ByteSourceBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteSourceBenchmark.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.caliper.BeforeExperiment;
+import com.google.caliper.Benchmark;
+import com.google.caliper.Param;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Benchmark for {@code ByteSource} performance.
+ */
+public class ByteSourceBenchmark {
+    @Param({"10", "100", "1000", "10000", "100000"})
+    int n;
+
+    private ByteSource byteSource;
+    private ByteSource byteSourceCopy;
+
+    @BeforeExperiment
+    public void setUp() {
+        Random rng = new Random();
+
+        byte[] bytes = new byte[n];
+
+        rng.nextBytes(bytes);
+
+        byteSource = ByteSource.wrap(bytes);
+        byteSourceCopy = ByteSource.wrap(Arrays.copyOf(bytes, bytes.length));
+    }
+
+    @Benchmark
+    public void contentEquals(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            byteSource.contentEquals(byteSourceCopy);
+        }
+    }
+}

--- a/guava-tests/benchmark/com/google/common/io/ByteStreamsBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteStreamsBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2015 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.caliper.BeforeExperiment;
+import com.google.caliper.Benchmark;
+import com.google.caliper.Param;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Benchmark for {@code ByteStreams} performance.
+ */
+public class ByteStreamsBenchmark {
+    @Param({"10", "100", "10000"})
+    int n;
+
+    private byte[] randomData;
+    private ByteArrayInputStream byteArrayInputStream;
+    private ByteArrayOutputStream byteArrayOutputStream;
+
+    @BeforeExperiment
+    public void setUp() {
+        Random rng = new Random();
+        randomData = new byte[n];
+        rng.nextBytes(randomData);
+        byteArrayInputStream = new ByteArrayInputStream(randomData);
+        byteArrayOutputStream = new ByteArrayOutputStream(randomData.length);
+    }
+
+    @Benchmark
+    public void copy(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.copy(byteArrayInputStream, byteArrayOutputStream);
+            byteArrayInputStream.reset();
+            byteArrayOutputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void toByteArray(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.toByteArray(byteArrayInputStream);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void toByteArrayWithExpectedSize(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.toByteArray(byteArrayInputStream, randomData.length);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void skipFully(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.skipFully(byteArrayInputStream, randomData.length);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitOneQuarter(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.25));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitHalf(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.5));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitThreeQuarter(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.75));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void readBytes(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.readBytes(
+                    byteArrayInputStream,
+                    new ByteProcessor<Object>() {
+                        @Override
+                        public boolean processBytes(byte[] buf, int off, int len) throws IOException {
+                            return true;
+                        }
+
+                        @Override
+                        public Object getResult() {
+                            return null;
+                        }
+                    }
+            );
+            byteArrayInputStream.reset();
+        }
+    }
+}

--- a/guava/src/com/google/common/base/Verify.java
+++ b/guava/src/com/google/common/base/Verify.java
@@ -92,6 +92,8 @@ public final class Verify {
   /**
    * Ensures that {@code expression} is {@code true}, throwing a {@code VerifyException} with no
    * message otherwise.
+   *
+   * @throws VerifyException if {@code expression} is {@code false}
    */
   public static void verify(boolean expression) {
     if (!expression) {
@@ -129,6 +131,7 @@ public final class Verify {
    * message otherwise.
    *
    * @return {@code reference}, guaranteed to be non-null, for convenience
+   * @throws VerifyException if {@code reference} is {@code null}
    */
   public static <T> T verifyNotNull(@Nullable T reference) {
     return verifyNotNull(reference, "expected a non-null reference");
@@ -148,6 +151,7 @@ public final class Verify {
    *     template. Arguments are converted to strings using
    *     {@link String#valueOf(Object)}.
    * @return {@code reference}, guaranteed to be non-null, for convenience
+   * @throws VerifyException if {@code reference} is {@code null}
    */
   public static <T> T verifyNotNull(
       @Nullable T reference,

--- a/guava/src/com/google/common/collect/ImmutableEnumSet.java
+++ b/guava/src/com/google/common/collect/ImmutableEnumSet.java
@@ -31,14 +31,15 @@ import java.util.EnumSet;
 @GwtCompatible(serializable = true, emulated = true)
 @SuppressWarnings("serial") // we're overriding default serialization
 final class ImmutableEnumSet<E extends Enum<E>> extends ImmutableSet<E> {
-  static <E extends Enum<E>> ImmutableSet<E> asImmutable(EnumSet<E> set) {
+  @SuppressWarnings("rawtypes") // necessary to compile against Java 8
+  static ImmutableSet asImmutable(EnumSet set) {
     switch (set.size()) {
       case 0:
         return ImmutableSet.of();
       case 1:
         return ImmutableSet.of(Iterables.getOnlyElement(set));
       default:
-        return new ImmutableEnumSet<E>(set);
+        return new ImmutableEnumSet(set);
     }
   }
 

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -305,7 +305,8 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
     }
   }
 
-  private static <E extends Enum<E>> ImmutableSet<E> copyOfEnumSet(EnumSet<E> enumSet) {
+  @SuppressWarnings("rawtypes") // necessary to compile against Java 8
+  private static ImmutableSet copyOfEnumSet(EnumSet enumSet) {
     return ImmutableEnumSet.asImmutable(EnumSet.copyOf(enumSet));
   }
 

--- a/guava/src/com/google/common/eventbus/Subscriber.java
+++ b/guava/src/com/google/common/eventbus/Subscriber.java
@@ -19,6 +19,7 @@ package com.google.common.eventbus;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.j2objc.annotations.Weak;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -47,7 +48,7 @@ class Subscriber {
   }
 
   /** The event bus this subscriber belongs to. */
-  private EventBus bus;
+  @Weak private EventBus bus;
 
   /** Object sporting the subscriber method. */
   @VisibleForTesting

--- a/guava/src/com/google/common/eventbus/SubscriberRegistry.java
+++ b/guava/src/com/google/common/eventbus/SubscriberRegistry.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.j2objc.annotations.Weak;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -67,7 +68,7 @@ final class SubscriberRegistry {
   /**
    * The event bus this registry belongs to.
    */
-  private final EventBus bus;
+  @Weak private final EventBus bus;
 
   SubscriberRegistry(EventBus bus) {
     this.bus = checkNotNull(bus);

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -222,7 +222,7 @@ public abstract class BaseEncoding {
    */
   final byte[] decodeChecked(CharSequence chars) throws DecodingException {
     chars = padding().trimTrailingFrom(chars);
-    byte[] tmp = new byte[maxDecodedSize(chars.length())];
+    byte[] tmp = ThreadLocalBuffers.getByteArray(maxDecodedSize(chars.length()), false);
     int len = decodeTo(tmp, chars);
     return extract(tmp, len);
   }

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -346,17 +347,21 @@ public abstract class ByteSource {
   public boolean contentEquals(ByteSource other) throws IOException {
     checkNotNull(other);
 
-    byte[] buf1 = new byte[BUF_SIZE];
-    byte[] buf2 = new byte[BUF_SIZE];
+    byte[] buffer = ThreadLocalBuffers.getByteArray(0, true);
+
+    int segmentLength = buffer.length / 2;
+
+    ByteBuffer segment1 = ByteBuffer.wrap(buffer, 0, segmentLength);
+    ByteBuffer segment2 = ByteBuffer.wrap(buffer, segmentLength, segmentLength);
 
     Closer closer = Closer.create();
     try {
       InputStream in1 = closer.register(openStream());
       InputStream in2 = closer.register(other.openStream());
       while (true) {
-        int read1 = ByteStreams.read(in1, buf1, 0, BUF_SIZE);
-        int read2 = ByteStreams.read(in2, buf2, 0, BUF_SIZE);
-        if (read1 != read2 || !Arrays.equals(buf1, buf2)) {
+        int read1 = ByteStreams.read(in1, buffer, 0, segmentLength);
+        int read2 = ByteStreams.read(in2, buffer, segmentLength, segmentLength);
+        if (read1 != read2 || !segment1.equals(segment2)) {
           return false;
         } else if (read1 != BUF_SIZE) {
           return true;

--- a/guava/src/com/google/common/io/FastByteArrayOutputStream.java
+++ b/guava/src/com/google/common/io/FastByteArrayOutputStream.java
@@ -1,0 +1,25 @@
+package com.google.common.io;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * A {@see ByteArrayOutputStream} with an additional method {@link FastByteArrayOutputStream#writeTo(byte[], int)}
+ * @since 19.0
+ * @author Chris Povirk
+ * @author Bernd Hopp
+ */
+class FastByteArrayOutputStream
+  extends ByteArrayOutputStream {
+    public FastByteArrayOutputStream(int initByteSize) {
+        super(initByteSize);
+    }
+
+    /**
+     * Writes the contents of the internal buffer to the given array starting
+     * at the given offset. Assumes the array has space to hold count bytes.
+     */
+    void writeTo(byte[] b, int off) {
+      System.arraycopy(buf, 0, b, off, count);
+    }
+}
+

--- a/guava/src/com/google/common/io/ThreadLocalBuffers.java
+++ b/guava/src/com/google/common/io/ThreadLocalBuffers.java
@@ -1,0 +1,126 @@
+package com.google.common.io;
+
+import com.google.common.annotations.Beta;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.ref.SoftReference;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Provides thread-local buffers in the form of either a byte-array of a {@link
+ * FastByteArrayOutputStream}. To circumvent any memory-leak issues, the implementation uses {@link
+ * SoftReference} internally, so the Garbage Collection may collect any memory allocated by this
+ * class that is not referenced outside the class itself at the time. This class is package-local
+ * for it is intended to be used by guava's io-classes, but can maybe eventually be made public.
+ *
+ * @author Bernd Hopp
+ * @since 19.0
+ */
+@Beta
+final class ThreadLocalBuffers {
+
+    private static final int INIT_BYTE_SIZE = 2048;
+
+    private static final ThreadLocal<SoftReference<FastByteArrayOutputStream>> BYTE_ARRAY_OUTPUTSTREAM_SOFTREFERENCE_THREADLOCAL =
+            new ThreadLocal<SoftReference<FastByteArrayOutputStream>>() {
+                @Override
+                protected SoftReference<FastByteArrayOutputStream> initialValue() {
+                    return new SoftReference<FastByteArrayOutputStream>(new FastByteArrayOutputStream(INIT_BYTE_SIZE));
+                }
+            };
+
+    private static final ThreadLocal<SoftReference<byte[]>> BYTE_ARRAY_SOFTREFERENCE_THREADLOCAL =
+            new ThreadLocal<SoftReference<byte[]>>() {
+                @Override
+                protected SoftReference<byte[]> initialValue() {
+                    return new SoftReference<byte[]>(new byte[INIT_BYTE_SIZE]);
+
+                }
+            };
+
+    private ThreadLocalBuffers() {
+    }
+
+    private static <T> T getOrCreateIfObjectWasCollected(ThreadLocal<SoftReference<T>> softReferenceThreadLocal) {
+        /**since it cannot be predicted when GC will collect the T value from the SoftReference,
+         * this loop will try as long as it takes to get a hard reference. If the softReference points to an already
+         * gc'ed T, remove() is called on the threadlocal to force it to create a new soft-referenced T in the next iteration.
+         */
+        while (true) {
+            SoftReference<T> softReference = softReferenceThreadLocal.get();
+
+            T value = softReference.get();
+
+            if (value != null) {
+                return value;
+            }
+
+            softReferenceThreadLocal.remove();
+        }
+    }
+
+    /**
+     * Returns a thread-local byte-array of arbitrary data, that can be used for buffering. It is
+     * guaranteed that the byte-array's length is a power of 2 greater than or equal 2048. If the
+     * array must have a minimum size larger than 2048 or should not contain arbitrary data but just
+     * zeros, see {@link ThreadLocalBuffers#getByteArray(int, boolean)}. Note that calls to this
+     * method from the same thread will return the same byte-array.
+     *
+     * @return a byte-array for buffering.
+     * @since 19.0
+     */
+    public static byte[] getByteArray() {
+        return getByteArray(0, false);
+    }
+
+    /**
+     * Returns a thread-local byte-array that can be used for buffering. It is guaranteed that the
+     * byte-array's length is a power of 2 greater than or equal minSize.
+     *
+     * @param minSize the minimum size ot the returned byte-array, must not be negative.
+     * @param zeroed  set to true if the byte-array should contain just zeros
+     * @return a byte-array for buffering
+     * @since 19.0
+     */
+    public static byte[] getByteArray(int minSize, boolean zeroed) {
+        checkArgument(minSize >= 0, "minSize must not be negative");
+
+        byte[] byteArray = getOrCreateIfObjectWasCollected(BYTE_ARRAY_SOFTREFERENCE_THREADLOCAL);
+
+        if ( byteArray.length < minSize ) {
+
+            int newLenght = byteArray.length;
+
+            do {
+                newLenght *= 2;
+            } while ( newLenght < minSize );
+
+            byteArray = new byte[newLenght];
+            BYTE_ARRAY_SOFTREFERENCE_THREADLOCAL.set(new SoftReference<byte[]>(byteArray));
+        } else if ( zeroed ) {
+            Arrays.fill(byteArray, (byte) 0);
+        }
+
+        return byteArray;
+    }
+
+    /**
+     * Returns a {@link FastByteArrayOutputStream}. It is guaranteed that the ByteArrayOutputStream will
+     * not be accessed outside the current thread. Note that calls to this method from the same
+     * thread will return the same ByteArrayOutputStream.
+     *
+     * @return a {@link FastByteArrayOutputStream} for buffering and stream-capturing.
+     * @since 19.0
+     */
+    public static FastByteArrayOutputStream getByteArrayOutputStream() {
+        FastByteArrayOutputStream byteArrayOutputStream = getOrCreateIfObjectWasCollected(
+            BYTE_ARRAY_OUTPUTSTREAM_SOFTREFERENCE_THREADLOCAL
+        );
+
+        byteArrayOutputStream.reset();
+
+        return byteArrayOutputStream;
+    }
+}


### PR DESCRIPTION
# Abstract

goal of this PR is to replace the often seen but unneccessary 
```
byte[] buf = new byte[BUF_SIZE];
```
or 
```
ByteArrayOutputStream baos = new ByteArrayOutputStream();

```
 with thread-local instances of the respective types in all cases where they are used method-internal, this way avoiding unneccessary memory allocation, increasing performance and enhancing the memory profile. 

# Implementation

[ThreadLocalBuffers](https://github.com/berndhopp/guava/blob/master/guava/src/com/google/common/io/ThreadLocalBuffers.java) is the manager of thread-local buffers. It uses [SoftReferences](https://docs.oracle.com/javase/6/docs/api/java/lang/ref/SoftReference.html) to store buffers, this way enabling Garbage Collection to collect the buffers when the system runs low on memory. This class is package-local right now but can eventually be made public for other scenarios where a buffer is needed.
All allocations of byte[] or ByteArrayOutputStream where the allocated byte[]/BAOS was not the returned value of the method have been replaced with calls to ThreadLocalBuffers. 

ByteSource.contentEquals was challenging, because it used not one but two byte-arrays for buffering, so I used two ByteBuffers that wrap around the upper and lower part of the thread-local buffer, thereby mimicking the two buffers.

# Results

The microbenchmarks show that avoiding buffer allocation yields a significant performance boost. 

|tested method|bytes copied|runtime w/ TL buffers|runtime w/out TL buffers|performance increase in %|
|------------------|-----------------|---------------------------|--------------------------------|-----------------------------------|
|ByteStreams.copy|10|105569|681130|645,2|
|ByteStreams.copy|100|107411|698152|649,98|
|ByteStreams.copy|10000|840354|1186307|141,17|
|ByteStreams.readBytes|10|68917|633365|919,03|
|ByteStreams.readBytes|100|69802|660336|946,01|
|ByteStreams.readBytes|10000|360357|934588|259,35|
|ByteStreams.toByteArray|10|122681|750095|611,42|
|ByteStreams.toByteArray|100|131705|773561|587,34|
|ByteStreams.toByteArray|10000|1962961|4962929|252,83|
|ByteSource.contentEquals|10|647249|3614650|558,46|
|ByteSource.contentEquals|100|685559|3586983|523,22|
|ByteSource.contentEquals|10000|696307|9460941|1358,73|

you can find the results here:

[ByteStreamsBenchmark w/ ThreadLocal](https://microbenchmarks.appspot.com/runs/087a68fc-af92-4971-97ae-346be17ee50b)
[ByteStreamsBenchmark w/out ThreadLocal](https://microbenchmarks.appspot.com/runs/dfb1c1b7-b9e2-431c-91f9-3be2f19db2a7)
[ByteSourceBenchmark w ThreadLocal](https://microbenchmarks.appspot.com/runs/f5517421-8f23-4237-9de1-f7d9e4c8f3ce)
[ByteSourceBenchmark w/out ThreadLocal](https://microbenchmarks.appspot.com/runs/573ac1ff-a1e9-4870-9b0d-414e77e163e6)