### PR TITLE
Improve FluentIterable.of to take variable # of arguments.

### DIFF
--- a/guava/src/com/google/common/collect/FluentIterable.java
+++ b/guava/src/com/google/common/collect/FluentIterable.java
@@ -165,7 +165,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
    */
   @Beta
   @CheckReturnValue
-  public static <E> FluentIterable<E> of(E[] elements) {
+  public static <E> FluentIterable<E> of(E... elements) {
     return from(Lists.newArrayList(elements));
   }
 


### PR DESCRIPTION
`FluentIterable.of(1, 2, 3)` would be easier to use/more succinct than `FluentIterable.of(new int[]{1, 2, 3})`

This change does not break the existing API as E... becomes E[] by the time it is used in the method.