### PR TITLE
Remove broken link in JavaDoc of CharMatcher

### DIFF
--- a/android/guava/src/com/google/common/base/CharMatcher.java
+++ b/android/guava/src/com/google/common/base/CharMatcher.java
@@ -121,9 +121,7 @@ public abstract class CharMatcher implements Predicate<Character> {
    * Determines whether a character is whitespace according to the latest Unicode standard, as
    * illustrated
    * <a href="http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bwhitespace%7D">here</a>.
-   * This is not the same definition used by other Java APIs. (See a
-   * <a href="http://spreadsheets.google.com/pub?key=pd8dAQyHbdewRsnE5x5GzKQ">comparison of several
-   * definitions of "whitespace"</a>.)
+   * This is not the same definition used by other Java APIs.
    *
    * <p><b>Note:</b> as the Unicode definition evolves, we will modify this matcher to keep it up to
    * date.
@@ -258,9 +256,7 @@ public abstract class CharMatcher implements Predicate<Character> {
    * Determines whether a character is whitespace according to the latest Unicode
    * standard, as illustrated
    * <a href="http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bwhitespace%7D">here</a>.
-   * This is not the same definition used by other Java APIs. (See a
-   * <a href="http://spreadsheets.google.com/pub?key=pd8dAQyHbdewRsnE5x5GzKQ">
-   * comparison of several definitions of "whitespace"</a>.)
+   * This is not the same definition used by other Java APIs.
    *
    * <p><b>Note:</b> as the Unicode definition evolves, we will modify this constant
    * to keep it up to date.

--- a/guava/src/com/google/common/base/CharMatcher.java
+++ b/guava/src/com/google/common/base/CharMatcher.java
@@ -121,9 +121,7 @@ public abstract class CharMatcher implements Predicate<Character> {
    * Determines whether a character is whitespace according to the latest Unicode standard, as
    * illustrated
    * <a href="http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bwhitespace%7D">here</a>.
-   * This is not the same definition used by other Java APIs. (See a
-   * <a href="http://spreadsheets.google.com/pub?key=pd8dAQyHbdewRsnE5x5GzKQ">comparison of several
-   * definitions of "whitespace"</a>.)
+   * This is not the same definition used by other Java APIs.
    *
    * <p><b>Note:</b> as the Unicode definition evolves, we will modify this matcher to keep it up to
    * date.
@@ -258,9 +256,7 @@ public abstract class CharMatcher implements Predicate<Character> {
    * Determines whether a character is whitespace according to the latest Unicode
    * standard, as illustrated
    * <a href="http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5Cp%7Bwhitespace%7D">here</a>.
-   * This is not the same definition used by other Java APIs. (See a
-   * <a href="http://spreadsheets.google.com/pub?key=pd8dAQyHbdewRsnE5x5GzKQ">
-   * comparison of several definitions of "whitespace"</a>.)
+   * This is not the same definition used by other Java APIs.
    *
    * <p><b>Note:</b> as the Unicode definition evolves, we will modify this constant
    * to keep it up to date.


### PR DESCRIPTION
The linked Google Spreadsheet is no longer available (at least externally). I think it's fine to remove since the link to unicode.org details which codepoints are defined as whitespace.

Also, I double checked, and the list hasn't changed compared to what's used in CharMatchers.