### PR TITLE
Implementation of #2113

### DIFF
--- a/guava-tests/test/com/google/common/base/RandomStringGeneratorTest.java
+++ b/guava-tests/test/com/google/common/base/RandomStringGeneratorTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2017 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.base;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import junit.framework.TestCase;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ *
+ * @author Olivier Grégoire
+ */
+public class RandomStringGeneratorTest extends TestCase {
+
+  private Random random = new Random(0L);
+  private static final CharMatcher DIGITS = CharMatcher.inRange('0', '9');
+  private static final CharMatcher LOWER_ALPHA = CharMatcher.inRange('a', 'z');
+  private static final CharMatcher UPPER_ALPHA = CharMatcher.inRange('A', 'Z');
+  private static final CharMatcher ALPHA = LOWER_ALPHA.or(UPPER_ALPHA);
+  private static final CharMatcher ALPHANUMERIC = ALPHA.or(DIGITS);
+  private static final CharMatcher SYMBOLS = CharMatcher.ascii()
+      .and(ALPHANUMERIC.negate())
+      .and(CharMatcher.inRange('\0', ' ').negate());
+
+  public void testGeneratedLength() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withCharacters("a")
+        .build(10, random);
+
+    for (int loop = 0; loop < 100; loop++) {
+      assertThat(generator.next().length(), is(10));
+    }
+  }
+
+  public void testRandom() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withLowercaseAsciiLetters()
+        .build(10, random);
+
+    Set<String> generated = new HashSet<>();
+    for (int loop = 0; loop < 100; loop++) {
+      generated.add(generator.next());
+    }
+    // 26^10 = 1.411671e+14 . 100 chances on 26^10 of duplicates. So it's very, very low. But still...
+    assertTrue(generated.size() >= 99); // Allow one duplicate, even though there are none with Random(0)
+  }
+
+  public void testLowerAlpha() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withLowercaseAsciiLetters()
+        .build(10, random);
+
+    doTestCharacters(generator, LOWER_ALPHA);
+  }
+
+  public void testUpperAlpha() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withUppercaseAsciiLetters()
+        .build(10, random);
+
+    doTestCharacters(generator, UPPER_ALPHA);
+  }
+
+  public void testDigits() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withAsciiDigits()
+        .build(10, random);
+
+    doTestCharacters(generator, DIGITS);
+  }
+
+  public void testSymbols() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withVisibleAsciiSymbols()
+        .build(10, random);
+
+    doTestCharacters(generator, SYMBOLS);
+  }
+
+  public void testAlphanumeric() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withUppercaseAsciiLetters()
+        .withLowercaseAsciiLetters()
+        .withAsciiDigits()
+        .build(10, random);
+
+    doTestCharacters(generator, ALPHANUMERIC);
+  }
+
+  public void testRange() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withRange('0', '9')
+        .build(10, random);
+
+    doTestCharacters(generator, DIGITS);
+  }
+
+  public void testMinimumQuantities() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withCharacters("-", 5)
+        .withLowercaseAsciiLetters()
+        .build(10, random);
+
+    CharMatcher isDash = CharMatcher.is('-');
+    CharMatcher isDashOrLowerAlpha = isDash.or(LOWER_ALPHA);
+
+    doTestCharacters(generator, isDashOrLowerAlpha);
+    for (int loop = 0; loop < 100; loop++) {
+      String generated = generator.next();
+      String dashes = isDash.retainFrom(generated);
+      assertTrue(dashes.length() >= 5);
+    }
+  }
+
+  public void testMinimumQuantitiesParametersFail() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withAsciiDigits(-1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("abc", -1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withLowercaseAsciiLetters(-1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withUppercaseAsciiLetters(-1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withRange('a', 'c', -1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withVisibleAsciiSymbols(-1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testRangeParametersFail() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withRange('z', 'a');
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withRange('z', 'a', 5);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testCharactersEmpty() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("");
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testWeighted() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withCharacters("aaaaaaaaab") // 9 'a', 1 'b'
+        .build(10, random);
+    testWeight(generator, 0.9, 0.1); // about 9 'a' for 1 'b'
+  }
+
+  public void testUnique() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withCharacters("aaaaaaaaab") // 9 'a', 1 'b'
+        .unique()
+        .build(10, random);
+    testWeight(generator, 0.5, 0.1); // about as much 'a' as 'b'
+  }
+
+  public void testAvoidSimilarChars() {
+    RandomStringGenerator generator = new RandomStringGenerator.Builder()
+        .withAsciiDigits()
+        .avoidSimilarAsciiCharacters()
+        .build(10, random);
+    CharMatcher digitsNoZeroNoOne = DIGITS.and(CharMatcher.anyOf("01").negate());
+    doTestCharacters(generator, digitsNoZeroNoOne);
+
+    generator = new RandomStringGenerator.Builder()
+        .withAsciiDigits()
+        .withLowercaseAsciiLetters()
+        .withUppercaseAsciiLetters()
+        .avoidSimilarAsciiCharacters()
+        .build(1000, random); // Bigger strings than usual to make sure they should be present, but aren't
+    CharMatcher noSimilarCharacter = ALPHANUMERIC.and(CharMatcher.anyOf("01IOl").negate());
+    doTestCharacters(generator, noSimilarCharacter);
+  }
+
+  public void testAvoidSimilarCharsWithSimilarChars() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("IO10") // Letter i uppercase, letter o uppercase, digit one, digit zero
+          .avoidSimilarAsciiCharacters()
+          .build(10);
+
+      fail("Expected IllegalStateException, but suceeded");
+    } catch (IllegalStateException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalStateException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testBuildParameters() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("abc")
+          .build(-1);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("abc")
+          .build(1, null);
+      fail("Expected NullPointerException, but suceeded");
+    } catch (NullPointerException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected NullPointerException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testBuildNoCallOfWithMethods() {
+    try {
+      new RandomStringGenerator.Builder()
+          .build(10);
+      fail("Expected IllegalStateException, but suceeded");
+    } catch (IllegalStateException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalStateException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  public void testSizeLowerThanMinimumQuantities() {
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("a", 4)
+          .build(2);
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+    try {
+      new RandomStringGenerator.Builder()
+          .withCharacters("a", 3)
+          .withCharacters("b", 3)
+          .build(5); // bigger than each, lower than sum
+      fail("Expected IllegalArgumentException, but suceeded");
+    } catch (IllegalArgumentException e) {
+      // success
+    } catch (Exception e) {
+      fail("Expected IllegalArgumentException, got " + e.getClass().getSimpleName());
+    }
+  }
+
+  private void testWeight(RandomStringGenerator generator, double expectedARatio, double delta) {
+    int as = 0;
+    int bs = 0;
+    for (int loop = 0; loop < 100; loop++) {
+      String generated = generator.next();
+      for (int index = 0; index < generated.length(); index++) {
+        char character = generated.charAt(index);
+        if (character == 'a') {
+          as++;
+        } else if (character == 'b') {
+          bs++;
+        } else {
+          fail("Not 'a' or 'b'");
+        }
+      }
+    }
+    assertThat(as + bs, is(1000));
+    double aRatio = as / 1000.0d;
+    assertEquals(expectedARatio, aRatio, delta);
+  }
+
+  private void doTestCharacters(RandomStringGenerator generator, CharMatcher matcher) {
+    for (int loop = 0; loop < 100; loop++) {
+      String generated = generator.next();
+      for (int index = 0; index < generated.length(); index++) {
+        char character = generated.charAt(index);
+        assertTrue(matcher.matches(character));
+      }
+    }
+  }
+}

--- a/guava/src/com/google/common/base/RandomStringGenerator.java
+++ b/guava/src/com/google/common/base/RandomStringGenerator.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2017 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.base;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.primitives.Chars;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * This class allows the generation of random {@code String}s within flexible parameters.
+ *
+ * <pre>
+ * {@code
+ *   RandomStringGenerator generator = new RandomStringGenerator()
+ *       .withLowercaseAsciiLetters()
+ *       .withAsciiDigits()
+ *       .build();
+ *   for (int i = 0; i &lt; 10; i++) {
+ *     System.out.println(generator.next());
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>
+ * By default, no check is done on the quantity a character is present, so if a generator has to
+ * look through {@code "aaab"}, {@code 'a'} has three times the chances of {@code 'b'} to appear. If
+ * this behavior is undesired, {@link Builder#unique()} must be called on the builder.
+ *
+ * <p>
+ * A possibility exists to avoid ascii characters that looks similar to each other. Calling {@link Builder#avoidSimilarAsciiCharacters()
+ * } on the builder will ensure that those characters do not appear. The list of those characters is
+ * the following:
+ *
+ * <ul>
+ * <li>{@code 0} (Digit zero, ASCII 0x30}</li>
+ * <li>{@code 1} (Digit one, ASCII 0x31}</li>
+ * <li>{@code I} (Uppercase letter i, ASCII 0x49}</li>
+ * <li>{@code O} (Uppercase letter o, ASCII 0x4F}</li>
+ * <li>{@code l} (Lowercase letter L, ASCII 0x6C}</li>
+ * </ul>
+ *
+ * <p>
+ * Note regarding performance: this class internally uses {@code Random}. So for a multithreaded
+ * environment, please note that the performances can be impacted, as mentioned in {@link Random}.
+ *
+ * @author Olivier Grégoire
+ */
+@ThreadSafe
+public class RandomStringGenerator implements Supplier<String> {
+
+  private static final CharMatcher SIMILAR_ASCII_CHARS = CharMatcher.anyOf("0O1Il");
+
+  private final int size;
+  private final Random random;
+  private final char[] allChars;
+  private final ImmutableMultiset<String> requiredChars;
+
+  private RandomStringGenerator(Builder builder, int size, Random random) {
+    this.size = size;
+    this.random = random;
+    StringBuilder chars = new StringBuilder();
+    ImmutableMultiset.Builder<String> requiredCharsBuilder = ImmutableMultiset.builder();
+    Set<Character> uniqueChars = new LinkedHashSet<>();
+    for (Map.Entry<String, Integer> rule : builder.chars.entrySet()) {
+      String characters = rule.getKey();
+      Integer amount = rule.getValue();
+      if (builder.avoidSimilarAsciiCharacters) {
+        characters = SIMILAR_ASCII_CHARS.removeFrom(characters);
+      }
+      if (builder.unique) {
+        Set<Character> uniques = new LinkedHashSet<>(Chars.asList(characters.toCharArray()));
+        uniqueChars.addAll(uniques);
+        characters = new String(Chars.toArray(uniques));
+      } else {
+        chars.append(characters);
+      }
+      if (amount != null) {
+        requiredCharsBuilder.addCopies(characters, amount);
+      }
+    }
+    if (builder.unique) {
+      this.allChars = Chars.toArray(uniqueChars);
+    } else {
+      this.allChars = chars.toString().toCharArray();
+    }
+    this.requiredChars = requiredCharsBuilder.build();
+  }
+
+  /**
+   * Provided only to satisfy the {@link Supplier} interface; use {@link #next() } instead.
+   *
+   * @return a new random {@code String} within the limits imposed to this object.
+   * @deprecated
+   */
+  @Override
+  @Deprecated
+  public String get() {
+    return next();
+  }
+
+  /**
+   * Generates a new random {@code String} within the limits imposed to this object by the builder.
+   *
+   * @return a new random {@code String}.
+   */
+  public String next() {
+    char[] chars = new char[size];
+    int index = 0;
+
+    // Add all required rules.
+    for (Multiset.Entry<String> required : requiredChars.entrySet()) {
+      for (int i = 0; i < required.getCount(); i++) {
+        String pool = required.getElement();
+        chars[index] = pool.charAt(random.nextInt(pool.length()));
+        index++;
+      }
+    }
+
+    for (; index < size; index++) {
+      chars[index] = allChars[random.nextInt(allChars.length)];
+    }
+
+    // If there are minimum letters requirements, they were added as first char. Shuffle is needed.
+    if (!requiredChars.isEmpty()) {
+      for (int i = chars.length - 1; i > 0; i--) {
+        int pos = random.nextInt(i + 1);
+        char swap = chars[pos];
+        chars[pos] = chars[i];
+        chars[i] = swap;
+      }
+    }
+    return new String(chars);
+  }
+
+  /**
+   * Builds new generators based on the rules it has.
+   */
+  public static class Builder {
+
+    private static final String ASCII_ALPHA_LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+    private static final String ASCII_ALPHA_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String ASCII_DIGITS = "0123456789";
+    private static final String ASCII_SYMBOLS = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
+    private final Map<String, Integer> chars = new HashMap<>();
+    private boolean unique = false;
+    private boolean avoidSimilarAsciiCharacters = false;
+    private int countRequiredCharacters = 0;
+
+    /**
+     * Creates a new {@code Builder}.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Add the letters {@code abcdefghijklmnopqrstuvwxyz} to the pool of characters to use in the
+     * generator.
+     *
+     * @return this {@code Builder}
+     */
+    public Builder withLowercaseAsciiLetters() {
+      return addCharacters(ASCII_ALPHA_LOWERCASE, null);
+    }
+
+    /**
+     * Adds the letters {@code abcdefghijklmnopqrstuvwxyz} to the pool of characters to use in the
+     * generator, and indicates that at least {@code minimumQuantity} characters of the generated
+     * {@code String} must be from this pool.
+     *
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     */
+    public Builder withLowercaseAsciiLetters(int minimumQuantity) {
+      return addCharacters(ASCII_ALPHA_LOWERCASE, minimumQuantity);
+    }
+
+    /**
+     * Adds the letters {@code ABCDEFGHIJKLMNOPQRSTUVWXYZ} to the pool of characters to use in the
+     * generator.
+     *
+     * @return this {@code Builder}
+     */
+    public Builder withUppercaseAsciiLetters() {
+      return addCharacters(ASCII_ALPHA_UPPERCASE, null);
+    }
+
+    /**
+     * Adds the letters {@code ABCDEFGHIJKLMNOPQRSTUVWXYZ} to the pool of characters to use in the
+     * generator, and indicates that at least {@code minimumQuantity} characters of the generated
+     * {@code String} must be from this pool.
+     *
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     */
+    public Builder withUppercaseAsciiLetters(int minimumQuantity) {
+      return addCharacters(ASCII_ALPHA_UPPERCASE, minimumQuantity);
+    }
+
+    /**
+     * Adds the digits {@code 0123456789} to the pool of characters to use in the generator.
+     *
+     * @return this {@code Builder}
+     */
+    public Builder withAsciiDigits() {
+      return addCharacters(ASCII_DIGITS, null);
+    }
+
+    /**
+     * Adds the digits {@code 0123456789} to the pool of characters to use in the generator, and
+     * indicates that at least {@code minimumQuantity} characters of the generated {@code String}
+     * must be from this pool.
+     *
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     */
+    public Builder withAsciiDigits(int minimumQuantity) {
+      return addCharacters(ASCII_DIGITS, minimumQuantity);
+    }
+
+    /**
+     * Adds the symbols {@code !\"#$%&'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~} to the pool of characters
+     * to use in the generator.
+     *
+     * @return this {@code Builder}
+     */
+    public Builder withVisibleAsciiSymbols() {
+      return addCharacters(ASCII_SYMBOLS, null);
+    }
+
+    /**
+     * Adds the symbols {@code !\"#$%&'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~} to the pool of characters
+     * to use in the generator, and indicates that at least {@code minimumQuantity} characters of
+     * the generated {@code String} must be from this pool.
+     *
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     */
+    public Builder withVisibleAsciiSymbols(int minimumQuantity) {
+      return addCharacters(ASCII_SYMBOLS, minimumQuantity);
+    }
+
+    /**
+     * Adds the custom {@code characters} to the pool of characters to use in the generator.
+     *
+     * @param characters the characters to be added to the character pool of the generated
+     * {@code String}s.
+     * @return this {@code Builder}
+     * @throws IllegalArgumentException if {@code charaters} is empty ({@code ""}).
+     */
+    public Builder withCharacters(String characters) {
+      checkNotNull(characters);
+      checkArgument(!characters.isEmpty());
+      return addCharacters(checkNotNull(characters), null);
+    }
+
+    /**
+     * Adds the custom {@code characters} to the pool of characters to use in the generator, and
+     * indicates that at least {@code minimumQuantity} characters of the generated {@code String}
+     * must be from this pool.
+     *
+     * @param characters the characters to be added to the character pool of the generated
+     * {@code String}s.
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     * @throws IllegalArgumentException if {@code charaters} is empty ({@code ""}).
+     */
+    public Builder withCharacters(String characters, int minimumQuantity) {
+      checkNotNull(characters);
+      checkArgument(!characters.isEmpty());
+      return addCharacters(characters, minimumQuantity);
+    }
+
+    /**
+     * Adds the characters in the range {@code [ from , to ]} (both inclusive) to the pool of
+     * characters to use in the generator.
+     *
+     * @param from the starting character, inclusive
+     * @param to the ending character, inclusive
+     * @return this {@code Builder}
+     * @throws IllegalArgumentException if {@code to &lt; from}
+     */
+    public Builder withRange(char from, char to) {
+      return addCharacters(rangeAsString(from, to), null);
+    }
+
+    /**
+     * Adds the characters in the range {@code [ from , to ]} (both inclusive) to the pool of
+     * characters to use in the generator, and indicates that at least {@code minimumQuantity}
+     * characters of the generated {@code String} must be from this pool.
+     *
+     * @param from the starting character, inclusive
+     * @param to the ending character, inclusive
+     * @param minimumQuantity the number of letters from this pool that must appear in the generated
+     * {@code String}.
+     * @return this {@code Builder}
+     * @throws IllegalArgumentException if {@code to &lt; from}
+     */
+    public Builder withRange(char from, char to, int minimumQuantity) {
+      return addCharacters(rangeAsString(from, to), minimumQuantity);
+    }
+
+    private String rangeAsString(char from, char to) {
+      checkArgument(from <= to);
+      int size = to - from + 1;
+      char[] range = new char[size];
+      for (int i = 0; i < range.length; i++, from++) {
+        range[i] = from;
+      }
+      return new String(range);
+    }
+
+    private Builder addCharacters(String characters, Integer minimumQuantity) {
+      checkArgument(minimumQuantity == null || minimumQuantity > 0,
+          "minimumQuantity (%s) must be strictly positive", minimumQuantity);
+      chars.put(characters, minimumQuantity);
+      if (minimumQuantity != null) {
+        countRequiredCharacters += minimumQuantity;
+      }
+      return this;
+    }
+
+    /**
+     * Makes sure that the number of times a character is provided has no influence on its weight:
+     * each unique character has an equal chance to appear in the generated {@code String}
+     *
+     * @return this {@code Builder}
+     */
+    public Builder unique() {
+      unique = true;
+      return this;
+    }
+
+    /**
+     * <p>
+     * Tells the builder that the following characters will be removed from the generated Strings:
+     *
+     * <ul>
+     * <li>{@code 0} (Digit zero, ASCII 0x30}</li>
+     * <li>{@code 1} (Digit one, ASCII 0x31}</li>
+     * <li>{@code I} (Uppercase letter i, ASCII 0x49}</li>
+     * <li>{@code O} (Uppercase letter o, ASCII 0x4F}</li>
+     * <li>{@code l} (Lowercase letter L, ASCII 0x6C}</li>
+     * </ul>
+     *
+     * @return this {@code Builder}
+     */
+    public Builder avoidSimilarAsciiCharacters() {
+      avoidSimilarAsciiCharacters = true;
+      return this;
+    }
+
+    /**
+     * Builds a new {@code RandomStringGenerator} with the defined size.
+     *
+     * @param size the size of the {@code String}s to generate
+     * @return a new {@code RandomStringGenerator} with the defined size.
+     * @throws IllegalArgumentException if the size is lower than or equal to {@code 0} or if size
+     * is lower than the sum of all {@code minimumQuantity} parameters added when building the
+     * generator.
+     * @throws IllegalStateException if no {@code with*} method was called or if a
+     * {@code withCharacters(String)} and {@code avoidSimilarAsciiCharacters()} cancel each other
+     */
+    public RandomStringGenerator build(int size) {
+      checkBuild(size);
+      return new RandomStringGenerator(this, size, new Random());
+    }
+
+    /**
+     * Builds a new {@code RandomStringGenerator} with the defined size and {@code Random}.
+     *
+     * @param size the size of the {@code String}s to generate
+     * @param random the random to use when generating {@code String}s.
+     * @return a new {@code RandomStringGenerator} with the defined size.
+     * @throws NullPointerException if {@code random} is {@code null}.
+     * @throws IllegalArgumentException if the size is lower than or equal to {@code 0} or if size
+     * is lower than the sum of all {@code minimumQuantity} parameters added when building the
+     * generator.
+     * @throws IllegalStateException if no {@code with*} method was called or if a
+     * {@code withCharacters(String [, int])} and {@code avoidSimilarAsciiCharacters()} cancel each
+     * other
+     */
+    public RandomStringGenerator build(int size, Random random) {
+      checkNotNull(random, "random must not be null");
+      checkBuild(size);
+      return new RandomStringGenerator(this, size, random);
+    }
+
+    private void checkBuild(int size) {
+      checkArgument(size >= countRequiredCharacters,
+          "size (%s) is too low compared to the minimum number of characters (%s)",
+          size, countRequiredCharacters);
+      checkState(!chars.isEmpty(), "No character definition was added to this builder");
+
+      if (avoidSimilarAsciiCharacters) {
+        for (String key : chars.keySet()) {
+          checkState(!SIMILAR_ASCII_CHARS.removeFrom(key).isEmpty(),
+              "withCharacters(%s) and avoidSimilarAsciiCharacters() cancel each other and may not be called together");
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a standard and clean implementation for a random string generation API.

    RandomStringGenerator generator = new RandomStringGenerator.Builder()
      .withLowercaseAsciiLetters()
      .withAsciiDigits(1)
      .withCharacters("!@#")
      .build(10);
    for (int i = 0; i < 100; i++) {
      String generated = generator.next();
      // generated is guaranteed to have 10 characters of which at least one digit
    }

There are a few choice that guided my implementation:

1. It must implement `Supplier`.
2. The configuration must be in the builder to allow a clean and simple API. The builder is necessary instead of a `Splitter`-like or `CharMatcher`-like API because we don't know which characters to provide by default and providing those methods at starting points make it overly complex.
3. A user-provided random had to be providable.
4. The implementation had to be thread-safe.
5. I discarded the idea of a variable length String generator because that would have been very difficult to implement, and is overkill. People usually want to generate `String`s of the same length. If not, one can still keep the `Builder` and create several generators.
6. There had to be a "similar characters" discarder.
7. `"aaab"` would have to give 3 times more `a` than `b` by default, and a method had to exist to leave the possibility to give each char the same weight.