### PR TITLE
Fix #1190

### DIFF
--- a/guava-tests/test/com/google/common/base/SplitterTest.java
+++ b/guava-tests/test/com/google/common/base/SplitterTest.java
@@ -383,6 +383,20 @@ public class SplitterTest extends TestCase {
   }
 
   @GwtIncompatible // java.util.regex.Pattern
+  public void testPatternSplitWordBoundary_singleCharInput() {
+    String string = "f";
+    Iterable<String> words = Splitter.on(Pattern.compile("\\b")).split(string);
+    assertThat(words).containsExactly("f").inOrder();
+  }
+
+  @GwtIncompatible // java.util.regex.Pattern
+  public void testPatternSplitWordBoundary_singleWordInput() {
+    String string = "foo";
+    Iterable<String> words = Splitter.on(Pattern.compile("\\b")).split(string);
+    assertThat(words).containsExactly("foo").inOrder();
+  }
+
+  @GwtIncompatible // java.util.regex.Pattern
   public void testPatternSplitEmptyToken() {
     String emptyToken = "a. .c";
     Iterable<String> letters = Splitter.on(literalDotPattern()).trimResults().split(emptyToken);

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -557,7 +557,7 @@ public final class Splitter {
            * of the next returned substring -- so nextStart stays the same.
            */
           offset++;
-          if (offset >= toSplit.length()) {
+          if (offset > toSplit.length()) {
             offset = -1;
           }
           continue;


### PR DESCRIPTION
Commit text body:

> Before this fix, splitting a single character input string with a
> Splitter.onPattern instance created with a zero-width regex pattern,
> would have caused the input string to be dropped from the output,
> resulting in an empty iterable being returned rather than a single
> element one.
> 
> This fix ensures that the input passes through untouched.
> 
> For example, whereas before in this code snippet, 'words' would have
> been initialized as an empty iterable...
> 
> ```
> String string = "f";
> Iterable<String> words =
>     Splitter.on(Pattern.compile("\\b")).split(string);
> // words is empty!
> ```
> 
> ...it is now initialized as ["f"].
