### PR TITLE
Update Mockito version to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.1.0-RC.1</version>
+        <version>2.1.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Mockito 2.1.0 is out! It should be a smooth upgrade from RC-1.