### PR TITLE
Add Splitter methods to return CharSequence types.

### DIFF
--- a/guava-tests/test/com/google/common/base/SplitterTest.java
+++ b/guava-tests/test/com/google/common/base/SplitterTest.java
@@ -66,6 +66,12 @@ public class SplitterTest extends TestCase {
     assertThat(letters).containsExactly("a", "b", "c").inOrder();
   }
 
+  public void testCharacterSimpleSplitToCharSequenceList() {
+    String simple = "a,b,c";
+    List<CharSequence> letters = COMMA_SPLITTER.splitToCharSequenceList(simple);
+    assertThat(letters).containsExactly("a", "b", "c").inOrder();
+  }
+
   public void testToString() {
     assertEquals("[]", Splitter.on(',').split("").toString());
     assertEquals("[a, b, c]", Splitter.on(',').split("a,b,c").toString());
@@ -710,6 +716,19 @@ public class SplitterTest extends TestCase {
         .split("boy:tom,girl:tina,cat:kitty,dog:tommy");
     ImmutableMap<String, String> expected =
         ImmutableMap.of("boy", "tom", "girl", "tina", "cat", "kitty", "dog", "tommy");
+
+    assertThat(m).isEqualTo(expected);
+    assertThat(m.entrySet()).containsExactlyElementsIn(expected.entrySet()).inOrder();
+  }
+
+  public void testMapSplitter_ToCharacterSequence() {
+    // try different delimiters.
+    Map<CharSequence, CharSequence> m = Splitter
+            .on(",")
+            .withKeyValueSeparator(':')
+            .splitToCharSequence("boy:tom,girl:tina,cat:kitty,dog:tommy");
+    ImmutableMap<String, String> expected =
+            ImmutableMap.of("boy", "tom", "girl", "tina", "cat", "kitty", "dog", "tommy");
 
     assertThat(m).isEqualTo(expected);
     assertThat(m.entrySet()).containsExactlyElementsIn(expected.entrySet()).inOrder();


### PR DESCRIPTION
Not sure if this has been discussed previously but it is trivial to add methods that return CharSequence types to the Splitter API and maintain the existing API. We have some use cases for this feature where we do not want to create temporary char[] array copies of the intermediate substrings.

The Splitter API accepts CharSequence types as input and internally manipulates CharSequence types. This patch maintains the existing methods that return String types and adds additional methods that
return CharSequence types. The performance overhead on the existing methods that return String type is one additional call to Iterators#transform() that calls toString() on the CharSequence results. Note the #toString() call was already present in the existing implementation.
