### PR TITLE
Make SloppyTearDown.logger private.

### DIFF
--- a/guava-testlib/src/com/google/common/testing/SloppyTearDown.java
+++ b/guava-testlib/src/com/google/common/testing/SloppyTearDown.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 @Beta
 @GwtCompatible
 public abstract class SloppyTearDown implements TearDown {
-  public static final Logger logger =
+  private static final Logger logger =
       Logger.getLogger(SloppyTearDown.class.getName());
 
   @Override


### PR DESCRIPTION
Being public, it always gets into way of our class (import is done automatically by auto-importing tools).
It's not used anywhere else, so can be `private`.
If it's intended to be used by inheritance, then it can be `protected` as well.
If it really neede to be public, then it's better be available through a getter method.