### PR TITLE
Fix usage example of ImmutableSortedMultiset.Builder

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -395,7 +395,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableSortedMultiset
    * <pre> {@code
    *
    *   public static final ImmutableSortedMultiset<Bean> BEANS =
-   *       new ImmutableSortedMultiset.Builder<Bean>()
+   *       ImmutableSortedMultiset.<Bean>naturalOrder()
    *           .addCopies(Bean.COCOA, 4)
    *           .addCopies(Bean.GARDEN, 6)
    *           .addCopies(Bean.RED, 8)


### PR DESCRIPTION
Currently, example code in the description of ImmutableSortedMultiset.Builder class contains call for constructor which doesn't exist. This PR replaces constructor with `ImmutableSortedMultiset.naturalOrder()` call