### PR TITLE
Make Cache class keys type safe

### DIFF
--- a/guava-tests/test/com/google/common/cache/AbstractCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/AbstractCacheTest.java
@@ -79,15 +79,15 @@ public class AbstractCacheTest extends TestCase {
   }
 
   public void testInvalidateAll() {
-    final List<Object> invalidated = Lists.newArrayList();
+    final List<Integer> invalidated = Lists.newArrayList();
     Cache<Integer, Integer> cache = new AbstractCache<Integer, Integer>() {
       @Override
-      public Integer getIfPresent(Object key) {
+      public Integer getIfPresent(Integer key) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public void invalidate(Object key) {
+      public void invalidate(Integer key) {
         invalidated.add(key);
       }
     };

--- a/guava/src/com/google/common/cache/AbstractCache.java
+++ b/guava/src/com/google/common/cache/AbstractCache.java
@@ -61,15 +61,13 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
    * @since 11.0
    */
   @Override
-  public ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+  public ImmutableMap<K, V> getAllPresent(Iterable<? extends K> keys) {
     Map<K, V> result = Maps.newLinkedHashMap();
-    for (Object key : keys) {
+    for (K key : keys) {
       if (!result.containsKey(key)) {
-        @SuppressWarnings("unchecked")
-        K castKey = (K) key;
         V value = getIfPresent(key);
         if (value != null) {
-          result.put(castKey, value);
+          result.put(key, value);
         }
       }
     }
@@ -103,7 +101,7 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
   }
 
   @Override
-  public void invalidate(Object key) {
+  public void invalidate(K key) {
     throw new UnsupportedOperationException();
   }
 
@@ -111,8 +109,8 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
    * @since 11.0
    */
   @Override
-  public void invalidateAll(Iterable<?> keys) {
-    for (Object key : keys) {
+  public void invalidateAll(Iterable<? extends K> keys) {
+    for (K key : keys) {
       invalidate(key);
     }
   }

--- a/guava/src/com/google/common/cache/Cache.java
+++ b/guava/src/com/google/common/cache/Cache.java
@@ -47,7 +47,7 @@ public interface Cache<K, V> {
    * @since 11.0
    */
   @Nullable
-  V getIfPresent(Object key);
+  V getIfPresent(K key);
 
   /**
    * Returns the value associated with {@code key} in this cache, obtaining that value from {@code
@@ -104,7 +104,7 @@ public interface Cache<K, V> {
    *
    * @since 11.0
    */
-  ImmutableMap<K, V> getAllPresent(Iterable<?> keys);
+  ImmutableMap<K, V> getAllPresent(Iterable<? extends K> keys);
 
   /**
    * Associates {@code value} with {@code key} in this cache. If the cache previously contained a
@@ -130,14 +130,14 @@ public interface Cache<K, V> {
   /**
    * Discards any cached value for key {@code key}.
    */
-  void invalidate(Object key);
+  void invalidate(K key);
 
   /**
    * Discards any cached values for keys {@code keys}.
    *
    * @since 11.0
    */
-  void invalidateAll(Iterable<?> keys);
+  void invalidateAll(Iterable<? extends K> keys);
 
   /**
    * Discards all entries in the cache.

--- a/guava/src/com/google/common/cache/ForwardingCache.java
+++ b/guava/src/com/google/common/cache/ForwardingCache.java
@@ -48,7 +48,7 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
    */
   @Override
   @Nullable
-  public V getIfPresent(Object key) {
+  public V getIfPresent(K key) {
     return delegate().getIfPresent(key);
   }
 
@@ -64,7 +64,7 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
    * @since 11.0
    */
   @Override
-  public ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+  public ImmutableMap<K, V> getAllPresent(Iterable<? extends K> keys) {
     return delegate().getAllPresent(keys);
   }
 
@@ -85,7 +85,7 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
   }
 
   @Override
-  public void invalidate(Object key) {
+  public void invalidate(K key) {
     delegate().invalidate(key);
   }
 
@@ -93,7 +93,7 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
    * @since 11.0
    */
   @Override
-  public void invalidateAll(Iterable<?> keys) {
+  public void invalidateAll(Iterable<? extends K> keys) {
     delegate().invalidateAll(keys);
   }
 

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -4057,20 +4057,18 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     return get(key, defaultLoader);
   }
 
-  ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+  ImmutableMap<K, V> getAllPresent(Iterable<? extends K> keys) {
     int hits = 0;
     int misses = 0;
 
     Map<K, V> result = Maps.newLinkedHashMap();
-    for (Object key : keys) {
+    for (K key : keys) {
       V value = get(key);
       if (value == null) {
         misses++;
       } else {
         // TODO(fry): store entry key instead of query key
-        @SuppressWarnings("unchecked")
-        K castKey = (K) key;
-        result.put(castKey, value);
+        result.put(key, value);
         hits++;
       }
     }
@@ -4323,7 +4321,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     }
   }
 
-  void invalidateAll(Iterable<?> keys) {
+  void invalidateAll(Iterable<? extends K> keys) {
     // TODO(fry): batch by segment
     for (Object key : keys) {
       remove(key);
@@ -4907,7 +4905,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     }
 
     @Override
-    public ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+    public ImmutableMap<K, V> getAllPresent(Iterable<? extends K> keys) {
       return localCache.getAllPresent(keys);
     }
 
@@ -4922,13 +4920,13 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     }
 
     @Override
-    public void invalidate(Object key) {
+    public void invalidate(K key) {
       checkNotNull(key);
       localCache.remove(key);
     }
 
     @Override
-    public void invalidateAll(Iterable<?> keys) {
+    public void invalidateAll(Iterable<? extends K> keys) {
       localCache.invalidateAll(keys);
     }
 


### PR DESCRIPTION
Maybe this should be an issue instead of pull request, if you find this to be against the guidelines for contributing, please feel free to close this request immediately. I wanted to send a pull request instead to demonstrate how invasive the change would be. (not very)

Basically I was using `LoadingCache<String, Value>` in my application and used it to cache data based on a string key, and I also needed to invalidate the cache, so invalidate(key) was called whenever necessary. Later on I needed to change the type of the `LoadingCache` to `LoadingCache<Wrapper, Value>` in order to pass on some extra parameters for the `CacheLoader`. Everything compiled and seemed to work fine, but after a while some cache invalidation issues started to come up.

After debugging I figured out that the signature of `invalidate(key)` is actually `invalidate(Object key)`, instead of using the actual key type. The lack of cache invalidation in turn caused inconsistency in our actual data and at least a day of extra work trying to fix everything manually. So I thought if having the key type included in the signature could've saved me hours of work, maybe I'm not the only one.

In theory it would be possible that someone is using an object for invalidation that is not a subclass of key, but would still equal to it. In practice I find this rather unlikely, but I would like to hear some comments about how to proceed with this suggested change.

Also, I have not signed the Google CLA yet, but I can do it if necessary.