### PR TITLE
Apply IntelliJ-suggested language feature migrations.

### DIFF
--- a/guava/src/com/google/common/collect/ArrayTable.java
+++ b/guava/src/com/google/common/collect/ArrayTable.java
@@ -354,10 +354,8 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
    */
   @GwtIncompatible // reflection
   public V[][] toArray(Class<V> valueClass) {
-    // Can change to use varargs in JDK 1.6 if we want
     @SuppressWarnings("unchecked") // TODO: safe?
-    V[][] copy =
-        (V[][]) Array.newInstance(valueClass, new int[] {rowList.size(), columnList.size()});
+    V[][] copy = (V[][]) Array.newInstance(valueClass, rowList.size(), columnList.size());
     for (int i = 0; i < rowList.size(); i++) {
       System.arraycopy(array[i], 0, copy[i], 0, array[i].length);
     }

--- a/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
@@ -110,8 +110,7 @@ final class RegularImmutableSortedMultiset<E> extends ImmutableSortedMultiset<E>
     } else if (from == 0 && to == length) {
       return this;
     } else {
-      RegularImmutableSortedSet<E> subElementSet =
-          (RegularImmutableSortedSet<E>) elementSet.getSubSet(from, to);
+      RegularImmutableSortedSet<E> subElementSet = elementSet.getSubSet(from, to);
       return new RegularImmutableSortedMultiset<E>(
           subElementSet, cumulativeCounts, offset + from, to - from);
     }

--- a/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
@@ -162,9 +162,7 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
     if (SortedIterables.hasSameComparator(comparator, that)) {
       Iterator<?> otherIterator = that.iterator();
       try {
-        Iterator<E> iterator = iterator();
-        while (iterator.hasNext()) {
-          Object element = iterator.next();
+        for (E element : this) {
           Object otherElement = otherIterator.next();
           if (otherElement == null || unsafeCompare(element, otherElement) != 0) {
             return false;
@@ -177,7 +175,7 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
         return false; // concurrent change to other set
       }
     }
-    return this.containsAll(that);
+    return containsAll(that);
   }
 
   @Override

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -514,17 +514,15 @@ public final class BloomFilter<T> implements Predicate<T>, Serializable {
       }
       return new BloomFilter<T>(new BitArray(data), numHashFunctions, funnel, strategy);
     } catch (RuntimeException e) {
-      IOException ioException =
-          new IOException(
-              "Unable to deserialize BloomFilter from InputStream."
-                  + " strategyOrdinal: "
-                  + strategyOrdinal
-                  + " numHashFunctions: "
-                  + numHashFunctions
-                  + " dataLength: "
-                  + dataLength);
-      ioException.initCause(e);
-      throw ioException;
+      String message =
+          "Unable to deserialize BloomFilter from InputStream."
+              + " strategyOrdinal: "
+              + strategyOrdinal
+              + " numHashFunctions: "
+              + numHashFunctions
+              + " dataLength: "
+              + dataLength;
+      throw new IOException(message, e);
     }
   }
 }


### PR DESCRIPTION
All code which initializes an IOException with a cause exception now uses the appropriate constructor (which was introduced in Java 6), rather than initCause. Since Guava now depends on Java 6, this (as far as I can tell) is a safe change to make.

A change was made from using an Iterator to an enhanced for-loop for (arguably) improved readability and, by my understanding, no performance impact.

All other changes should hopefully be self-explanatory. :)