### PR TITLE
Allowing Range.intersect to return empty sets when ranges are not connected

### DIFF
--- a/guava-tests/test/com/google/common/collect/RangeTest.java
+++ b/guava-tests/test/com/google/common/collect/RangeTest.java
@@ -461,6 +461,36 @@ public class RangeTest extends TestCase {
     }
   }
 
+  public void testOverlapping() {
+    assertEquals(Range.openClosed(2, 2), Range.open(0, 1).intersection(Range.open(2, 3), true));
+    assertEquals(Range.closedOpen(2, 2), Range.open(0, 1).intersection(Range.closed(2, 3), true));
+    assertEquals(Range.openClosed(1, 1), Range.open(0, 1).intersection(Range.open(1, 2), true));
+    assertEquals(Range.openClosed(1, 1), Range.openClosed(0, 1).intersection(Range.open(1, 2), true));
+    assertEquals(Range.openClosed(1, 1), Range.openClosed(0, 1).intersection(Range.openClosed(1, 2), true));
+    assertEquals(Range.closedOpen(1, 1), Range.closedOpen(0, 1).intersection(Range.closedOpen(1, 2), true));
+    assertEquals(Range.openClosed(1, 1), Range.open(0, 1).intersection(Range.openClosed(1, 2), true));
+    assertEquals(Range.closedOpen(1, 1), Range.open(0, 1).intersection(Range.closedOpen(1, 2), true));
+    assertEquals(Range.openClosed(1, 1), Range.closedOpen(0, 1).intersection(Range.open(1, 2), true));
+    assertEquals(Range.openClosed(1,1), Range.closedOpen(0, 1).intersection(Range.openClosed(1, 2), true));
+    assertEquals(Range.closed(1,1), Range.openClosed(0, 1).intersection(Range.closedOpen(1, 2), true));
+
+    assertEquals(Range.closedOpen(0, 0), Range.closedOpen(0, 0).intersection(Range.closed(0, 0), true));
+    assertEquals(Range.openClosed(0, 0), Range.closedOpen(0, 0).intersection(Range.open(0, 1), true));
+    assertEquals(Range.closedOpen(0, 0), Range.closedOpen(0, 0).intersection(Range.closed(0, 1), true));
+    assertEquals(Range.closed(0,0), Range.closed(0, 0).intersection(Range.closed(0, 1), true));
+    assertEquals(Range.openClosed(0,0), Range.closed(0, 0).intersection(Range.open(0, 1), true));
+
+    assertEquals(Range.closedOpen(1, 1), Range.closedOpen(0, 1).intersection(Range.closedOpen(1, 1), true));
+    assertEquals(Range.closedOpen(1, 1), Range.closed(0, 1).intersection(Range.closedOpen(1, 1), true));
+    assertEquals(Range.openClosed(1,1), Range.closed(0, 1).intersection(Range.openClosed(1, 1), true));
+    assertEquals(Range.closed(1,1), Range.closed(0, 1).intersection(Range.closed(1, 1), true));
+    assertEquals(Range.closedOpen(1, 1), Range.open(0, 1).intersection(Range.closed(1, 1), true));
+
+    assertEquals(Range.openClosed(3, 3), Range.open(3, 4).intersection(Range.atMost(3), true));
+    assertEquals(Range.openClosed(3, 4), Range.openClosed(3, 4).intersection(Range.<Integer>all(), true));
+    assertEquals(Range.<Integer>all(), Range.<Integer>all().intersection(Range.<Integer>all(), true));
+  }
+
   public void testSpan_general() {
     Range<Integer> range = Range.closed(4, 8);
 

--- a/guava/src/com/google/common/collect/Range.java
+++ b/guava/src/com/google/common/collect/Range.java
@@ -540,10 +540,13 @@ public final class Range<C extends Comparable> implements Predicate<C>, Serializ
    *
    * <p>The intersection operation is commutative, associative and idempotent, and its identity
    * element is {@link Range#all}).
+   * 
+   * <p>If the flag {@code allowEmptyRanges} is true, method will return an empty range instead of throwing an 
+   * {@link IllegalArgumentException} when the ranges are not connected.
    *
-   * @throws IllegalArgumentException if {@code isConnected(connectedRange)} is {@code false}
+   * @throws IllegalArgumentException if {@code allowEmptyRanges} and {@code isConnected(connectedRange)} is {@code false}
    */
-  public Range<C> intersection(Range<C> connectedRange) {
+  public Range<C> intersection(Range<C> connectedRange, boolean allowEmptyRanges) {
     int lowerCmp = lowerBound.compareTo(connectedRange.lowerBound);
     int upperCmp = upperBound.compareTo(connectedRange.upperBound);
     if (lowerCmp >= 0 && upperCmp <= 0) {
@@ -553,8 +556,31 @@ public final class Range<C extends Comparable> implements Predicate<C>, Serializ
     } else {
       Cut<C> newLower = (lowerCmp >= 0) ? lowerBound : connectedRange.lowerBound;
       Cut<C> newUpper = (upperCmp <= 0) ? upperBound : connectedRange.upperBound;
-      return create(newLower, newUpper);
+      if (allowEmptyRanges && newLower.compareTo(newUpper) > 0)
+        return create(newLower, newLower);
+      else
+        return create(newLower, newUpper);
     }
+  }
+
+  /**
+   * Returns the maximal range {@linkplain #encloses enclosed} by both this range and {@code
+   * connectedRange}, if such a range exists.
+   *
+   * <p>For example, the intersection of {@code [1..5]} and {@code (3..7)} is {@code (3..5]}. The
+   * resulting range may be empty; for example, {@code [1..5)} intersected with {@code [5..7)}
+   * yields the empty range {@code [5..5)}.
+   *
+   * <p>The intersection exists if and only if the two ranges are {@linkplain #isConnected
+   * connected}.
+   *
+   * <p>The intersection operation is commutative, associative and idempotent, and its identity
+   * element is {@link Range#all}).
+   *
+   * @throws IllegalArgumentException if {@code isConnected(connectedRange)} is {@code false}
+   */
+  public Range<C> intersection(Range<C> connectedRange) {
+    return intersection(connectedRange, false);
   }
 
   /**


### PR DESCRIPTION
When I am working with ranges that sometimes are connected and sometimes not, It is a litle cumbersome to have to check if the ranges are connected before any calling to the intersection method.

I added a new intersection method with a new optional flag parameter "_allowEmptyRanges_". When this flag is true, the method will return an empty set when ranges are not connected (instead of throwing an IllegalArgumentException).

The change is backward-compatible but I have included specitifc unit tests for this little change.

I would be glad to hear any comments from you.
