### PR TITLE
Add an Automatic-Module-Name manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.3.1</version>
           <configuration>
+            <archive>
+              <manifestEntries>
+                  <Automatic-Module-Name>com.google.guava</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
             <excludes>
               <exclude>**/ForceGuavaCompilation*</exclude>
             </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
           <configuration>
             <archive>
               <manifestEntries>
-                  <Automatic-Module-Name>com.google.guava</Automatic-Module-Name>
+                  <Automatic-Module-Name>com.google.common</Automatic-Module-Name>
               </manifestEntries>
             </archive>
             <excludes>


### PR DESCRIPTION
This is recommended for any java library which is being published to
repositories like MavenCentral or JCenter to ensure that when you do
eventually convert the library to a Java 9 module, it won't change
names requiring all of your consumers and the projects which depend
upon your consumers to update their `moudle-info.java` files to
pick up the new name.

We can debate whether or not `com.google.guava` is the name you want
to adopt for your module. Other possible candidates are:
 * `guava`
 * `google.guava`
 * `com.google.common.guava`
 * Something else

[This article](http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html) covers
a lot of the reasons you might want to use `com.google.guava`, but I have also read reasonable arguments for more concise names if you aren't worried about module name conflicts.

Related (a little bit) to #2571