### PR TITLE
Added the lastIndexOf method for the Bytes primitives class for both parameters as byte array types.

### DIFF
--- a/guava-tests/test/com/google/common/primitives/BytesTest.java
+++ b/guava-tests/test/com/google/common/primitives/BytesTest.java
@@ -119,6 +119,38 @@ public class BytesTest extends TestCase {
         (byte) 3));
   }
 
+  public void testLastIndexOf_arrayTarget() {
+    assertEquals(-1, Bytes.lastIndexOf(EMPTY, EMPTY));
+    assertEquals(ARRAY234.length - 1, Bytes.lastIndexOf(ARRAY234, EMPTY));
+    assertEquals(-1, Bytes.lastIndexOf(EMPTY, ARRAY234));
+    assertEquals(-1, Bytes.lastIndexOf(ARRAY234, ARRAY1));
+    assertEquals(-1, Bytes.lastIndexOf(ARRAY1, ARRAY234));
+    assertEquals(0, Bytes.lastIndexOf(ARRAY1, ARRAY1));
+    assertEquals(0, Bytes.lastIndexOf(ARRAY234, ARRAY234));
+    assertEquals(0, Bytes.lastIndexOf(
+            ARRAY234, new byte[] { (byte) 2, (byte) 3 }));
+    assertEquals(1, Bytes.lastIndexOf(
+            ARRAY234, new byte[] { (byte) 3, (byte) 4 }));
+    assertEquals(1, Bytes.lastIndexOf(ARRAY234, new byte[] { (byte) 3 }));
+    assertEquals(2, Bytes.lastIndexOf(ARRAY234, new byte[] { (byte) 4 }));
+    assertEquals(4, Bytes.lastIndexOf(
+            new byte[] { (byte) 2, (byte) 3, (byte) 3, (byte) 3, (byte) 3 },
+            new byte[] { (byte) 3 }
+    ));
+    assertEquals(2, Bytes.lastIndexOf(
+            new byte[] { (byte) 2, (byte) 3, (byte) 2, (byte) 3, (byte) 4, (byte) 2, (byte) 3},
+            new byte[] { (byte) 2, (byte) 3, (byte) 4}
+    ));
+    assertEquals(4, Bytes.lastIndexOf(
+            new byte[] { (byte) 2, (byte) 2, (byte) 3, (byte) 4, (byte) 2, (byte) 3, (byte) 4},
+            new byte[] { (byte) 2, (byte) 3, (byte) 4}
+    ));
+    assertEquals(-1, Bytes.lastIndexOf(
+            new byte[] { (byte) 4, (byte) 3, (byte) 2},
+            new byte[] { (byte) 2, (byte) 3, (byte) 4}
+    ));
+  }
+
   public void testConcat() {
     assertTrue(Arrays.equals(EMPTY, Bytes.concat()));
     assertTrue(Arrays.equals(EMPTY, Bytes.concat(EMPTY)));

--- a/guava/src/com/google/common/collect/RegularImmutableAsList.java
+++ b/guava/src/com/google/common/collect/RegularImmutableAsList.java
@@ -18,7 +18,6 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.j2objc.annotations.Weak;
 
 /**
  * An {@link ImmutableAsList} implementation specialized for when the delegate collection is
@@ -29,7 +28,7 @@ import com.google.j2objc.annotations.Weak;
 @GwtCompatible(emulated = true)
 @SuppressWarnings("serial") // uses writeReplace, not default serialization
 class RegularImmutableAsList<E> extends ImmutableAsList<E> {
-  @Weak private final ImmutableCollection<E> delegate;
+  private final ImmutableCollection<E> delegate;
   private final ImmutableList<? extends E> delegateList;
 
   RegularImmutableAsList(ImmutableCollection<E> delegate, ImmutableList<? extends E> delegateList) {

--- a/guava/src/com/google/common/primitives/Bytes.java
+++ b/guava/src/com/google/common/primitives/Bytes.java
@@ -152,6 +152,45 @@ public final class Bytes {
   }
 
   /**
+   * Returns the first position of the last occurrence of the specified {@code
+   * target} within {@code array}, or {@code -1} if there is no such occurrence.
+   *
+   * <p>More formally, returns the greatest index {@code i} such that
+   * {@code Arrays.copyOfRange(array, i, i + target.length)} contains exactly the same elements as
+   * {@code target}.
+   *
+   * @param array the array to search for the sequence {@code target}
+   * @param target the array to search for as a sub-sequence of {@code array}
+   */
+  public static int lastIndexOf(byte[] array, byte[] target) {
+    checkNotNull(array, "array");
+    checkNotNull(target, "target");
+    if (target.length == 0) {
+      return array.length - 1;
+    } else if (target.length > array.length) {
+      return -1;
+    }
+
+    int lastIndexOf = -1;
+    boolean differentValue;
+
+    for (int i = 0; i <= array.length - target.length; i++) {
+      differentValue = false;
+      for (int j = 0; j < target.length; j++) {
+        if (array[i + j] != target[j]) {
+          differentValue = true;
+          break;
+        }
+      }
+      if (!differentValue) {
+        lastIndexOf = i;
+      }
+    }
+
+    return lastIndexOf;
+  }
+
+  /**
    * Returns the values from each provided array combined into a single array. For example,
    * {@code concat(new byte[] {a, b}, new byte[] {}, new byte[] {c}} returns the array {@code {a, b,
    * c}}.


### PR DESCRIPTION
Added the lastIndexOf method which receives two byte array as parameters for the Bytes primitive class and its corresponding tests.

It is a fix for the issue #2617 .