### PR TITLE
fixes serialization errors when serializing a RegularImmutableAsList

### DIFF
--- a/guava-gwt/src/com/google/common/collect/RegularImmutableAsList_CustomFieldSerializer.java
+++ b/guava-gwt/src/com/google/common/collect/RegularImmutableAsList_CustomFieldSerializer.java
@@ -16,10 +16,13 @@
 
 package com.google.common.collect;
 
+import java.util.ArrayList;
+
 import com.google.common.annotations.GwtCompatible;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.SerializationStreamReader;
 import com.google.gwt.user.client.rpc.SerializationStreamWriter;
+import com.google.gwt.user.client.rpc.core.java.util.Collection_CustomFieldSerializerBase;
 
 /**
  * This class implements the server-side GWT serialization of
@@ -35,15 +38,14 @@ public class RegularImmutableAsList_CustomFieldSerializer {
 
   public static RegularImmutableAsList<Object> instantiate(SerializationStreamReader reader)
       throws SerializationException {
-    @SuppressWarnings("unchecked") // serialization is necessarily type unsafe
-    ImmutableCollection<Object> delegateCollection = (ImmutableCollection) reader.readObject();
-    ImmutableList<?> delegateList = (ImmutableList<?>) reader.readObject();
-    return new RegularImmutableAsList<Object>(delegateCollection, delegateList);
+    final ArrayList<Object> elements = new ArrayList<Object>();
+    Collection_CustomFieldSerializerBase.deserialize(reader, elements);
+    final ImmutableList<Object> delegate = ImmutableList.copyOf(elements);
+    return new RegularImmutableAsList<Object>(delegate, delegate);
   }
 
   public static void serialize(SerializationStreamWriter writer, RegularImmutableAsList<?> instance)
       throws SerializationException {
-    writer.writeObject(instance.delegateCollection());
-    writer.writeObject(instance.delegateList());
+    Collection_CustomFieldSerializerBase.serialize(writer, instance);
   }
 }


### PR DESCRIPTION
the issue occur when ImmutableList is included in gwt's serialization
policy and ImmutableSet not and a list created by ImmutableSet.asList
needs to be serialized

fixes #1841