### PR TITLE
Now that the CanIgnoreReturnValue annotation is used throughout the code the dependency is no longer optional

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <optional>true</optional><!-- needed only for annotations -->
+      <optional>false</optional>
     </dependency>
     <dependency>
       <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
In version 20.0 the errorprone annotations are used throughout the codebase so the error_prone_annotations dependency is not optional anymore.