### PR TITLE
Update documentation to clarify that empty immutable collections may be singletons

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -35,6 +35,11 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
 
   /**
    * Returns the empty bimap.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link BiMap}
+   * object for each call.
+   * </p>
    */
   // Casting to any type is safe because the set will never hold any elements.
   @SuppressWarnings("unchecked")

--- a/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
@@ -41,6 +41,11 @@ public final class ImmutableClassToInstanceMap<B> extends ForwardingMap<Class<? 
   /**
    * Returns an empty {@code ImmutableClassToInstanceMap}.
    *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link ClassToInstanceMap}
+   * object for each call.
+   * </p>
+   *
    * @since 19.0
    */
   @SuppressWarnings("unchecked")

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -57,6 +57,11 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    * Returns the empty immutable list. This set behaves and performs comparably
    * to {@link Collections#emptyList}, and is preferable mainly for consistency
    * and maintainability of your code.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link List}
+   * object for each call.
+   * </p>
    */
   // Casting to any type is safe because the list will never hold any elements.
   @SuppressWarnings("unchecked")

--- a/guava/src/com/google/common/collect/ImmutableListMultimap.java
+++ b/guava/src/com/google/common/collect/ImmutableListMultimap.java
@@ -45,7 +45,13 @@ import javax.annotation.Nullable;
 public class ImmutableListMultimap<K, V> extends ImmutableMultimap<K, V>
     implements ListMultimap<K, V> {
 
-  /** Returns the empty multimap. */
+  /** Returns the empty multimap.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link ListMultimap}
+   * object for each call.
+   * </p>
+   * */
   // Casting is safe because the multimap will never hold any elements.
   @SuppressWarnings("unchecked")
   public static <K, V> ImmutableListMultimap<K, V> of() {

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -55,6 +55,11 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    * Returns the empty map. This map behaves and performs comparably to
    * {@link Collections#emptyMap}, and is preferable mainly for consistency
    * and maintainability of your code.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link Map}
+   * object for each call.
+   * </p>
    */
   public static <K, V> ImmutableMap<K, V> of() {
     return ImmutableBiMap.of();

--- a/guava/src/com/google/common/collect/ImmutableMultimap.java
+++ b/guava/src/com/google/common/collect/ImmutableMultimap.java
@@ -68,7 +68,13 @@ import javax.annotation.Nullable;
 public abstract class ImmutableMultimap<K, V> extends AbstractMultimap<K, V>
     implements Serializable {
 
-  /** Returns an empty multimap. */
+  /** Returns an empty multimap.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link Multimap}
+   * object for each call.
+   * </p>
+   * */
   public static <K, V> ImmutableMultimap<K, V> of() {
     return ImmutableListMultimap.of();
   }

--- a/guava/src/com/google/common/collect/ImmutableMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableMultiset.java
@@ -53,6 +53,11 @@ import javax.annotation.Nullable;
 public abstract class ImmutableMultiset<E> extends ImmutableCollection<E> implements Multiset<E> {
   /**
    * Returns the empty immutable multiset.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link Multiset}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked") // all supported methods are covariant
   public static <E> ImmutableMultiset<E> of() {

--- a/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -47,6 +47,11 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
 
   /**
    * Returns an empty immutable range map.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link RangeMap}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked")
   public static <K extends Comparable<?>, V> ImmutableRangeMap<K, V> of() {

--- a/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -52,6 +52,11 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
   /**
    * Returns an empty immutable range set.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link RangeSet}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked")
   public static <C extends Comparable> ImmutableRangeSet<C> of() {
@@ -60,6 +65,11 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
   /**
    * Returns an immutable range set containing the single range {@link Range#all()}.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link RangeSet}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked")
   static <C extends Comparable> ImmutableRangeSet<C> all() {

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -45,6 +45,11 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
   /**
    * Returns the empty immutable set. Preferred over {@link Collections#emptySet} for code
    * consistency, and because the return type conveys the immutability guarantee.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link Set}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings({"unchecked"}) // fully variant implementation (never actually produces any Es)
   public static <E> ImmutableSet<E> of() {

--- a/guava/src/com/google/common/collect/ImmutableSetMultimap.java
+++ b/guava/src/com/google/common/collect/ImmutableSetMultimap.java
@@ -52,7 +52,13 @@ import javax.annotation.Nullable;
 public class ImmutableSetMultimap<K, V> extends ImmutableMultimap<K, V>
     implements SetMultimap<K, V> {
 
-  /** Returns the empty multimap. */
+  /** Returns the empty multimap.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link SetMultimap}
+   * object for each call.
+   * </p>
+   * */
   // Casting is safe because the multimap will never hold any elements.
   @SuppressWarnings("unchecked")
   public static <K, V> ImmutableSetMultimap<K, V> of() {

--- a/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -78,6 +78,11 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
 
   /**
    * Returns the empty sorted map.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link SortedMap}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked")
   // unsafe, comparator() returns a comparator on the specified type

--- a/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -53,6 +53,11 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableSortedMultiset
 
   /**
    * Returns the empty immutable sorted multiset.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link SortedMultiSet}
+   * object for each call.
+   * </p>
    */
   @SuppressWarnings("unchecked")
   public static <E> ImmutableSortedMultiset<E> of() {

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -68,6 +68,11 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSortedSetFauxveride
 
   /**
    * Returns the empty immutable sorted set.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link SortedSet}
+   * object for each call.
+   * </p>
    */
   public static <E> ImmutableSortedSet<E> of() {
     return (ImmutableSortedSet<E>) RegularImmutableSortedSet.NATURAL_EMPTY_SET;

--- a/guava/src/com/google/common/collect/ImmutableTable.java
+++ b/guava/src/com/google/common/collect/ImmutableTable.java
@@ -42,7 +42,13 @@ import javax.annotation.Nullable;
 @GwtCompatible
 // TODO(gak): make serializable
 public abstract class ImmutableTable<R, C, V> extends AbstractTable<R, C, V> {
-  /** Returns an empty immutable table. */
+  /** Returns an empty immutable table.
+   *
+   * <p><b>Performance note:</b>
+   * Implementations of this method need not create a separate {@link Table}
+   * object for each call.
+   * </p>
+   * */
   @SuppressWarnings("unchecked")
   public static <R, C, V> ImmutableTable<R, C, V> of() {
     return (ImmutableTable<R, C, V>) SparseImmutableTable.EMPTY;


### PR DESCRIPTION
This updates the documentation (no functional changes), to clarify that empty immutable collections may be singletons, as raised in a bug: https://github.com/google/guava/issues/2083
