### PR TITLE
Use a newer JDK 8 for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
+
+# https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-130860338
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 install: mvn -B install -U -DskipTests=true
 


### PR DESCRIPTION
The travis docker image uses JDK 8u31, which is ancient and has type
inference bugs that are fixed at head. This change causes it to use 8u111:

https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-130860338