### PR TITLE
Update Mockito version to 2.1.0-RC.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.8.5</version>
+        <version>2.1.0-RC.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Last week we released our first release candidate of Mockito 2.
This release should be backwards compatible with the codebase
of Google Guava.

To read about all changes in Mockito 2, check out
https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2

I have ran your test suite locally before and after this change and
did not discover any regressions nor test failures.
While this version is a release candidate, we are not planning
to introduce any changes for the final release. There might be
possible bug fixes included in the final release, but so far
we have not received any reports of regressions in our library.

Thank you for using Mockito and please let us know what you think!