### PR TITLE
Reuse the mac instance just constructed for bit-length calculation

### DIFF
--- a/guava/src/com/google/common/hash/MacHashFunction.java
+++ b/guava/src/com/google/common/hash/MacHashFunction.java
@@ -39,7 +39,7 @@ final class MacHashFunction extends AbstractStreamingHashFunction {
     this.prototype = getMac(algorithmName, key);
     this.key = checkNotNull(key);
     this.toString = checkNotNull(toString);
-    this.bits = getMac(algorithmName, key).getMacLength() * Byte.SIZE;
+    this.bits = prototype.getMacLength() * Byte.SIZE;
     this.supportsClone = supportsClone(prototype);
   }
 


### PR DESCRIPTION
No use in constructing a fresh copy of the Mac just to get the bit-length.