### PR TITLE
Fix HttpHeaders constants to be lowercase.

### DIFF
--- a/guava-tests/test/com/google/common/net/HttpHeadersTest.java
+++ b/guava-tests/test/com/google/common/net/HttpHeadersTest.java
@@ -17,16 +17,10 @@
 package com.google.common.net;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-
-import junit.framework.TestCase;
-
 import java.lang.reflect.Field;
-import java.util.List;
+import junit.framework.TestCase;
 
 /**
  * Tests for the HttpHeaders class.
@@ -39,18 +33,15 @@ public class HttpHeadersTest extends TestCase {
     // Special case some of the weird HTTP Header names...
     ImmutableBiMap<String, String> specialCases = ImmutableBiMap.of("ETAG", "ETag",
         "X_WEBKIT_CSP", "X-WebKit-CSP", "X_WEBKIT_CSP_REPORT_ONLY", "X-WebKit-CSP-Report-Only");
-    ImmutableSet<String> uppercaseAcronyms = ImmutableSet.of(
-        "ID", "DNT", "IP", "MD5", "P3P", "TE", "UID", "URL", "WWW", "XSS");
-    assertConstantNameMatchesString(HttpHeaders.class, specialCases, uppercaseAcronyms);
+    assertConstantNameMatchesString(HttpHeaders.class, specialCases);
   }
 
   // Visible for other tests to use
-  static void assertConstantNameMatchesString(Class<?> clazz,
-      ImmutableBiMap<String, String> specialCases, ImmutableSet<String> uppercaseAcronyms)
+  static void assertConstantNameMatchesString(
+      Class<?> clazz, ImmutableBiMap<String, String> specialCases)
       throws IllegalAccessException {
     for (Field field : relevantFields(clazz)) {
-      assertEquals(upperToHttpHeaderName(field.getName(), specialCases, uppercaseAcronyms),
-          field.get(null));
+      assertEquals(upperToHttpHeaderName(field.getName(), specialCases), field.get(null));
     }
   }
 
@@ -70,21 +61,11 @@ public class HttpHeadersTest extends TestCase {
     return builder.build();
   }
 
-  private static final Splitter SPLITTER = Splitter.on('_');
-  private static final Joiner JOINER = Joiner.on('-');
-
-  private static String upperToHttpHeaderName(String constantName,
-      ImmutableBiMap<String, String> specialCases, ImmutableSet<String> uppercaseAcronyms) {
+  private static String upperToHttpHeaderName(
+      String constantName, ImmutableBiMap<String, String> specialCases) {
     if (specialCases.containsKey(constantName)) {
-      return specialCases.get(constantName);
+      return Ascii.toLowerCase(specialCases.get(constantName));
     }
-    List<String> parts = Lists.newArrayList();
-    for (String part : SPLITTER.split(constantName)) {
-      if (!uppercaseAcronyms.contains(part)) {
-        part = part.charAt(0) + Ascii.toLowerCase(part.substring(1));
-      }
-      parts.add(part);
-    }
-    return JOINER.join(parts);
+    return Ascii.toLowerCase(constantName).replace('_', '-');
   }
 }

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -38,44 +38,44 @@ public final class HttpHeaders {
   // HTTP Request and Response header fields
 
   /** The HTTP {@code Cache-Control} header field name. */
-  public static final String CACHE_CONTROL = "Cache-Control";
+  public static final String CACHE_CONTROL = "cache-control";
   /** The HTTP {@code Content-Length} header field name. */
-  public static final String CONTENT_LENGTH = "Content-Length";
+  public static final String CONTENT_LENGTH = "content-length";
   /** The HTTP {@code Content-Type} header field name. */
-  public static final String CONTENT_TYPE = "Content-Type";
+  public static final String CONTENT_TYPE = "content-type";
   /** The HTTP {@code Date} header field name. */
-  public static final String DATE = "Date";
+  public static final String DATE = "date";
   /** The HTTP {@code Pragma} header field name. */
-  public static final String PRAGMA = "Pragma";
+  public static final String PRAGMA = "pragma";
   /** The HTTP {@code Via} header field name. */
-  public static final String VIA = "Via";
+  public static final String VIA = "via";
   /** The HTTP {@code Warning} header field name. */
-  public static final String WARNING = "Warning";
+  public static final String WARNING = "warning";
 
   // HTTP Request header fields
 
   /** The HTTP {@code Accept} header field name. */
-  public static final String ACCEPT = "Accept";
+  public static final String ACCEPT = "accept";
   /** The HTTP {@code Accept-Charset} header field name. */
-  public static final String ACCEPT_CHARSET = "Accept-Charset";
+  public static final String ACCEPT_CHARSET = "accept-charset";
   /** The HTTP {@code Accept-Encoding} header field name. */
-  public static final String ACCEPT_ENCODING = "Accept-Encoding";
+  public static final String ACCEPT_ENCODING = "accept-encoding";
   /** The HTTP {@code Accept-Language} header field name. */
-  public static final String ACCEPT_LANGUAGE = "Accept-Language";
+  public static final String ACCEPT_LANGUAGE = "accept-language";
   /** The HTTP {@code Access-Control-Request-Headers} header field name. */
-  public static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+  public static final String ACCESS_CONTROL_REQUEST_HEADERS = "access-control-request-headers";
   /** The HTTP {@code Access-Control-Request-Method} header field name. */
-  public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+  public static final String ACCESS_CONTROL_REQUEST_METHOD = "access-control-request-method";
   /** The HTTP {@code Authorization} header field name. */
-  public static final String AUTHORIZATION = "Authorization";
+  public static final String AUTHORIZATION = "authorization";
   /** The HTTP {@code Connection} header field name. */
-  public static final String CONNECTION = "Connection";
+  public static final String CONNECTION = "connection";
   /** The HTTP {@code Cookie} header field name. */
-  public static final String COOKIE = "Cookie";
+  public static final String COOKIE = "cookie";
   /** The HTTP {@code Expect} header field name. */
-  public static final String EXPECT = "Expect";
+  public static final String EXPECT = "expect";
   /** The HTTP {@code From} header field name. */
-  public static final String FROM = "From";
+  public static final String FROM = "from";
 
   /**
    * The HTTP {@code Follow-Only-When-Prerender-Shown}</a> header field name.
@@ -83,82 +83,82 @@ public final class HttpHeaders {
    * @since 17.0
    */
   @Beta
-  public static final String FOLLOW_ONLY_WHEN_PRERENDER_SHOWN = "Follow-Only-When-Prerender-Shown";
+  public static final String FOLLOW_ONLY_WHEN_PRERENDER_SHOWN = "follow-only-when-prerender-shown";
   /** The HTTP {@code Host} header field name. */
-  public static final String HOST = "Host";
+  public static final String HOST = "host";
   /** The HTTP {@code If-Match} header field name. */
-  public static final String IF_MATCH = "If-Match";
+  public static final String IF_MATCH = "if-match";
   /** The HTTP {@code If-Modified-Since} header field name. */
-  public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
+  public static final String IF_MODIFIED_SINCE = "if-modified-since";
   /** The HTTP {@code If-None-Match} header field name. */
-  public static final String IF_NONE_MATCH = "If-None-Match";
+  public static final String IF_NONE_MATCH = "if-none-match";
   /** The HTTP {@code If-Range} header field name. */
-  public static final String IF_RANGE = "If-Range";
+  public static final String IF_RANGE = "if-range";
   /** The HTTP {@code If-Unmodified-Since} header field name. */
-  public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
+  public static final String IF_UNMODIFIED_SINCE = "if-unmodified-since";
   /** The HTTP {@code Last-Event-ID} header field name. */
-  public static final String LAST_EVENT_ID = "Last-Event-ID";
+  public static final String LAST_EVENT_ID = "last-event-id";
   /** The HTTP {@code Max-Forwards} header field name. */
-  public static final String MAX_FORWARDS = "Max-Forwards";
+  public static final String MAX_FORWARDS = "max-forwards";
   /** The HTTP {@code Origin} header field name. */
-  public static final String ORIGIN = "Origin";
+  public static final String ORIGIN = "origin";
   /** The HTTP {@code Proxy-Authorization} header field name. */
-  public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+  public static final String PROXY_AUTHORIZATION = "proxy-authorization";
   /** The HTTP {@code Range} header field name. */
-  public static final String RANGE = "Range";
+  public static final String RANGE = "range";
   /** The HTTP {@code Referer} header field name. */
-  public static final String REFERER = "Referer";
+  public static final String REFERER = "referer";
   /**
    * The HTTP <a href="https://www.w3.org/TR/service-workers/#update-algorithm">
    * {@code Service-Worker}</a> header field name.
    */
-  public static final String SERVICE_WORKER = "Service-Worker";
+  public static final String SERVICE_WORKER = "service-worker";
   /** The HTTP {@code TE} header field name. */
-  public static final String TE = "TE";
+  public static final String TE = "te";
   /** The HTTP {@code Upgrade} header field name. */
-  public static final String UPGRADE = "Upgrade";
+  public static final String UPGRADE = "upgrade";
   /** The HTTP {@code User-Agent} header field name. */
-  public static final String USER_AGENT = "User-Agent";
+  public static final String USER_AGENT = "user-agent";
 
   // HTTP Response header fields
 
   /** The HTTP {@code Accept-Ranges} header field name. */
-  public static final String ACCEPT_RANGES = "Accept-Ranges";
+  public static final String ACCEPT_RANGES = "accept-ranges";
   /** The HTTP {@code Access-Control-Allow-Headers} header field name. */
-  public static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+  public static final String ACCESS_CONTROL_ALLOW_HEADERS = "access-control-allow-headers";
   /** The HTTP {@code Access-Control-Allow-Methods} header field name. */
-  public static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+  public static final String ACCESS_CONTROL_ALLOW_METHODS = "access-control-allow-methods";
   /** The HTTP {@code Access-Control-Allow-Origin} header field name. */
-  public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+  public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "access-control-allow-origin";
   /** The HTTP {@code Access-Control-Allow-Credentials} header field name. */
-  public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+  public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "access-control-allow-credentials";
   /** The HTTP {@code Access-Control-Expose-Headers} header field name. */
-  public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
+  public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "access-control-expose-headers";
   /** The HTTP {@code Access-Control-Max-Age} header field name. */
-  public static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
+  public static final String ACCESS_CONTROL_MAX_AGE = "access-control-max-age";
   /** The HTTP {@code Age} header field name. */
-  public static final String AGE = "Age";
+  public static final String AGE = "age";
   /** The HTTP {@code Allow} header field name. */
-  public static final String ALLOW = "Allow";
+  public static final String ALLOW = "allow";
   /** The HTTP {@code Content-Disposition} header field name. */
-  public static final String CONTENT_DISPOSITION = "Content-Disposition";
+  public static final String CONTENT_DISPOSITION = "content-disposition";
   /** The HTTP {@code Content-Encoding} header field name. */
-  public static final String CONTENT_ENCODING = "Content-Encoding";
+  public static final String CONTENT_ENCODING = "content-encoding";
   /** The HTTP {@code Content-Language} header field name. */
-  public static final String CONTENT_LANGUAGE = "Content-Language";
+  public static final String CONTENT_LANGUAGE = "content-language";
   /** The HTTP {@code Content-Location} header field name. */
-  public static final String CONTENT_LOCATION = "Content-Location";
+  public static final String CONTENT_LOCATION = "content-location";
   /** The HTTP {@code Content-MD5} header field name. */
-  public static final String CONTENT_MD5 = "Content-MD5";
+  public static final String CONTENT_MD5 = "content-md5";
   /** The HTTP {@code Content-Range} header field name. */
-  public static final String CONTENT_RANGE = "Content-Range";
+  public static final String CONTENT_RANGE = "content-range";
   /**
    * The HTTP <a href="http://w3.org/TR/CSP/#content-security-policy-header-field">
    * {@code Content-Security-Policy}</a> header field name.
    *
    * @since 15.0
    */
-  public static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+  public static final String CONTENT_SECURITY_POLICY = "content-security-policy";
   /**
    * The HTTP <a href="http://w3.org/TR/CSP/#content-security-policy-report-only-header-field">
    * {@code Content-Security-Policy-Report-Only}</a> header field name.
@@ -166,7 +166,7 @@ public final class HttpHeaders {
    * @since 15.0
    */
   public static final String CONTENT_SECURITY_POLICY_REPORT_ONLY =
-      "Content-Security-Policy-Report-Only";
+      "content-security-policy-report-only";
   /**
    * The HTTP nonstandard {@code X-Content-Security-Policy} header field name. It was introduced in
    * <a href="https://www.w3.org/TR/2011/WD-CSP-20111129/">CSP v.1</a> and used by the Firefox
@@ -175,7 +175,7 @@ public final class HttpHeaders {
    *
    * @since 20.0
    */
-  public static final String X_CONTENT_SECURITY_POLICY = "X-Content-Security-Policy";
+  public static final String X_CONTENT_SECURITY_POLICY = "x-content-security-policy";
   /**
    * The HTTP nonstandard {@code X-Content-Security-Policy-Report-Only} header field name.
    * It was introduced in <a href="https://www.w3.org/TR/2011/WD-CSP-20111129/">CSP v.1</a> and
@@ -185,7 +185,7 @@ public final class HttpHeaders {
    * @since 20.0
    */
   public static final String X_CONTENT_SECURITY_POLICY_REPORT_ONLY =
-      "X-Content-Security-Policy-Report-Only";
+      "x-content-security-policy-report-only";
   /**
    * The HTTP nonstandard {@code X-WebKit-CSP} header field name. It was introduced in
    * <a href="https://www.w3.org/TR/2011/WD-CSP-20111129/">CSP v.1</a> and used by the Chrome until
@@ -193,7 +193,7 @@ public final class HttpHeaders {
    *
    * @since 20.0
    */
-  public static final String X_WEBKIT_CSP = "X-WebKit-CSP";
+  public static final String X_WEBKIT_CSP = "x-webkit-csp";
   /**
    * The HTTP nonstandard {@code X-WebKit-CSP-Report-Only} header field name. It was introduced in
    * <a href="https://www.w3.org/TR/2011/WD-CSP-20111129/">CSP v.1</a> and used by the Chrome until
@@ -201,38 +201,38 @@ public final class HttpHeaders {
    *
    * @since 20.0
    */
-  public static final String X_WEBKIT_CSP_REPORT_ONLY = "X-WebKit-CSP-Report-Only";
+  public static final String X_WEBKIT_CSP_REPORT_ONLY = "x-webkit-csp-report-only";
   /** The HTTP {@code ETag} header field name. */
-  public static final String ETAG = "ETag";
+  public static final String ETAG = "etag";
   /** The HTTP {@code Expires} header field name. */
-  public static final String EXPIRES = "Expires";
+  public static final String EXPIRES = "expires";
   /** The HTTP {@code Last-Modified} header field name. */
-  public static final String LAST_MODIFIED = "Last-Modified";
+  public static final String LAST_MODIFIED = "last-modified";
   /** The HTTP {@code Link} header field name. */
-  public static final String LINK = "Link";
+  public static final String LINK = "link";
   /** The HTTP {@code Location} header field name. */
-  public static final String LOCATION = "Location";
+  public static final String LOCATION = "location";
   /** The HTTP {@code P3P} header field name. Limited browser support. */
-  public static final String P3P = "P3P";
+  public static final String P3P = "p3p";
   /** The HTTP {@code Proxy-Authenticate} header field name. */
-  public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
+  public static final String PROXY_AUTHENTICATE = "proxy-authenticate";
   /** The HTTP {@code Refresh} header field name. Non-standard header supported by most browsers. */
-  public static final String REFRESH = "Refresh";
+  public static final String REFRESH = "refresh";
   /** The HTTP {@code Retry-After} header field name. */
-  public static final String RETRY_AFTER = "Retry-After";
+  public static final String RETRY_AFTER = "retry-after";
   /** The HTTP {@code Server} header field name. */
-  public static final String SERVER = "Server";
+  public static final String SERVER = "server";
   /**
    * The HTTP <a href="https://www.w3.org/TR/service-workers/#update-algorithm">
    * {@code Service-Worker-Allowed}</a> header field name.
    *
    * @since 20.0
    */
-  public static final String SERVICE_WORKER_ALLOWED = "Service-Worker-Allowed";
+  public static final String SERVICE_WORKER_ALLOWED = "service-worker-allowed";
   /** The HTTP {@code Set-Cookie} header field name. */
-  public static final String SET_COOKIE = "Set-Cookie";
+  public static final String SET_COOKIE = "set-cookie";
   /** The HTTP {@code Set-Cookie2} header field name. */
-  public static final String SET_COOKIE2 = "Set-Cookie2";
+  public static final String SET_COOKIE2 = "set-cookie2";
   /**
    * The HTTP
    * <a href="http://tools.ietf.org/html/rfc6797#section-6.1">{@code Strict-Transport-Security}</a>
@@ -240,51 +240,51 @@ public final class HttpHeaders {
    *
    * @since 15.0
    */
-  public static final String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+  public static final String STRICT_TRANSPORT_SECURITY = "strict-transport-security";
   /**
    * The HTTP <a href="http://www.w3.org/TR/resource-timing/#cross-origin-resources">
    * {@code Timing-Allow-Origin}</a> header field name.
    *
    * @since 15.0
    */
-  public static final String TIMING_ALLOW_ORIGIN = "Timing-Allow-Origin";
+  public static final String TIMING_ALLOW_ORIGIN = "timing-allow-origin";
   /** The HTTP {@code Trailer} header field name. */
-  public static final String TRAILER = "Trailer";
+  public static final String TRAILER = "trailer";
   /** The HTTP {@code Transfer-Encoding} header field name. */
-  public static final String TRANSFER_ENCODING = "Transfer-Encoding";
+  public static final String TRANSFER_ENCODING = "transfer-encoding";
   /** The HTTP {@code Vary} header field name. */
-  public static final String VARY = "Vary";
+  public static final String VARY = "vary";
   /** The HTTP {@code WWW-Authenticate} header field name. */
-  public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+  public static final String WWW_AUTHENTICATE = "www-authenticate";
 
   // Common, non-standard HTTP header fields
 
   /** The HTTP {@code DNT} header field name. */
-  public static final String DNT = "DNT";
+  public static final String DNT = "dnt";
   /** The HTTP {@code X-Content-Type-Options} header field name. */
-  public static final String X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+  public static final String X_CONTENT_TYPE_OPTIONS = "x-content-type-options";
   /** The HTTP {@code X-Do-Not-Track} header field name. */
-  public static final String X_DO_NOT_TRACK = "X-Do-Not-Track";
+  public static final String X_DO_NOT_TRACK = "x-do-not-track";
   /** The HTTP {@code X-Forwarded-For} header field name. */
-  public static final String X_FORWARDED_FOR = "X-Forwarded-For";
+  public static final String X_FORWARDED_FOR = "x-forwarded-for";
   /** The HTTP {@code X-Forwarded-Proto} header field name. */
-  public static final String X_FORWARDED_PROTO = "X-Forwarded-Proto";
+  public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
   /**
    * The HTTP <a href="http://goo.gl/lQirAH">{@code X-Forwarded-Host}</a> header field name.
    *
    * @since 20.0
    */
-  public static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+  public static final String X_FORWARDED_HOST = "x-forwarded-host";
   /**
    * The HTTP <a href="http://goo.gl/YtV2at">{@code X-Forwarded-Port}</a> header field name.
    *
    * @since 20.0
    */
-  public static final String X_FORWARDED_PORT = "X-Forwarded-Port";
+  public static final String X_FORWARDED_PORT = "x-forwarded-port";
   /** The HTTP {@code X-Frame-Options} header field name. */
-  public static final String X_FRAME_OPTIONS = "X-Frame-Options";
+  public static final String X_FRAME_OPTIONS = "x-frame-options";
   /** The HTTP {@code X-Powered-By} header field name. */
-  public static final String X_POWERED_BY = "X-Powered-By";
+  public static final String X_POWERED_BY = "x-powered-by";
   /**
    * The HTTP
    * <a href="http://tools.ietf.org/html/draft-evans-palmer-key-pinning">{@code Public-Key-Pins}</a>
@@ -292,32 +292,32 @@ public final class HttpHeaders {
    *
    * @since 15.0
    */
-  @Beta public static final String PUBLIC_KEY_PINS = "Public-Key-Pins";
+  @Beta public static final String PUBLIC_KEY_PINS = "public-key-pins";
   /**
    * The HTTP <a href="http://tools.ietf.org/html/draft-evans-palmer-key-pinning">
    * {@code Public-Key-Pins-Report-Only}</a> header field name.
    *
    * @since 15.0
    */
-  @Beta public static final String PUBLIC_KEY_PINS_REPORT_ONLY = "Public-Key-Pins-Report-Only";
+  @Beta public static final String PUBLIC_KEY_PINS_REPORT_ONLY = "public-key-pins-report-only";
   /** The HTTP {@code X-Requested-With} header field name. */
-  public static final String X_REQUESTED_WITH = "X-Requested-With";
+  public static final String X_REQUESTED_WITH = "x-requested-with";
   /** The HTTP {@code X-User-IP} header field name. */
-  public static final String X_USER_IP = "X-User-IP";
+  public static final String X_USER_IP = "x-user-ip";
   /** The HTTP {@code X-XSS-Protection} header field name. */
-  public static final String X_XSS_PROTECTION = "X-XSS-Protection";
+  public static final String X_XSS_PROTECTION = "x-xss-protection";
   /**
    * The HTTP <a href="http://html.spec.whatwg.org/multipage/semantics.html#hyperlink-auditing">
    * {@code Ping-From}</a> header field name.
    *
    * @since 19.0
    */
-  public static final String PING_FROM = "Ping-From";
+  public static final String PING_FROM = "ping-from";
   /**
    * The HTTP <a href="http://html.spec.whatwg.org/multipage/semantics.html#hyperlink-auditing">
    * {@code Ping-To}</a> header field name.
    *
    * @since 19.0
    */
-  public static final String PING_TO = "Ping-To";
+  public static final String PING_TO = "ping-to";
 }


### PR DESCRIPTION
HTTP/2 requires lowercase, and it's our collective future. Any code that cares
about the casing of headers is broken, so any code that breaks from this change
is destined to break when it's used with HTTP/2.

String.toLowerCase() and Ascii.toLowerCase() both have optimizations that make
code run faster if the input is already lowercase. I estimate that 0.0000001%
of Google's extensive compute resources are currently wasted converting headers
to lowercase when they could be lowercase already.