### PR TITLE
ImmediateEventBus that uses Dispatcher.IMMEDIATE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ out/
 .project
 .settings/
 .metadata/
+.recommenders/
 
 # OS X
 .DS_Store

--- a/guava-tests/test/com/google/common/eventbus/ImmediateEventBusTest.java
+++ b/guava-tests/test/com/google/common/eventbus/ImmediateEventBusTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.eventbus;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import junit.framework.TestCase;
+
+/**
+ * Test case for {@link ImmediateEventBus}.
+ *
+ * @author David Rain
+ */
+public class ImmediateEventBusTest extends TestCase {
+
+  static final String FIRST = "one";
+  static final Double SECOND = 2.0d;
+
+  final EventBus bus = new ImmediateEventBus("x");
+
+  public void testNoReentrantEvents() {
+    ReentrantEventsHater hater = new ReentrantEventsHater();
+    bus.register(hater);
+
+    bus.post(FIRST);
+
+    assertEquals("ReentrantEventHater expected 2 events", Lists.<Object>newArrayList(SECOND, FIRST),
+        hater.eventsReceived);
+  }
+
+  public class ReentrantEventsHater {
+    boolean ready = true;
+    List<Object> eventsReceived = Lists.newArrayList();
+
+    @Subscribe
+    public void listenForStrings(String event) {
+      bus.post(SECOND);
+      eventsReceived.add(event);
+    }
+
+    @Subscribe
+    public void listenForDoubles(Double event) {
+      eventsReceived.add(event);
+    }
+  }
+
+  public void testEventOrderingIsPredictable() {
+    EventProcessor processor = new EventProcessor();
+    bus.register(processor);
+
+    EventRecorder recorder = new EventRecorder();
+    bus.register(recorder);
+
+    bus.post(FIRST);
+
+    assertEquals("EventRecorder expected events in order", Lists.<Object>newArrayList(SECOND, FIRST),
+        recorder.eventsReceived);
+  }
+
+  public class EventProcessor {
+    @Subscribe
+    public void listenForStrings(String event) {
+      bus.post(SECOND);
+    }
+  }
+
+  public class EventRecorder {
+    List<Object> eventsReceived = Lists.newArrayList();
+
+    @Subscribe
+    public void listenForEverything(Object event) {
+      eventsReceived.add(event);
+    }
+  }
+}

--- a/guava-tests/test/com/google/common/eventbus/ImmediateEventBusTest.java
+++ b/guava-tests/test/com/google/common/eventbus/ImmediateEventBusTest.java
@@ -32,7 +32,7 @@ public class ImmediateEventBusTest extends TestCase {
   static final String FIRST = "one";
   static final Double SECOND = 2.0d;
 
-  final EventBus bus = new ImmediateEventBus("x");
+  final EventBus bus = new ImmediateEventBus("default");
 
   public void testNoReentrantEvents() {
     ReentrantEventsHater hater = new ReentrantEventsHater();

--- a/guava/src/com/google/common/eventbus/ImmediateEventBus.java
+++ b/guava/src/com/google/common/eventbus/ImmediateEventBus.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.eventbus;
+
+import com.google.common.annotations.Beta;
+import com.google.common.eventbus.EventBus.LoggingHandler;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.util.concurrent.Executor;
+
+/**
+ * An {@link EventBus} that takes the Executor of your choice and uses it to
+ * dispatch events to subscribers immediately as they're posted without using an
+ * intermediate queue to change the dispatch order.
+ * 
+ * @see Dispatcher#immediate()
+ *
+ * @author David Rain
+ * @since 22.0
+ */
+@Beta
+public class ImmediateEventBus extends EventBus {
+  /**
+   * Creates a new ImmediateEventBus with the given {@code identifier}.
+   *
+   * @param identifier
+   *          a brief name for this bus, for logging purposes. Should be a valid
+   *          Java identifier.
+   */
+  public ImmediateEventBus(String identifier) {
+    super(identifier, MoreExecutors.directExecutor(), Dispatcher.immediate(), LoggingHandler.INSTANCE);
+  }
+
+  /**
+   * Creates a new ImmediateEventBus that will use {@code executor} to dispatch
+   * events. Assigns {@code identifier} as the bus's name for logging purposes.
+   *
+   * @param identifier
+   *          short name for the bus, for logging purposes.
+   * @param executor
+   *          Executor to use to dispatch events. It is the caller's
+   *          responsibility to shut down the executor after the last event has
+   *          been posted to this event bus.
+   */
+  public ImmediateEventBus(String identifier, Executor executor) {
+    super(identifier, executor, Dispatcher.immediate(), LoggingHandler.INSTANCE);
+  }
+
+  /**
+   * Creates a new ImmediateEventBus that will use {@code executor} to dispatch
+   * events.
+   *
+   * @param executor
+   *          Executor to use to dispatch events. It is the caller's
+   *          responsibility to shut down the executor after the last event has
+   *          been posted to this event bus.
+   * @param subscriberExceptionHandler
+   *          Handler used to handle exceptions thrown from subscribers. See
+   *          {@link SubscriberExceptionHandler} for more information.
+   * @since 16.0
+   */
+  public ImmediateEventBus(Executor executor, SubscriberExceptionHandler subscriberExceptionHandler) {
+    super("default", executor, Dispatcher.immediate(), subscriberExceptionHandler);
+  }
+
+  /**
+   * Creates a new ImmediateEventBus that will use {@code executor} to dispatch
+   * events.
+   *
+   * @param executor
+   *          Executor to use to dispatch events. It is the caller's
+   *          responsibility to shut down the executor after the last event has
+   *          been posted to this event bus.
+   */
+  public ImmediateEventBus(Executor executor) {
+    super("default", executor, Dispatcher.immediate(), LoggingHandler.INSTANCE);
+  }
+}


### PR DESCRIPTION
New child of EventBus that uses immediate Dispatcher, which isn't used in any impl as of now.