### PR TITLE
Separate java tokens by a single space

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/google/SetMultimapTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/SetMultimapTestSuiteBuilder.java
@@ -92,7 +92,7 @@ public class SetMultimapTestSuiteBuilder<K, V>
 
   @Override
   TestSuite computeEntriesTestSuite(
-      FeatureSpecificTestSuiteBuilder<?, ?  extends
+      FeatureSpecificTestSuiteBuilder<?, ? extends
           OneSizeTestContainerGenerator<SetMultimap<K, V>, Map.Entry<K, V>>> parentBuilder) {
     return SetTestSuiteBuilder.using(
         new EntriesGenerator<K, V>(parentBuilder.getSubjectGenerator()))

--- a/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
+++ b/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
@@ -119,7 +119,7 @@ public final class ForwardingWrapperTester {
   }
 
   private static <T> void testSuccessfulForwarding(
-      Class<T> interfaceType,  Method method, Function<? super T, ? extends T> wrapperFunction) {
+      Class<T> interfaceType, Method method, Function<? super T, ? extends T> wrapperFunction) {
     new InteractionTester<T>(interfaceType, method).testInteraction(wrapperFunction);
   }
 

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -91,7 +91,7 @@ public class TestLogHandlerTest extends TestCase {
         = Logger.getLogger(ExampleClassUnderTest.class.getName());
 
     static void foo() {
-      logger.log(Level.INFO,  "message", EXCEPTION);
+      logger.log(Level.INFO, "message", EXCEPTION);
     }
   }
 }

--- a/guava-tests/test/com/google/common/collect/FilteredCollectionsTest.java
+++ b/guava-tests/test/com/google/common/collect/FilteredCollectionsTest.java
@@ -93,7 +93,7 @@ public class FilteredCollectionsTest extends TestCase {
 
     public void testReadsThroughAdd() {
       for (List<Integer> contents : SAMPLE_INPUTS) {
-        C unfiltered  = createUnfiltered(contents);
+        C unfiltered = createUnfiltered(contents);
         C filterThenAdd = filter(unfiltered, EVEN);
         unfiltered.add(4);
 

--- a/guava-tests/test/com/google/common/escape/UnicodeEscaperTest.java
+++ b/guava-tests/test/com/google/common/escape/UnicodeEscaperTest.java
@@ -35,7 +35,7 @@ public class UnicodeEscaperTest extends TestCase {
 
   private static final String TEST_STRING =
       "\0abyz\u0080\u0100\u0800\u1000ABYZ\uffff" +
-      SMALLEST_SURROGATE + "0189" +  LARGEST_SURROGATE;
+      SMALLEST_SURROGATE + "0189" + LARGEST_SURROGATE;
 
   // Escapes nothing
   private static final UnicodeEscaper NOP_ESCAPER = new UnicodeEscaper() {

--- a/guava-tests/test/com/google/common/hash/AbstractStreamingHasherTest.java
+++ b/guava-tests/test/com/google/common/hash/AbstractStreamingHasherTest.java
@@ -82,7 +82,7 @@ public class AbstractStreamingHasherTest extends TestCase {
     sink.putChar((char) 0x0201);
     sink.hash();
     sink.assertInvariants(2);
-    sink.assertBytes(new byte[] { 1, 2, 0, 0  }); // padded with zeros
+    sink.assertBytes(new byte[] { 1, 2, 0, 0 }); // padded with zeros
   }
 
   public void testString() {

--- a/guava-tests/test/com/google/common/primitives/FloatsTest.java
+++ b/guava-tests/test/com/google/common/primitives/FloatsTest.java
@@ -53,7 +53,7 @@ public class FloatsTest extends TestCase {
 
   private static final float[] NUMBERS = new float[] {
       LEAST, -Float.MAX_VALUE, -1f, -0f, 0f, 1f, Float.MAX_VALUE, GREATEST,
-      Float.MIN_NORMAL, -Float.MIN_NORMAL,  Float.MIN_VALUE, -Float.MIN_VALUE,
+      Float.MIN_NORMAL, -Float.MIN_NORMAL, Float.MIN_VALUE, -Float.MIN_VALUE,
       Integer.MIN_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE, Long.MAX_VALUE
   };
 

--- a/guava-tests/test/com/google/common/reflect/ClassPathTest.java
+++ b/guava-tests/test/com/google/common/reflect/ClassPathTest.java
@@ -92,7 +92,7 @@ public class ClassPathTest extends TestCase {
     URLClassLoader parent = new URLClassLoader(new URL[] {url1}, null);
     URLClassLoader child = new URLClassLoader(new URL[] {url2}, parent) {};
     ImmutableMap<File, ClassLoader> classPathEntries = ClassPath.Scanner.getClassPathEntries(child);
-    assertEquals(ImmutableMap.of(new File("/a"), parent, new File("/b"), child),  classPathEntries);
+    assertEquals(ImmutableMap.of(new File("/a"), parent, new File("/b"), child), classPathEntries);
     assertThat(classPathEntries.keySet()).containsExactly(new File("/a"), new File("/b")).inOrder();
   }
 

--- a/guava-tests/test/com/google/common/util/concurrent/ExecutionListTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ExecutionListTest.java
@@ -101,7 +101,7 @@ public class ExecutionListTest extends TestCase {
 
     // If it passed, then verify an Add will be executed without calling run
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    list.add(new MockRunnable(countDownLatch),  Executors.newCachedThreadPool());
+    list.add(new MockRunnable(countDownLatch), Executors.newCachedThreadPool());
     assertTrue(countDownLatch.await(1L, TimeUnit.SECONDS));
   }
 

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -166,7 +166,7 @@ public final class ClassPath {
       }
     }
 
-    ResourceInfo(String resourceName,  ClassLoader loader) {
+    ResourceInfo(String resourceName, ClassLoader loader) {
       this.resourceName = checkNotNull(resourceName);
       this.loader = checkNotNull(loader);
     }

--- a/guava/src/com/google/common/reflect/Invokable.java
+++ b/guava/src/com/google/common/reflect/Invokable.java
@@ -218,7 +218,7 @@ public abstract class Invokable<T, R> extends Element implements GenericDeclarat
     }
 
     @Override public final boolean isOverridable() {
-      return  !(isFinal() || isPrivate() || isStatic()
+      return !(isFinal() || isPrivate() || isStatic()
           || Modifier.isFinal(getDeclaringClass().getModifiers()));
     }
 

--- a/guava/src/com/google/common/reflect/TypeToInstanceMap.java
+++ b/guava/src/com/google/common/reflect/TypeToInstanceMap.java
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
  * @since 13.0
  */
 @Beta
-public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B>  {
+public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
 
   /**
    * Returns the value the specified class is mapped to, or {@code null} if no


### PR DESCRIPTION
Replacing multiple spaces and tabs, which separates java tokens, by a
single space, excluding horizontal aligned tokens.