### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -255,7 +255,7 @@
               <failOnError>true</failOnError>
               <logLevel>${gwt.logLevel}</logLevel>
               <validateOnly>true</validateOnly>
-              <sourceLevel>1.7</sourceLevel>
+              <sourceLevel>1.8</sourceLevel>
             </configuration>
           </execution>
           <!--
@@ -304,7 +304,7 @@
               <productionMode>true</productionMode>
               <testTimeOut>600</testTimeOut>
               <extraJvmArgs>-Xms3500m -Xmx3500m -Xss1024k</extraJvmArgs>
-              <sourceLevel>1.7</sourceLevel>
+              <sourceLevel>1.8</sourceLevel>
             </configuration>
           </execution>
         </executions>

--- a/guava/src/com/google/common/cache/AbstractCache.java
+++ b/guava/src/com/google/common/cache/AbstractCache.java
@@ -15,13 +15,8 @@
 package com.google.common.cache;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
-import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 
 /**
  * This class provides a skeletal implementation of the {@code Cache} interface to minimize the
@@ -42,90 +37,6 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
 
   /** Constructor for use by subclasses. */
   protected AbstractCache() {}
-
-  /**
-   * @since 11.0
-   */
-  @Override
-  public V get(K key, Callable<? extends V> valueLoader) throws ExecutionException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * This implementation of {@code getAllPresent} lacks any insight into the internal cache data
-   * structure, and is thus forced to return the query keys instead of the cached keys. This is only
-   * possible with an unsafe cast which requires {@code keys} to actually be of type {@code K}.
-   *
-   * {@inheritDoc}
-   *
-   * @since 11.0
-   */
-  @Override
-  public ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
-    Map<K, V> result = Maps.newLinkedHashMap();
-    for (Object key : keys) {
-      if (!result.containsKey(key)) {
-        @SuppressWarnings("unchecked")
-        K castKey = (K) key;
-        V value = getIfPresent(key);
-        if (value != null) {
-          result.put(castKey, value);
-        }
-      }
-    }
-    return ImmutableMap.copyOf(result);
-  }
-
-  /**
-   * @since 11.0
-   */
-  @Override
-  public void put(K key, V value) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * @since 12.0
-   */
-  @Override
-  public void putAll(Map<? extends K, ? extends V> m) {
-    for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
-      put(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @Override
-  public void cleanUp() {}
-
-  @Override
-  public long size() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void invalidate(Object key) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * @since 11.0
-   */
-  @Override
-  public void invalidateAll(Iterable<?> keys) {
-    for (Object key : keys) {
-      invalidate(key);
-    }
-  }
-
-  @Override
-  public void invalidateAll() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public CacheStats stats() {
-    throw new UnsupportedOperationException();
-  }
 
   @Override
   public ConcurrentMap<K, V> asMap() {

--- a/guava/src/com/google/common/cache/Cache.java
+++ b/guava/src/com/google/common/cache/Cache.java
@@ -16,6 +16,7 @@ package com.google.common.cache;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
@@ -96,7 +97,9 @@ public interface Cache<K, V> {
    *
    * @since 11.0
    */
-  V get(K key, Callable<? extends V> loader) throws ExecutionException;
+  default V get(K key, Callable<? extends V> valueLoader) throws ExecutionException {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns a map of the values associated with {@code keys} in this cache. The returned map will
@@ -104,7 +107,20 @@ public interface Cache<K, V> {
    *
    * @since 11.0
    */
-  ImmutableMap<K, V> getAllPresent(Iterable<?> keys);
+  default ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+    Map<K, V> result = Maps.newLinkedHashMap();
+    for (Object key : keys) {
+      if (!result.containsKey(key)) {
+        @SuppressWarnings("unchecked")
+        K castKey = (K) key;
+        V value = getIfPresent(key);
+        if (value != null) {
+          result.put(castKey, value);
+        }
+      }
+    }
+    return ImmutableMap.copyOf(result);
+  }
 
   /**
    * Associates {@code value} with {@code key} in this cache. If the cache previously contained a
@@ -115,7 +131,9 @@ public interface Cache<K, V> {
    *
    * @since 11.0
    */
-  void put(K key, V value);
+  default void put(K key, V value) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Copies all of the mappings from the specified map to the cache. The effect of this call is
@@ -125,29 +143,43 @@ public interface Cache<K, V> {
    *
    * @since 12.0
    */
-  void putAll(Map<? extends K, ? extends V> m);
+  default void putAll(Map<? extends K, ? extends V> m) {
+    for (Map.Entry<? extends K, ? extends V> entry : m.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
 
   /**
    * Discards any cached value for key {@code key}.
    */
-  void invalidate(Object key);
+  default void invalidate(Object key) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Discards any cached values for keys {@code keys}.
    *
    * @since 11.0
    */
-  void invalidateAll(Iterable<?> keys);
+  default void invalidateAll(Iterable<?> keys) {
+    for (Object key : keys) {
+      invalidate(key);
+    }
+  }
 
   /**
    * Discards all entries in the cache.
    */
-  void invalidateAll();
+  default void invalidateAll() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns the approximate number of entries in this cache.
    */
-  long size();
+  default long size() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns a current snapshot of this cache's cumulative statistics, or a set of default values if
@@ -160,7 +192,9 @@ public interface Cache<K, V> {
    * all values is returned.
    *
    */
-  CacheStats stats();
+  default CacheStats stats() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns a view of the entries stored in this cache as a thread-safe map. Modifications made to
@@ -181,5 +215,5 @@ public interface Cache<K, V> {
    * Performs any pending maintenance operations needed by the cache. Exactly which activities are
    * performed -- if any -- is implementation-dependent.
    */
-  void cleanUp();
+  default void cleanUp() {}
 }

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -35,6 +35,8 @@ import com.google.common.cache.CacheBuilder.NullListener;
 import com.google.common.cache.CacheBuilder.OneWeigher;
 import com.google.common.cache.CacheLoader.InvalidCacheLoadException;
 import com.google.common.cache.CacheLoader.UnsupportedLoadingOperationException;
+import com.google.common.cache.LocalCache.ReferenceEntry;
+import com.google.common.cache.LocalCache.ValueReference;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -763,12 +765,16 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     /**
      * Returns the value reference from this entry.
      */
-    ValueReference<K, V> getValueReference();
+    default ValueReference<K, V> getValueReference() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the value reference for this entry.
      */
-    void setValueReference(ValueReference<K, V> valueReference);
+    default void setValueReference(ValueReference<K, V> valueReference) {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the next entry in the chain.
@@ -779,7 +785,9 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     /**
      * Returns the entry's hash.
      */
-    int getHash();
+    default int getHash() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the key for this entry.
@@ -796,32 +804,44 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     /**
      * Returns the time that this entry was last accessed, in ns.
      */
-    long getAccessTime();
+    default long getAccessTime() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the entry access time in ns.
      */
-    void setAccessTime(long time);
+    default void setAccessTime(long time) {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the next entry in the access queue.
      */
-    ReferenceEntry<K, V> getNextInAccessQueue();
+    default ReferenceEntry<K, V> getNextInAccessQueue() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the next entry in the access queue.
      */
-    void setNextInAccessQueue(ReferenceEntry<K, V> next);
+    default void setNextInAccessQueue(ReferenceEntry<K, V> next) {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the previous entry in the access queue.
      */
-    ReferenceEntry<K, V> getPreviousInAccessQueue();
+    default ReferenceEntry<K, V> getPreviousInAccessQueue() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the previous entry in the access queue.
      */
-    void setPreviousInAccessQueue(ReferenceEntry<K, V> previous);
+    default void setPreviousInAccessQueue(ReferenceEntry<K, V> previous) {
+	  throw new UnsupportedOperationException();
+	}
 
     /*
      * Implemented by entries that use write order. Write entries are maintained in a doubly-linked
@@ -832,32 +852,44 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     /**
      * Returns the time that this entry was last written, in ns.
      */
-    long getWriteTime();
+    default long getWriteTime() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the entry write time in ns.
      */
-    void setWriteTime(long time);
+    default void setWriteTime(long time) {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the next entry in the write queue.
      */
-    ReferenceEntry<K, V> getNextInWriteQueue();
+    default ReferenceEntry<K, V> getNextInWriteQueue() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the next entry in the write queue.
      */
-    void setNextInWriteQueue(ReferenceEntry<K, V> next);
+    default void setNextInWriteQueue(ReferenceEntry<K, V> next) {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Returns the previous entry in the write queue.
      */
-    ReferenceEntry<K, V> getPreviousInWriteQueue();
+    default ReferenceEntry<K, V> getPreviousInWriteQueue() {
+	  throw new UnsupportedOperationException();
+	}
 
     /**
      * Sets the previous entry in the write queue.
      */
-    void setPreviousInWriteQueue(ReferenceEntry<K, V> previous);
+    default void setPreviousInWriteQueue(ReferenceEntry<K, V> previous) {
+	  throw new UnsupportedOperationException();
+	}
   }
 
   private enum NullEntry implements ReferenceEntry<Object, Object> {
@@ -937,87 +969,12 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
 
   abstract static class AbstractReferenceEntry<K, V> implements ReferenceEntry<K, V> {
     @Override
-    public ValueReference<K, V> getValueReference() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setValueReference(ValueReference<K, V> valueReference) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public ReferenceEntry<K, V> getNext() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public int getHash() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public K getKey() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long getAccessTime() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setAccessTime(long time) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ReferenceEntry<K, V> getNextInAccessQueue() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setNextInAccessQueue(ReferenceEntry<K, V> next) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ReferenceEntry<K, V> getPreviousInAccessQueue() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setPreviousInAccessQueue(ReferenceEntry<K, V> previous) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long getWriteTime() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setWriteTime(long time) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ReferenceEntry<K, V> getNextInWriteQueue() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setNextInWriteQueue(ReferenceEntry<K, V> next) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ReferenceEntry<K, V> getPreviousInWriteQueue() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setPreviousInWriteQueue(ReferenceEntry<K, V> previous) {
       throw new UnsupportedOperationException();
     }
   }

--- a/guava/src/com/google/common/collect/AbstractMultimap.java
+++ b/guava/src/com/google/common/collect/AbstractMultimap.java
@@ -16,10 +16,7 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.GwtCompatible;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
 
 import java.util.AbstractCollection;
@@ -38,75 +35,6 @@ import javax.annotation.Nullable;
  */
 @GwtCompatible
 abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
-  @Override
-  public boolean isEmpty() {
-    return size() == 0;
-  }
-
-  @Override
-  public boolean containsValue(@Nullable Object value) {
-    for (Collection<V> collection : asMap().values()) {
-      if (collection.contains(value)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  @Override
-  public boolean containsEntry(@Nullable Object key, @Nullable Object value) {
-    Collection<V> collection = asMap().get(key);
-    return collection != null && collection.contains(value);
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public boolean remove(@Nullable Object key, @Nullable Object value) {
-    Collection<V> collection = asMap().get(key);
-    return collection != null && collection.remove(value);
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public boolean put(@Nullable K key, @Nullable V value) {
-    return get(key).add(value);
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public boolean putAll(@Nullable K key, Iterable<? extends V> values) {
-    checkNotNull(values);
-    // make sure we only call values.iterator() once
-    // and we only call get(key) if values is nonempty
-    if (values instanceof Collection) {
-      Collection<? extends V> valueCollection = (Collection<? extends V>) values;
-      return !valueCollection.isEmpty() && get(key).addAll(valueCollection);
-    } else {
-      Iterator<? extends V> valueItr = values.iterator();
-      return valueItr.hasNext() && Iterators.addAll(get(key), valueItr);
-    }
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public boolean putAll(Multimap<? extends K, ? extends V> multimap) {
-    boolean changed = false;
-    for (Map.Entry<? extends K, ? extends V> entry : multimap.entries()) {
-      changed |= put(entry.getKey(), entry.getValue());
-    }
-    return changed;
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public Collection<V> replaceValues(@Nullable K key, Iterable<? extends V> values) {
-    checkNotNull(values);
-    Collection<V> result = removeAll(key);
-    putAll(key, values);
-    return result;
-  }
-
   private transient Collection<Entry<K, V>> entries;
 
   @Override

--- a/guava/src/com/google/common/collect/AbstractMultiset.java
+++ b/guava/src/com/google/common/collect/AbstractMultiset.java
@@ -19,7 +19,6 @@ package com.google.common.collect;
 import static com.google.common.collect.Multisets.setCountImpl;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.base.Objects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
 
@@ -69,16 +68,6 @@ abstract class AbstractMultiset<E> extends AbstractCollection<E> implements Mult
     return Multisets.iteratorImpl(this);
   }
 
-  @Override
-  public int count(@Nullable Object element) {
-    for (Entry<E> entry : entrySet()) {
-      if (Objects.equal(entry.getElement(), element)) {
-        return entry.getCount();
-      }
-    }
-    return 0;
-  }
-
   // Modification Operations
   @CanIgnoreReturnValue
   @Override
@@ -89,20 +78,8 @@ abstract class AbstractMultiset<E> extends AbstractCollection<E> implements Mult
 
   @CanIgnoreReturnValue
   @Override
-  public int add(@Nullable E element, int occurrences) {
-    throw new UnsupportedOperationException();
-  }
-
-  @CanIgnoreReturnValue
-  @Override
   public boolean remove(@Nullable Object element) {
     return remove(element, 1) > 0;
-  }
-
-  @CanIgnoreReturnValue
-  @Override
-  public int remove(@Nullable Object element, int occurrences) {
-    throw new UnsupportedOperationException();
   }
 
   @CanIgnoreReturnValue

--- a/guava/src/com/google/common/collect/AbstractTable.java
+++ b/guava/src/com/google/common/collect/AbstractTable.java
@@ -35,58 +35,6 @@ import javax.annotation.Nullable;
 @GwtCompatible
 abstract class AbstractTable<R, C, V> implements Table<R, C, V> {
 
-  @Override
-  public boolean containsRow(@Nullable Object rowKey) {
-    return Maps.safeContainsKey(rowMap(), rowKey);
-  }
-
-  @Override
-  public boolean containsColumn(@Nullable Object columnKey) {
-    return Maps.safeContainsKey(columnMap(), columnKey);
-  }
-
-  @Override
-  public Set<R> rowKeySet() {
-    return rowMap().keySet();
-  }
-
-  @Override
-  public Set<C> columnKeySet() {
-    return columnMap().keySet();
-  }
-
-  @Override
-  public boolean containsValue(@Nullable Object value) {
-    for (Map<C, V> row : rowMap().values()) {
-      if (row.containsValue(value)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  @Override
-  public boolean contains(@Nullable Object rowKey, @Nullable Object columnKey) {
-    Map<C, V> row = Maps.safeGet(rowMap(), rowKey);
-    return row != null && Maps.safeContainsKey(row, columnKey);
-  }
-
-  @Override
-  public V get(@Nullable Object rowKey, @Nullable Object columnKey) {
-    Map<C, V> row = Maps.safeGet(rowMap(), rowKey);
-    return (row == null) ? null : Maps.safeGet(row, columnKey);
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return size() == 0;
-  }
-
-  @Override
-  public void clear() {
-    Iterators.clear(cellSet().iterator());
-  }
-
   @CanIgnoreReturnValue
   @Override
   public V remove(@Nullable Object rowKey, @Nullable Object columnKey) {
@@ -98,13 +46,6 @@ abstract class AbstractTable<R, C, V> implements Table<R, C, V> {
   @Override
   public V put(R rowKey, C columnKey, V value) {
     return row(rowKey).put(columnKey, value);
-  }
-
-  @Override
-  public void putAll(Table<? extends R, ? extends C, ? extends V> table) {
-    for (Table.Cell<? extends R, ? extends C, ? extends V> cell : table.cellSet()) {
-      put(cell.getRowKey(), cell.getColumnKey(), cell.getValue());
-    }
   }
 
   private transient Set<Cell<R, C, V>> cellSet;

--- a/guava/src/com/google/common/collect/Multiset.java
+++ b/guava/src/com/google/common/collect/Multiset.java
@@ -17,6 +17,8 @@
 package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Objects;
+import com.google.common.collect.Multiset.Entry;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import java.util.Collection;
@@ -104,7 +106,14 @@ public interface Multiset<E> extends Collection<E> {
    * @return the number of occurrences of the element in this multiset; possibly
    *     zero but never negative
    */
-  int count(@Nullable Object element);
+  default int count(@Nullable Object element) {
+    for (Entry<E> entry : entrySet()) {
+      if (Objects.equal(entry.getElement(), element)) {
+        return entry.getCount();
+      }
+    }
+    return 0;
+  }
 
   // Bulk Operations
 
@@ -128,7 +137,10 @@ public interface Multiset<E> extends Collection<E> {
    *     occurrences} is zero, the implementation may opt to return normally.
    */
   @CanIgnoreReturnValue
-  int add(@Nullable E element, int occurrences);
+default
+  int add(@Nullable E element, int occurrences) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Removes a number of occurrences of the specified element from this
@@ -144,7 +156,10 @@ public interface Multiset<E> extends Collection<E> {
    * @throws IllegalArgumentException if {@code occurrences} is negative
    */
   @CanIgnoreReturnValue
-  int remove(@Nullable Object element, int occurrences);
+default
+  int remove(@Nullable Object element, int occurrences) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Adds or removes the necessary occurrences of an element such that the

--- a/guava/src/com/google/common/graph/AbstractDirectedNodeConnections.java
+++ b/guava/src/com/google/common/graph/AbstractDirectedNodeConnections.java
@@ -57,11 +57,6 @@ abstract class AbstractDirectedNodeConnections<N, E> implements NodeConnections<
   }
 
   @Override
-  public Set<N> adjacentNodes() {
-    return Sets.union(predecessors(), successors());
-  }
-
-  @Override
   public Set<E> incidentEdges() {
     return new AbstractSet<E>() {
       @Override

--- a/guava/src/com/google/common/graph/AbstractGraph.java
+++ b/guava/src/com/google/common/graph/AbstractGraph.java
@@ -33,24 +33,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractGraph<N> implements Graph<N> {
 
   @Override
-  public int degree(Object node) {
-    // only works for non-multigraphs; multigraphs not yet supported
-    return adjacentNodes(node).size();
-  }
-
-  @Override
-  public int inDegree(Object node) {
-    // only works for non-multigraphs; multigraphs not yet supported
-    return predecessors(node).size();
-  }
-
-  @Override
-  public int outDegree(Object node) {
-    // only works for non-multigraphs; multigraphs not yet supported
-    return successors(node).size();
-  }
-
-  @Override
   public boolean equals(@Nullable Object object) {
     if (!(object instanceof Graph)) {
       return false;

--- a/guava/src/com/google/common/graph/AbstractUndirectedNodeConnections.java
+++ b/guava/src/com/google/common/graph/AbstractUndirectedNodeConnections.java
@@ -41,28 +41,8 @@ abstract class AbstractUndirectedNodeConnections<N, E> implements NodeConnection
   }
 
   @Override
-  public Set<N> predecessors() {
-    return adjacentNodes();
-  }
-
-  @Override
-  public Set<N> successors() {
-    return adjacentNodes();
-  }
-
-  @Override
   public Set<E> incidentEdges() {
     return Collections.unmodifiableSet(incidentEdgeMap.keySet());
-  }
-
-  @Override
-  public Set<E> inEdges() {
-    return incidentEdges();
-  }
-
-  @Override
-  public Set<E> outEdges() {
-    return incidentEdges();
   }
 
   @Override
@@ -83,13 +63,6 @@ abstract class AbstractUndirectedNodeConnections<N, E> implements NodeConnection
     checkNotNull(edge, "edge");
     N previousNode = incidentEdgeMap.remove(edge);
     return checkNotNull(previousNode);
-  }
-
-  @Override
-  public void addInEdge(E edge, N node, boolean isSelfLoop) {
-    if (!isSelfLoop) {
-      addOutEdge(edge, node);
-    }
   }
 
   @Override

--- a/guava/src/com/google/common/graph/Graph.java
+++ b/guava/src/com/google/common/graph/Graph.java
@@ -237,7 +237,10 @@ public interface Graph<N> {
    *
    * @throws IllegalArgumentException if {@code node} is not an element of this graph
    */
-  int degree(Object node);
+  default int degree(Object node) {
+    // only works for non-multigraphs; multigraphs not yet supported
+    return adjacentNodes(node).size();
+  }
 
   /**
    * Returns the number of incoming edges in this graph of {@code node}.  If this node has more than
@@ -245,7 +248,10 @@ public interface Graph<N> {
    *
    * @throws IllegalArgumentException if {@code node} is not an element of this graph
    */
-  int inDegree(Object node);
+  default int inDegree(Object node) {
+    // only works for non-multigraphs; multigraphs not yet supported
+    return predecessors(node).size();
+  }
 
   /**
    * Returns the number of outgoing edges in this graph of {@code node}.  If this node has more than
@@ -253,7 +259,10 @@ public interface Graph<N> {
    *
    * @throws IllegalArgumentException if {@code node} is not an element of this graph
    */
-  int outDegree(Object node);
+  default int outDegree(Object node) {
+    // only works for non-multigraphs; multigraphs not yet supported
+    return successors(node).size();
+  }
 
   /**
    * Returns {@code true} iff {@code object} is a graph that has the same node relationships

--- a/guava/src/com/google/common/graph/NodeConnections.java
+++ b/guava/src/com/google/common/graph/NodeConnections.java
@@ -16,6 +16,7 @@
 
 package com.google.common.graph;
 
+import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import java.util.Set;
@@ -29,17 +30,27 @@ import java.util.Set;
  */
 interface NodeConnections<N, E> {
 
-  Set<N> adjacentNodes();
+  default Set<N> adjacentNodes() {
+    return Sets.union(predecessors(), successors());
+  }
 
-  Set<N> predecessors();
+  default Set<N> predecessors() {
+    return adjacentNodes();
+  }
 
-  Set<N> successors();
+  default Set<N> successors() {
+    return adjacentNodes();
+  }
 
   Set<E> incidentEdges();
 
-  Set<E> inEdges();
+  default Set<E> inEdges() {
+    return incidentEdges();
+  }
 
-  Set<E> outEdges();
+  default Set<E> outEdges() {
+    return incidentEdges();
+  }
 
   /**
    * Returns the node that is opposite the origin node along {@code edge}.
@@ -71,7 +82,11 @@ interface NodeConnections<N, E> {
   /**
    * Add {@code edge} to the set of incoming edges. Implicitly adds {@code node} as a predecessor.
    */
-  void addInEdge(E edge, N node, boolean isSelfLoop);
+  default void addInEdge(E edge, N node, boolean isSelfLoop) {
+    if (!isSelfLoop) {
+      addOutEdge(edge, node);
+    }
+  }
 
   /**
    * Add {@code edge} to the set of outgoing edges. Implicitly adds {@code node} as a successor.

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This is a semantics-preserving refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

We have upgraded the compilation process to use Java 8 so that default methods can be used. However, we realize that this may not be acceptable. Still, any feedback you can supply would be helpful.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if each of the proposed changes are helpful or not.