### PR TITLE
ImmutableMap.copyOf(Map): minor performance improvement

### DIFF
--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableMap.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableMap.java
@@ -183,10 +183,12 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
 
   public static <K, V> ImmutableMap<K, V> copyOf(
       Map<? extends K, ? extends V> map) {
-    if ((map instanceof ImmutableMap) && !(map instanceof ImmutableSortedMap)) {
-      @SuppressWarnings("unchecked") // safe since map is not writable
-      ImmutableMap<K, V> kvMap = (ImmutableMap<K, V>) map;
-      return kvMap;
+    if (map instanceof ImmutableMap) {
+      if (!(map instanceof ImmutableSortedMap)) {
+        @SuppressWarnings("unchecked") // safe since map is not writable
+        ImmutableMap<K, V> kvMap = (ImmutableMap<K, V>) map;
+        return kvMap;
+      }
     } else if (map instanceof EnumMap) {
       EnumMap<?, ?> enumMap = (EnumMap<?, ?>) map;
       for (Map.Entry<?, ?> entry : enumMap.entrySet()) {

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -310,14 +310,16 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    * @throws NullPointerException if any key or value in {@code map} is null
    */
   public static <K, V> ImmutableMap<K, V> copyOf(Map<? extends K, ? extends V> map) {
-    if ((map instanceof ImmutableMap) && !(map instanceof ImmutableSortedMap)) {
-      // TODO(lowasser): Make ImmutableMap.copyOf(immutableBiMap) call copyOf()
-      // on the ImmutableMap delegate(), rather than the bimap itself
-
-      @SuppressWarnings("unchecked") // safe since map is not writable
-      ImmutableMap<K, V> kvMap = (ImmutableMap<K, V>) map;
-      if (!kvMap.isPartialView()) {
-        return kvMap;
+    if (map instanceof ImmutableMap) {
+      if (!(map instanceof ImmutableSortedMap)) {
+        // TODO(lowasser): Make ImmutableMap.copyOf(immutableBiMap) call copyOf()
+        // on the ImmutableMap delegate(), rather than the bimap itself
+  
+        @SuppressWarnings("unchecked") // safe since map is not writable
+        ImmutableMap<K, V> kvMap = (ImmutableMap<K, V>) map;
+        if (!kvMap.isPartialView()) {
+          return kvMap;
+        }
       }
     } else if (map instanceof EnumMap) {
       @SuppressWarnings("unchecked") // safe since map is not writable


### PR DESCRIPTION
Minor performance improvement in `ImmutableMap.copyOf(Map)`:

If `map instanceof ImmutableSortedMap`, no longer unnecessarily run the following, since it will always be `false`:

```
else if (map instanceof EnumMap)
```
