### PR TITLE
Add generics with Maps. fromProperties().

### DIFF
--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1382,10 +1382,12 @@ public final class Maps {
     }
   }
 
+  @FunctionalInterface
   public interface KConverter<K>{
     K convert(String key);
   };
 
+  @FunctionalInterface
   public interface VConverter<V>{
     V convert(String value);
   };

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1382,16 +1382,6 @@ public final class Maps {
     }
   }
 
-  @FunctionalInterface
-  public interface KConverter<K>{
-    K convert(String key);
-  };
-
-  @FunctionalInterface
-  public interface VConverter<V>{
-    V convert(String value);
-  };
-
   /**
    * Creates an {@code ImmutableMap<K, V>} from a {@code Properties}
    * instance. Properties normally derive from {@code Map<Object, Object>}, but
@@ -1409,12 +1399,14 @@ public final class Maps {
    */
   @GwtIncompatible // java.util.Properties
   public static <K, V> ImmutableMap<K, V> fromProperties(
-          Properties properties, KConverter<K> kConverter, VConverter<V> vConverter) {
+          Properties properties, Function<String, K> kConverter, Function<String, V> vConverter) {
+    checkNotNull(kConverter);
+    checkNotNull(vConverter);
     ImmutableMap.Builder<K, V> builder = ImmutableMap.builder();
 
     for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements();) {
       String key = (String) e.nextElement();
-      builder.put(kConverter.convert(key), vConverter.convert(properties.getProperty(key)));
+      builder.put(kConverter.apply(key), vConverter.apply(properties.getProperty(key)));
     }
 
     return builder.build();
@@ -1436,7 +1428,7 @@ public final class Maps {
    */
   @GwtIncompatible // java.util.Properties
   public static <V> ImmutableMap<String, V> fromProperties(
-          Properties properties, VConverter<V> vConverter) {
+          Properties properties, Function<String, V> vConverter) {
     return fromProperties(properties, (k) -> k, vConverter);
   }
 

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1382,6 +1382,62 @@ public final class Maps {
     }
   }
 
+  public interface KConverter<K>{
+    K convert(String key);
+  };
+
+  public interface VConverter<V>{
+    V convert(String value);
+  };
+
+  /**
+   * Creates an {@code ImmutableMap<K, V>} from a {@code Properties}
+   * instance. Properties normally derive from {@code Map<Object, Object>}, but
+   * they typically contain strings, which is awkward. This method lets you get
+   * a plain-old-{@code Map} out of a {@code Properties}.
+   *
+   * @param properties a {@code Properties} object to be converted
+   * @param kConverter a {@code KConverter<K>} key converter
+   * @param vConverter a {@code VConverter<V>} value converter
+   * @return an immutable map containing all the entries in {@code properties}
+   * @throws ClassCastException if any key in {@code Properties} is not a {@code
+   *         String}
+   * @throws NullPointerException if any key or value in {@code Properties} is
+   *         null
+   */
+  @GwtIncompatible // java.util.Properties
+  public static <K, V> ImmutableMap<K, V> fromProperties(
+          Properties properties, KConverter<K> kConverter, VConverter<V> vConverter) {
+    ImmutableMap.Builder<K, V> builder = ImmutableMap.builder();
+
+    for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements();) {
+      String key = (String) e.nextElement();
+      builder.put(kConverter.convert(key), vConverter.convert(properties.getProperty(key)));
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Creates an {@code ImmutableMap<String, V>} from a {@code Properties}
+   * instance. Properties normally derive from {@code Map<Object, Object>}, but
+   * they typically contain strings, which is awkward. This method lets you get
+   * a plain-old-{@code Map} out of a {@code Properties}.
+   *
+   * @param properties a {@code Properties} object to be converted
+   * @param vConverter a {@code VConverter<V>} value converter
+   * @return an immutable map containing all the entries in {@code properties}
+   * @throws ClassCastException if any key in {@code Properties} is not a {@code
+   *         String}
+   * @throws NullPointerException if any key or value in {@code Properties} is
+   *         null
+   */
+  @GwtIncompatible // java.util.Properties
+  public static <V> ImmutableMap<String, V> fromProperties(
+          Properties properties, VConverter<V> vConverter) {
+    return fromProperties(properties, (k) -> k, vConverter);
+  }
+
   /**
    * Creates an {@code ImmutableMap<String, String>} from a {@code Properties}
    * instance. Properties normally derive from {@code Map<Object, Object>}, but
@@ -1396,15 +1452,9 @@ public final class Maps {
    *         null
    */
   @GwtIncompatible // java.util.Properties
-  public static ImmutableMap<String, String> fromProperties(Properties properties) {
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-
-    for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements(); ) {
-      String key = (String) e.nextElement();
-      builder.put(key, properties.getProperty(key));
-    }
-
-    return builder.build();
+  public static ImmutableMap<String, String> fromProperties(
+          Properties properties) {
+    return fromProperties(properties, (k) -> k, (v) -> v);
   }
 
   /**


### PR DESCRIPTION
Add generics with Maps. fromProperties().

It can use like this:
```java
Map<Integer, Integer> maps = fromProperties(prop, (k)->Integer.valueOf(k), (v)->Integer.valueOf(v));
```
It's very useful when we use it to convert properties to a generics map.

And in other way, we can implement with BiFunction<T, U, R> to expand this method.