### PR TITLE
modify testCheckArgument_simpleMessage_failure to clean code

### DIFF
--- a/guava-tests/test/com/google/common/base/PreconditionsTest.java
+++ b/guava-tests/test/com/google/common/base/PreconditionsTest.java
@@ -54,7 +54,6 @@ public class PreconditionsTest extends TestCase {
       Preconditions.checkArgument(false, new Message());
       fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
-      //verifySimpleMessage(expected);
       assertThat(expected).hasMessage("A message");
     }
   }

--- a/guava-tests/test/com/google/common/base/PreconditionsTest.java
+++ b/guava-tests/test/com/google/common/base/PreconditionsTest.java
@@ -54,7 +54,8 @@ public class PreconditionsTest extends TestCase {
       Preconditions.checkArgument(false, new Message());
       fail("no exception thrown");
     } catch (IllegalArgumentException expected) {
-      verifySimpleMessage(expected);
+      //verifySimpleMessage(expected);
+      assertThat(expected).hasMessage("A message");
     }
   }
 


### PR DESCRIPTION
verifySimpleMessage(expected)  change to assertThat(expected).hasMessage("A message"), 

so that the  compared target("A message") can be saw straightway
