### PR TITLE
Fix links to javadoc.io for Maven Javadoc Plugin

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -109,9 +109,9 @@
           <linksource>true</linksource>
           <links>
             <link>http://docs.oracle.com/javase/8/docs/api/</link>
-            <link>http://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/</link>
+            <link>http://static.javadoc.io/com.google.code.findbugs/jsr305/3.0.1/</link>
             <link>http://errorprone.info/api/latest/</link>
-            <link>http://javadoc.io/doc/com.google.j2objc/j2objc-annotations/1.1/</link>
+            <link>http://static.javadoc.io/com.google.j2objc/j2objc-annotations/1.1/</link>
           </links>
           <!-- TODO(cpovirk): can we use includeDependencySources and a local com.oracle.java:jdk-lib:noversion:sources instead of all this unzipping and manual sourcepath modification? -->
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>


### PR DESCRIPTION
Fixes #2479
Links must have a /package-list file