### PR TITLE
Introduce ImmutableMap#mergeMapsCollector

### DIFF
--- a/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -646,6 +646,21 @@ public class ImmutableMapTest extends TestCase {
               mapEntry("three", 3),
               mapEntry("two", 2));
     }
+
+    public void testMergeMapsCollector() {
+      Collector<? super Map<String, Integer>, ?, ImmutableMap<String, Integer>> collector =
+          ImmutableMap.mergeMapsCollector();
+      Equivalence<ImmutableMap<String, Integer>> equivalence =
+          Equivalence.equals()
+              .<Entry<String, Integer>>pairwise()
+              .onResultOf(ImmutableMap::entrySet);
+      CollectorTester.of(collector, equivalence)
+          .expectCollects(
+              ImmutableMap.of("one", 1, "two", 2, "three", 3, "four", 4),
+              ImmutableMap.of("one", 1, "two", 2),
+              ImmutableMap.of("three", 3, "four", 4)
+          );
+    }
   }
 
   public void testNullGet() {

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -103,6 +103,18 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
   }
 
   /**
+   * Returns a {@link Collector} that accumulates elements into an {@link ImmutableMap} taking
+   * all the entries of all the encountered {@link Map}.
+   */
+  public static <K, V> Collector<? super Map<K, V>, ?, ImmutableMap<K, V>> mergeMapsCollector() {
+    return Collector.of(
+            ImmutableMap.Builder<K, V>::new,
+            ImmutableMap.Builder::putAll,
+            ImmutableMap.Builder::combine,
+            ImmutableMap.Builder::build);
+  }
+
+  /**
    * Returns the empty map. This map behaves and performs comparably to
    * {@link Collections#emptyMap}, and is preferable mainly for consistency
    * and maintainability of your code.


### PR DESCRIPTION
Introduce a Collector to ease merging of Maps with java stream API.

Given (random Maps implementations used to ensure collector is generic):
```java
HashMap<String, Integer> foo = new LinkedHashMap<>();
foo.put("one", 1);
foo.put("two", 2);
NavigableMap<String, Integer> bar = new TreeMap<>();
bar.put("three", 3);
bar.put("four", 4);
Stream<Map<String, Integer>> stream = ImmutableSet.of(foo, bar).stream();
```

This code:
```java
ImmutableMap<String, Integer> collectedTheOldWay = stream
        .map(Map::entrySet)
        .flatMap(Set::stream)
        .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
```
can now be done with:
```java
ImmutableMap<String, Integer> collected = stream.collect(ImmutableMap.mergeMapsCollector());
```