### PR TITLE
Object can not be serializabled

### DIFF
--- a/guava/src/com/google/common/collect/TransformedIterator.java
+++ b/guava/src/com/google/common/collect/TransformedIterator.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Iterator;
  * @author Louis Wasserman
  */
 @GwtCompatible
-abstract class TransformedIterator<F, T> implements Iterator<T> {
+abstract class TransformedIterator<F, T> implements Iterator<T>, Serializable {
   final Iterator<? extends F> backingIterator;
 
   TransformedIterator(Iterator<? extends F> backingIterator) {


### PR DESCRIPTION
fix bug:
List<String> resultList = Lists.transform(list, new Function<Bean, String>() {
                        @Override
                        public String apply(Bean input) {
                            return input.getId();
                        }
                    });

after using this , the resultList can't be serializable
