### PR TITLE
Extensions for Preconditions API

### DIFF
--- a/guava-tests/test/com/google/common/base/PreconditionsTest.java
+++ b/guava-tests/test/com/google/common/base/PreconditionsTest.java
@@ -17,7 +17,22 @@
 package com.google.common.base;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.catchException;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import junit.framework.AssertionFailedError;
+import junit.framework.TestCase;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -26,15 +41,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.testing.ArbitraryInstances;
 import com.google.common.testing.NullPointerTester;
-
-import junit.framework.AssertionFailedError;
-import junit.framework.TestCase;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Unit test for {@link Preconditions}.
@@ -531,5 +537,180 @@ public class PreconditionsTest extends TestCase {
 
   private static void verifyComplexMessage(Exception e) {
     assertThat(e).hasMessage("I ate 5 pies.");
+  }
+
+  @GwtIncompatible
+  public void testThatArgumentExceptionIsThrownWithMessageFromCallback() {
+    // given
+    final boolean falseExpression = false;
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+    String errorMessage = "error";
+    when(errorMessageCallback.get()).thenReturn(errorMessage);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Preconditions.checkArgument(falseExpression, errorMessageCallback);
+      }
+    });
+
+    // then
+    assertThat(caughtException).isNotNull();
+    assertThat(caughtException).isInstanceOf(IllegalArgumentException.class);
+    assertThat(caughtException).hasMessage(errorMessage);
+  }
+
+  @GwtIncompatible
+  public void testThatErrorMessageCallbackIsNotCalledWhenArgumentExceptionIsNotThrown() {
+    // given
+    final boolean trueExpression = true;
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Preconditions.checkArgument(trueExpression, errorMessageCallback);
+      }
+    });
+
+    // then
+    assertThat(caughtException).isNull();
+    verify(errorMessageCallback, never()).get();
+  }
+
+  @GwtIncompatible
+  public void testThatStateExceptionIsThrownWithMessageFromCallback() {
+    // given
+    final boolean falseExpression = false;
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+    String errorMessage = "error";
+    when(errorMessageCallback.get()).thenReturn(errorMessage);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Preconditions.checkState(falseExpression, errorMessageCallback);
+      }
+    });
+
+    // then
+    assertThat(caughtException).isNotNull();
+    assertThat(caughtException).isInstanceOf(IllegalStateException.class);
+    assertThat(caughtException).hasMessage(errorMessage);
+  }
+
+  @GwtIncompatible
+  public void testThatErrorMessageCallbackIsNotCalledWhenStateExceptionIsNotThrown() {
+    // given
+    final boolean trueExpression = true;
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Preconditions.checkState(trueExpression, errorMessageCallback);
+      }
+    });
+
+    // then
+    assertThat(caughtException).isNull();
+    verify(errorMessageCallback, never()).get();
+  }
+
+  @GwtIncompatible
+  public void testThatNullExceptionIsThrownWithMessageFromCallback() {
+    // given
+    final Object nullReference = null;
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+    String errorMessage = "error";
+    when(errorMessageCallback.get()).thenReturn(errorMessage);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Preconditions.checkNotNull(nullReference, errorMessageCallback);
+       }
+    });
+
+    // then
+    assertThat(caughtException).isNotNull();
+    assertThat(caughtException).isInstanceOf(NullPointerException.class);
+    assertThat(caughtException).hasMessage(errorMessage);
+  }
+
+  @GwtIncompatible
+  public void testThatErrorMessageCallbackIsNotCalledWhenNullExceptionIsNotThrown() {
+    // given
+    final Object notNullReference = new Object();
+    @SuppressWarnings("unchecked")
+    final Supplier<Object> errorMessageCallback = mock(Supplier.class);
+    @SuppressWarnings("unchecked")
+    final Function<Object, Void> result = mock(Function.class);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() {
+        Object checkResult = Preconditions.checkNotNull(
+          notNullReference, errorMessageCallback);
+          result.apply(checkResult);
+      }
+    });
+
+    // then
+    assertThat(caughtException).isNull();
+    verify(errorMessageCallback, never()).get();
+    verify(result).apply(notNullReference);
+  }
+
+  @GwtIncompatible
+  public void testThatExceptionFromCallbackIsThrownWhenGivenExpressionIfFalse()
+    throws IOException {
+    // given
+    final boolean falseExpression = false;
+    final IOException exception = new IOException();
+    @SuppressWarnings("unchecked")
+    final Supplier<IOException> exceptionCallback = mock(Supplier.class);
+    when(exceptionCallback.get()).thenReturn(exception);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() throws IOException {
+        Preconditions.check(falseExpression, exceptionCallback);
+      }});
+
+    // then
+    assertThat(caughtException).isEqualTo(exception);
+  }
+
+  @GwtIncompatible
+  public void testThatExceptionCallbackIsNotCalledWhenExpressionIsTrue()
+    throws IOException {
+    // given
+    final boolean trueExpression = true;
+    @SuppressWarnings("unchecked")
+    final Supplier<IOException> exceptionCallback = mock(Supplier.class);
+
+    // when
+    Throwable caughtException = catchException(new ThrowableAction() {
+      @Override
+      public void call() throws IOException {
+        Preconditions.check(trueExpression, exceptionCallback);
+      }});
+
+    // then
+    assertThat(caughtException).isNull();
+    verify(exceptionCallback, never()).get();
   }
 }

--- a/guava-tests/test/com/google/common/base/ThrowablesTest.java
+++ b/guava-tests/test/com/google/common/base/ThrowablesTest.java
@@ -683,4 +683,34 @@ public class ThrowablesTest extends TestCase {
   public void testNullPointers() {
     new NullPointerTester().testAllPublicStaticMethods(Throwables.class);
   }
+
+  @GwtIncompatible
+  public void testThatExceptionInGivenActionHasBeenCaught() {
+    // given
+    final Exception exception = new Exception();
+    ThrowableAction action = new ThrowableAction() {
+      @Override
+      public void call() throws Throwable {
+         throw exception;
+      }
+    };
+
+    // when
+    Throwable caughtException = Throwables.catchException(action);
+
+    // then
+    assertThat(caughtException).isEqualTo(exception);
+  }
+
+  @GwtIncompatible
+  public void testThatNullIsReturnedWhenExceptionWasNotThrown() {
+    // given
+    ThrowableAction action = ThrowableActions.doNothing();
+
+    // when
+    Throwable caughtException = Throwables.catchException(action);
+
+    // then
+    assertThat(caughtException).isNull();
+  }
 }

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -51,6 +51,13 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.3.7</version>
         <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
         </executions>
         <configuration>
           <instructions>

--- a/guava/src/com/google/common/base/Preconditions.java
+++ b/guava/src/com/google/common/base/Preconditions.java
@@ -419,6 +419,24 @@ public final class Preconditions {
   }
 
   /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   * If expression happens to be false {@link IllegalArgumentException} will be thrown with messsage
+   * provided from the errorMessage callback. Otherwise errorMessage will not be called.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message callback
+   * @throws IllegalArgumentException if {@code expression} is false
+   */
+  public static void checkArgument(final boolean expression, final @Nullable Supplier<Object> errorMessage) {
+    if (!expression) {
+      if (errorMessage == null) {
+          checkArgument(expression, (Object) null);
+      }
+      throw new IllegalArgumentException(String.valueOf(errorMessage.get()));
+    }
+  }
+
+  /**
    * Ensures the truth of an expression involving the state of the calling instance, but not
    * involving any parameters to the calling method.
    *
@@ -755,6 +773,25 @@ public final class Preconditions {
       @Nullable Object p4) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2, p3, p4));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   * If expression happens to be false {@link IllegalStateException} will be thrown with messsage
+   * provided from the errorMessage callback. Otherwise errorMessage will not be called.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message callback
+   * @throws IllegalStateException if {@code expression} is false
+   */
+  public static void checkState(boolean expression, @Nullable Supplier<Object> errorMessage) {
+    if (!expression) {
+      if (errorMessage == null) {
+          checkState(expression, (Object) null);
+      }
+      throw new IllegalStateException(String.valueOf(errorMessage.get()));
     }
   }
 
@@ -1119,6 +1156,27 @@ public final class Preconditions {
     return obj;
   }
 
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   * If reference happens to be null {@link NullPointerException} will be thrown with messsage
+   * provided from the errorMessage callback. Otherwise errorMessage will not be called.
+   *
+   * @param reference an object reference
+   * @param errorMessage the exception message callback
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  @CanIgnoreReturnValue
+  public static <T> T checkNotNull(T reference, @Nullable Supplier<Object> errorMessage) {
+    if (reference == null) {
+      if (errorMessage == null) {
+          checkNotNull(reference, (Object) null);
+      }
+      throw new NullPointerException(String.valueOf(errorMessage.get()));
+    }
+    return reference;
+  }
+
   /*
    * All recent hotspots (as of 2009) *really* like to have the natural code
    *
@@ -1306,5 +1364,20 @@ public final class Preconditions {
     }
 
     return builder.toString();
+  }
+
+  /**
+   *  Ensures the truth of an expression.
+   *  When expression is false exception from given callback will be thrown.
+   *
+   * @param expression a boolean expression
+   * @param exception callback to exception
+   * @throws TException exception thrown when given expression is false
+   */
+  public static <TException extends Throwable> void check(boolean expression, Supplier<TException> exception)
+        throws TException {
+    if (!expression) {
+      throw exception.get();
+    }
   }
 }

--- a/guava/src/com/google/common/base/ThrowableAction.java
+++ b/guava/src/com/google/common/base/ThrowableAction.java
@@ -1,0 +1,15 @@
+package com.google.common.base;
+
+
+/**
+ * Action callback with possibility of exception throw.
+ */
+public interface ThrowableAction {
+
+  /**
+   * Calls action.
+   *
+   * @throws Throwable when exception occurs
+   */
+   void call() throws Throwable;
+}

--- a/guava/src/com/google/common/base/ThrowableActions.java
+++ b/guava/src/com/google/common/base/ThrowableActions.java
@@ -1,0 +1,21 @@
+package com.google.common.base;
+
+/**
+ * Static utility methofs for {@link ThrowableAction} interface.
+ */
+public final class ThrowableActions {
+  private ThrowableActions() {}
+
+  private static final ThrowableAction EMPTY_ACTION =
+      new ThrowableAction() {
+        @Override
+        public void call() throws Throwable {}
+      };
+
+   /**
+    * Returns empty action.
+    */
+   public static ThrowableAction doNothing() {
+	   return EMPTY_ACTION;
+   }
+}

--- a/guava/src/com/google/common/base/Throwables.java
+++ b/guava/src/com/google/common/base/Throwables.java
@@ -471,4 +471,22 @@ public final class Throwables {
       return null;
     }
   }
+
+  /**
+   * Returns exception thrown in given action. If exception didn't occur returns null.
+   *
+   * @param action checked action
+   * @return caught exception or null
+   */
+  @GwtIncompatible
+  @Nullable
+  public static Throwable catchException(ThrowableAction action) {
+    Preconditions.checkNotNull(action, "Action was not specified");
+    try {
+      action.call();
+      return null;
+    } catch (Throwable e) {
+      return e;
+    }
+  }
 }


### PR DESCRIPTION
1. Addition of callback support for Preconditions API :
- checkArgument(boolean expression, Supplier<Object> errorMessge)
- checkState(boolean expression, Supplier<Object> errorMessge)
- checkNotNull(T reference, Supplier<Object> errorMessge)
- check(boolean expression, Supplier<TException> exception)
1. Throwable.catchException utility along with ThrowableAction interface and ThrowableActions utility methods.
