### PR TITLE
ImmutableSortedSet.copyOf should fail if input is not Comparable

### DIFF
--- a/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -665,6 +665,22 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     assertSame(STRING_LENGTH, set.comparator());
   }
 
+  public void testCopyOf_immutableSingletonSetNotComparable_throwsClassCastException() {
+    try {
+      ImmutableSortedSet.copyOf(ImmutableSet.of(new Object()));
+      fail("Should complain that the element isn't Comparable");
+    } catch (ClassCastException expected) {
+    }
+  }
+
+  public void testCopyOf_immutableSetNotComparable_throwsClassCastException() {
+    try {
+        ImmutableSortedSet.copyOf(ImmutableSet.of(new Object(), new Object()));
+        fail("Should complain that the element isn't Comparable");
+    } catch (ClassCastException expected) {
+    }
+  }
+
   public void testEquals_bothDefaultOrdering() {
     SortedSet<String> set = of("a", "b", "c");
     assertEquals(set, Sets.newTreeSet(asList("a", "b", "c")));

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -367,6 +367,9 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSortedSetFauxveride
       return emptySet(comparator);
     }
     checkElementsNotNull(contents, n);
+    if (n == 1) {
+      comparator.compare(contents[0],contents[0]);
+    }
     Arrays.sort(contents, 0, n, comparator);
     int uniques = 1;
     for (int i = 1; i < n; i++) {


### PR DESCRIPTION
ImmutableSortedSet.copyOf(Collection) should fail if the input collection is not comparable.
This currently applies for most collections, but fails if the input is a singleton.
This is recorded in issue #1835.

I have noted that this is caught within TreeSet by invoking the comparator on the singleton item, so this change makes a similar call to catch the un-comparable items in a singleton ImmutableSortedSet.

I have added tests for a two-element input collection (which was already caught), and a new test for a single-element input; this latter test only passes once the code change has been inserted.
