### PR TITLE
Remove reference to a deprecated method

### DIFF
--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -268,7 +268,7 @@ public final class MoreExecutors {
     return new DirectExecutorService();
   }
 
-  // See sameThreadExecutor javadoc for behavioral notes.
+  // See newDirectExecutorService javadoc for behavioral notes.
   @GwtIncompatible // TODO
   private static final class DirectExecutorService extends AbstractListeningExecutorService {
     /**
@@ -316,7 +316,7 @@ public final class MoreExecutors {
       }
     }
 
-    // See sameThreadExecutor javadoc for unusual behavior of this method.
+    // See newDirectExecutorService javadoc for unusual behavior of this method.
     @Override
     public List<Runnable> shutdownNow() {
       shutdown();


### PR DESCRIPTION
I found these comments slightly confusing. (I also wonder whether you removed `sameThreadExecutor` internally, since it's scheduled for removal in August 2016, but I guess it means in "when Guava 20 is out".)