### PR TITLE
add RateLimiter acquire with double permits

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -97,7 +97,17 @@ public class RateLimiterTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
     try {
+      limiter.acquire(0.);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
       limiter.acquire(-1);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      limiter.acquire(-1.);
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -107,7 +117,17 @@ public class RateLimiterTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
     try {
+      limiter.tryAcquire(0.);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
       limiter.tryAcquire(-1);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      limiter.tryAcquire(-1.);
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -117,7 +137,17 @@ public class RateLimiterTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
     try {
+      limiter.tryAcquire(0., 1, SECONDS);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
       limiter.tryAcquire(-1, 1, SECONDS);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      limiter.tryAcquire(-1., 1, SECONDS);
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -371,6 +401,28 @@ public class RateLimiterTest extends TestCase {
     rateLimiter.acquire(4); // R2.00, to repay previous
     rateLimiter.acquire(8); // R4.00, to repay previous
     rateLimiter.acquire(1); // R8.00, to repay previous
+    assertEvents("R0.00", "R1.00", "R1.00", "R2.00", "R4.00", "R8.00");
+  }
+
+  public void testIntegerDoublePermits() {
+    RateLimiter rateLimiter = RateLimiter.create(stopwatch, 1.0);
+    rateLimiter.acquire(1.0); // no wait
+    rateLimiter.acquire(1.0); // R1.00, to repay previous
+    rateLimiter.acquire(2.0); // R1.00, to repay previous
+    rateLimiter.acquire(4.0); // R2.00, to repay previous
+    rateLimiter.acquire(8.0); // R4.00, to repay previous
+    rateLimiter.acquire(1.0); // R8.00, to repay previous
+    assertEvents("R0.00", "R1.00", "R1.00", "R2.00", "R4.00", "R8.00");
+  }
+
+  public void testDoublePermits() {
+    RateLimiter rateLimiter = RateLimiter.create(stopwatch, 0.1);
+    rateLimiter.acquire(0.1); // no wait
+    rateLimiter.acquire(0.1); // R1.00, to repay previous
+    rateLimiter.acquire(0.2); // R1.00, to repay previous
+    rateLimiter.acquire(0.4); // R2.00, to repay previous
+    rateLimiter.acquire(0.8); // R4.00, to repay previous
+    rateLimiter.acquire(0.1); // R8.00, to repay previous
     assertEvents("R0.00", "R1.00", "R1.00", "R2.00", "R4.00", "R8.00");
   }
 

--- a/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -345,7 +345,7 @@ abstract class SmoothRateLimiter extends RateLimiter {
   }
 
   @Override
-  final long reserveEarliestAvailable(int requiredPermits, long nowMicros) {
+  final long reserveEarliestAvailable(double requiredPermits, long nowMicros) {
     resync(nowMicros);
     long returnValue = nextFreeTicketMicros;
     double storedPermitsToSpend = min(requiredPermits, this.storedPermits);


### PR DESCRIPTION
pull request for #2392

Duplicates the acquire methods for backwards compatibility.
The package private methods with signature changes have not been duplicated.