### PR TITLE
Fix google/guava#2599

### DIFF
--- a/guava/src/com/google/common/math/Quantiles.java
+++ b/guava/src/com/google/common/math/Quantiles.java
@@ -271,8 +271,7 @@ public final class Quantiles {
      *
      * @param dataset the dataset to do the calculation on, which must be non-empty, and which will
      *     be arbitrarily reordered by this method call
-     * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     * @return the quantile value
      */
     public double computeInPlace(double... dataset) {
       checkArgument(dataset.length > 0, "Cannot calculate quantiles of an empty dataset");


### PR DESCRIPTION
This change fixes a documentation error regarding the return type/value
of computeInPlace function.