### PR TITLE
Add Throwables.propagateIf

### DIFF
--- a/guava-tests/test/com/google/common/base/ThrowablesTest.java
+++ b/guava-tests/test/com/google/common/base/ThrowablesTest.java
@@ -323,6 +323,29 @@ public class ThrowablesTest extends TestCase {
         SomeUncheckedException.class);
   }
 
+  @GwtIncompatible // propagateIfPossible(Expression, Supplier)
+  public void testPropageIf_null() throws SomeCheckedException {
+    try {
+      Throwables.propagateIf(false, null);
+      fail();
+    } catch (NullPointerException e){
+    }
+  }
+
+  @GwtIncompatible // propagateIfPossible(Expression, Supplier)
+  public void testPropageIf_FalseExpression() throws SomeCheckedException {
+    Throwables.propagateIf(false, () -> new SomeCheckedException());
+  }
+
+  @GwtIncompatible // propagateIfPossible(Expression, Supplier)
+  public void testPropageIf_TrueExpression() throws SomeCheckedException {
+    try {
+      Throwables.propagateIf(true, () -> new SomeCheckedException());
+      fail();
+    } catch (SomeCheckedException e) {
+    }
+  }
+
   @GwtIncompatible // propagate
   public void testPropagate_NoneDeclared_NoneThrown() {
     Sample sample = new Sample() {

--- a/guava/src/com/google/common/base/Throwables.java
+++ b/guava/src/com/google/common/base/Throwables.java
@@ -205,6 +205,25 @@ public final class Throwables {
   }
 
   /**
+   * Propagates supplied {@code throwable} exactly as-is, if and only if the expression is truth. Example
+   * usage:
+   *
+   * <pre>
+   * Throwables.propagateIf(!optional.isPresent(), () -> new Exception());
+   * </pre>
+   *
+   * @param expression a boolean expression
+   * @param supplier a Throwable supplier
+   */
+  @GwtIncompatible
+  public static <X extends Throwable> void propagateIf(boolean expression, Supplier<X> supplier) throws X {
+    checkNotNull(supplier);
+    if (expression) {
+      throw supplier.get();
+    }
+  }
+
+  /**
    * Propagates {@code throwable} as-is if it is an instance of {@link RuntimeException} or {@link
    * Error}, or else as a last resort, wraps it in a {@code RuntimeException} and then propagates.
    *


### PR DESCRIPTION
In a normal application is common to throw an exception after eval an expression like

```
if (balance < amount) {
   throw new InsufficientFundsException();
}
```

```
if (!optional.isPresent()) {
  throw new NotFoundException();
}
```

This PR aims to get rid of those boilerplate code with propagateIf

```
Throwables.propagateIf(balance < amount, () -> new InsufficientFundsException());
Throwables.propagateIf(!optional.isPresent(), () -> new NotFoundException());
```

