### PR TITLE
allow inheriting from SettableFuture and overriding cancel() method

### DIFF
--- a/guava/src/com/google/common/util/concurrent/SettableFuture.java
+++ b/guava/src/com/google/common/util/concurrent/SettableFuture.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  * @since 9.0 (in 1.0 as {@code ValueFuture})
  */
 @GwtCompatible
-public final class SettableFuture<V> extends AbstractFuture.TrustedFuture<V> {
+public class SettableFuture<V> extends AbstractFuture.TrustedFuture<V> {
 
   /**
    * Creates a new {@code SettableFuture} in the default state.
@@ -43,7 +43,7 @@ public final class SettableFuture<V> extends AbstractFuture.TrustedFuture<V> {
    * Explicit private constructor, use the {@link #create} factory method to
    * create instances of {@code SettableFuture}.
    */
-  private SettableFuture() {}
+  protected SettableFuture() {}
 
   @Override public boolean set(@Nullable V value) {
     return super.set(value);


### PR DESCRIPTION
I'd like to be able to implement custom ListenableFuture class where I could easily override cancel(boolean) method. The SettableFuture seems to be best fit but unfortunately it's declared final. Removing this restriction makes it much more reusable.
