### PR TITLE
LocalCache.asMap().compute(...) deadlocks if its lambda throws an exception

### DIFF
--- a/guava-tests/test/com/google/common/cache/LocalCacheMapComputeTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheMapComputeTest.java
@@ -82,4 +82,13 @@ public class LocalCacheMapComputeTest extends TestCase {
     });
     assertEquals(0, cache.size());
   }
+
+  public void testComputeExceptionally() {
+    try {
+      doParallelCacheOp(count, n -> {
+        cache.asMap().compute(key, (k, v) -> { throw new RuntimeException(); });
+      });
+    } catch (RuntimeException ex) {
+    }
+  }
 }

--- a/guava-tests/test/com/google/common/cache/LocalCacheMapComputeTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheMapComputeTest.java
@@ -88,6 +88,7 @@ public class LocalCacheMapComputeTest extends TestCase {
       doParallelCacheOp(count, n -> {
         cache.asMap().compute(key, (k, v) -> { throw new RuntimeException(); });
       });
+      fail("Should not get here");
     } catch (RuntimeException ex) {
     }
   }

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -3741,7 +3741,13 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
       } catch (ExecutionException e) {
         previousValue = null;
       }
-      V newValue = function.apply(key, previousValue);
+      V newValue;
+      try {
+         newValue = function.apply(key, previousValue);
+      } catch (Throwable th) {
+         this.setException(th);
+         throw th;
+      }
       this.set(newValue);
       return newValue;
     }


### PR DESCRIPTION
LocalCache.asMap().compute(...) deadlocks if its lambda throws an exception. Demonstrated by the test. Fixed by properly handling the exception and realising the lock.