### PR TITLE
while-statement did not loop

### DIFF
--- a/guava/src/com/google/common/collect/TreeRangeMap.java
+++ b/guava/src/com/google/common/collect/TreeRangeMap.java
@@ -448,7 +448,7 @@ public final class TreeRangeMap<K extends Comparable, V> implements RangeMap<K, 
 
             @Override
             protected Entry<Range<K>, V> computeNext() {
-              while (backingItr.hasNext()) {
+              if (backingItr.hasNext()) {
                 RangeMapEntry<K, V> entry = backingItr.next();
                 if (entry.getUpperBound().compareTo(subRange.lowerBound) <= 0) {
                   return endOfData();


### PR DESCRIPTION
A return statement occurred in the first
iteration of the loop making the loop
statement redundant, as it is semantically
equivalent to an if-statement.

Replaced the loop-statement with the
equivalent if.