### PR TITLE
fix warning on eclipse4.6 (com.google.common.collect.MutableClassToInstanceMap)

### DIFF
--- a/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
@@ -127,7 +127,7 @@ public final class MutableClassToInstanceMap<B> extends ForwardingMap<Class<? ex
   @Override
   public void putAll(Map<? extends Class<? extends B>, ? extends B> map) {
     Map<Class<? extends B>, B> copy = new LinkedHashMap<Class<? extends B>, B>(map);
-    for (Entry<? extends Class<? extends B>, ? extends B> entry : copy.entrySet()) {
+    for (Entry<Class<? extends B>, B> entry : copy.entrySet()) {
       cast(entry.getKey(), entry.getValue());
     }
     super.putAll(copy);

--- a/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
@@ -127,7 +127,7 @@ public final class MutableClassToInstanceMap<B> extends ForwardingMap<Class<? ex
   @Override
   public void putAll(Map<? extends Class<? extends B>, ? extends B> map) {
     Map<Class<? extends B>, B> copy = new LinkedHashMap<Class<? extends B>, B>(map);
-    for (Entry<Class<? extends B>, B> entry : copy.entrySet()) {
+    for (Entry<? extends Class<? extends B>, B> entry : copy.entrySet()) {
       cast(entry.getKey(), entry.getValue());
     }
     super.putAll(copy);


### PR DESCRIPTION
Warning on eclipse , 

`
Bound mismatch: The generic method cast(Class<T>, B) of type MutableClassToInstanceMap<B> is not applicable for the arguments (capture#8-of ? extends Class<? extends B>, capture#12-of ? extends B). The inferred type capture#10-of ? extends B is not a valid substitute for the bounded parameter <T extends B>
`