### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Links
 -----
 
 - [GitHub project](https://github.com/google/guava)
-- [Issue tracker: report a defect or feature request](https://github.com/google/guava/issues/new)
+- [Issue tracker: Report a defect or feature request](https://github.com/google/guava/issues/new)
 - [StackOverflow: Ask "how-to" and "why-didn't-it-work" questions](https://stackoverflow.com/questions/ask?tags=guava+java)
 - [guava-discuss: For open-ended questions and discussion](http://groups.google.com/group/guava-discuss)
 


### PR DESCRIPTION
Capitalization change in documentation line 62, report changed to Report 

Very very trivial change to documentation of the read-me. Just cutting my teeth on Git..