### PR TITLE
Replace unnecessary StringBuilder calls with String concat

### DIFF
--- a/guava/src/com/google/common/base/CaseFormat.java
+++ b/guava/src/com/google/common/base/CaseFormat.java
@@ -218,9 +218,6 @@ public enum CaseFormat {
   private static String firstCharOnlyToUpper(String word) {
     return (word.isEmpty())
         ? word
-        : new StringBuilder(word.length())
-            .append(Ascii.toUpperCase(word.charAt(0)))
-            .append(Ascii.toLowerCase(word.substring(1)))
-            .toString();
+        : Ascii.toUpperCase(word.charAt(0)) + Ascii.toLowerCase(word.substring(1));
   }
 }

--- a/guava/src/com/google/common/collect/GeneralRange.java
+++ b/guava/src/com/google/common/collect/GeneralRange.java
@@ -273,15 +273,13 @@ final class GeneralRange<T> implements Serializable {
 
   @Override
   public String toString() {
-    return new StringBuilder()
-        .append(comparator)
-        .append(":")
-        .append(lowerBoundType == CLOSED ? '[' : '(')
-        .append(hasLowerBound ? lowerEndpoint : "-\u221e")
-        .append(',')
-        .append(hasUpperBound ? upperEndpoint : "\u221e")
-        .append(upperBoundType == CLOSED ? ']' : ')')
-        .toString();
+    return comparator.toString()
+        + ":"
+        + (lowerBoundType == CLOSED ? '[' : '(')
+        + (hasLowerBound ? lowerEndpoint : "-\u221e")
+        + ','
+        + (hasUpperBound ? upperEndpoint : "\u221e")
+        + (upperBoundType == CLOSED ? ']' : ')');
   }
 
   T getLowerEndpoint() {

--- a/guava/src/com/google/common/collect/SingletonImmutableList.java
+++ b/guava/src/com/google/common/collect/SingletonImmutableList.java
@@ -60,12 +60,7 @@ final class SingletonImmutableList<E> extends ImmutableList<E> {
 
   @Override
   public String toString() {
-    String elementToString = element.toString();
-    return new StringBuilder(elementToString.length() + 2)
-        .append('[')
-        .append(elementToString)
-        .append(']')
-        .toString();
+    return '[' + element.toString() + ']';
   }
 
   @Override

--- a/guava/src/com/google/common/collect/SingletonImmutableSet.java
+++ b/guava/src/com/google/common/collect/SingletonImmutableSet.java
@@ -97,11 +97,6 @@ final class SingletonImmutableSet<E> extends ImmutableSet<E> {
 
   @Override
   public String toString() {
-    String elementToString = element.toString();
-    return new StringBuilder(elementToString.length() + 2)
-        .append('[')
-        .append(elementToString)
-        .append(']')
-        .toString();
+    return '[' + element.toString() + ']';
   }
 }


### PR DESCRIPTION
According to IntelliJ, these usages of StringBuilder can be simplified. By my understanding, this is because they do not contain any loops, and thus, as of Java 6, JVMs are able to optimize these concatenations into more-efficient StringBuilder calls at compile time. Thus this change improves readability without losing performance.