### PR TITLE
Added a vararg overload for firstNonNull

### DIFF
--- a/guava-gwt/test-super/com/google/common/base/super/com/google/common/base/MoreObjectsTest.java
+++ b/guava-gwt/test-super/com/google/common/base/super/com/google/common/base/MoreObjectsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2006 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.base;
+
+import com.google.common.annotations.*;
+import junit.framework.*;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+/**
+ * Tests for {@link MoreObjects}.
+ */
+@GwtCompatible(emulated = true)
+public class MoreObjectsTest extends TestCase {
+  public void testFirstNonNull_withNonNull() throws Exception {
+    String s1 = "foo";
+    String s2 = firstNonNull(s1, "bar");
+    assertSame(s1, s2);
+
+    Long n1 = (long) 42;
+    Long n2 = firstNonNull(null, n1);
+    assertSame(n1, n2);
+  }
+
+  public void testFirstNonNull_throwsNullPointerException() throws Exception {
+    try {
+      firstNonNull(null, null);
+      fail("expected NullPointerException");
+    } catch (NullPointerException ignored) {
+    }
+  }
+
+  public void testFirstNonNull_varArg() throws Exception {
+    Integer input1 = 1;
+    assertEquals(input1, firstNonNull(input1, null, null));
+
+    Character input2 = '2';
+    assertEquals(input2, firstNonNull(null, input2, null));
+
+    Double input3 = 3.0;
+    assertEquals(input3, firstNonNull(null, null, input3, null)); // the whole vararg is null
+
+    Long input4 = 4L;
+    assertEquals(input4, firstNonNull(null, null, input4, (Long) null)); // vararg contains a single null
+
+    String input5 = "5";
+    assertEquals(input5, firstNonNull(null, null, null, null, input5, null)); // find in vararg
+
+    try {
+      firstNonNull(null, null, null, null); // the whole vararg is null
+      fail("expected NullPointerException");
+    } catch (NullPointerException ignored) {
+    }
+
+    try {
+      firstNonNull(null, null, null, null, null); // vararg contains only nulls
+      fail("expected NullPointerException");
+    } catch (NullPointerException ignored) {
+    }
+  }
+}

--- a/guava/src/com/google/common/base/MoreObjects.java
+++ b/guava/src/com/google/common/base/MoreObjects.java
@@ -16,14 +16,12 @@
 
 package com.google.common.base;
 
+import com.google.common.annotations.*;
+
+import javax.annotation.*;
+import java.util.*;
+
 import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.annotations.GwtCompatible;
-
-import java.util.Arrays;
-
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 
 /**
  * Helper functions that operate on any {@code Object}, and are not already provided in
@@ -39,21 +37,37 @@ import javax.annotation.Nullable;
 @GwtCompatible
 public final class MoreObjects {
   /**
-   * Returns the first of two given parameters that is not {@code null}, if either is, or otherwise
-   * throws a {@link NullPointerException}.
+   * Returns the first of the given parameters that is not {@code null}.
+   * If all are null, throws a {@link NullPointerException}.
    *
    * <p><b>Note:</b> if {@code first} is represented as an {@link Optional}, this can be
    * accomplished with {@link Optional#or(Object) first.or(second)}. That approach also allows for
    * lazy evaluation of the fallback instance, using {@link Optional#or(Supplier)
    * first.or(supplier)}.
    *
-   * @return {@code first} if it is non-null; otherwise {@code second} if it is non-null
-   * @throws NullPointerException if both {@code first} and {@code second} are null
+   * @return the first non-null parameter
+   * @throws NullPointerException if all parameters are null
    * @since 18.0 (since 3.0 as {@code Objects.firstNonNull()}).
    */
   @CheckReturnValue
   public static <T> T firstNonNull(@Nullable T first, @Nullable T second) {
-    return first != null ? first : checkNotNull(second);
+    return (first != null) ? first
+                           : checkNotNull(second);
+  }
+
+  /**
+   * @see MoreObjects#firstNonNull(Object, Object)
+   */
+  @CheckReturnValue
+  public static <T> T firstNonNull(@Nullable T first, @Nullable T second, @Nullable T third, @Nullable T... rest) {
+    if (first != null) return first;
+    else if (second != null) return second;
+    else if (third != null) return third;
+
+    for (T t : checkNotNull(rest))
+      if (t != null) return t;
+
+    throw new NullPointerException();
   }
 
   /**


### PR DESCRIPTION
Avoiding nullability in Java is a recurring problem.

Other languages offer an `Optional`, which makes nullability composable.
This however is very verbose in Java and cannot consistently be inserted into an existing, nullable codebase (especially since the `Optional` can be null also).

Guava tries to simplify some of the common cases, e.g. we have a value, but if it's not set, we want a default (but the same can be true for the default).
Unfortunately this method wasn't called `defaultIfNull`, but `firstNonNull`, therefore people assumed it's a search.

This commit tries to solve that by _making_ it a search, and letting the users decide which approach they want:
ternary,

``` Java
(first != null) ? first : ((second != null) ? second : checkNotNull(third));
```

Find,

``` Java
Iterables.find(asList(first, second, third), Predicates.notNull());
```

Optional,

``` Java
Optional.fromNullable(first).or(second).or(third).get();
```

or the same approach Guava already provided:

``` Java
firstNonNull(first, second, third);
```
