### PR TITLE
Static initializer references subclass

### DIFF
--- a/guava/src/com/google/common/collect/ComparisonChain.java
+++ b/guava/src/com/google/common/collect/ComparisonChain.java
@@ -124,9 +124,9 @@ public abstract class ComparisonChain {
         }
       };
 
-  private static final ComparisonChain LESS = new InactiveComparisonChain(-1);
+    private static final ThreadLocal<ComparisonChain> LESS = ThreadLocal.withInitial(() -> new InactiveComparisonChain(-1));
 
-  private static final ComparisonChain GREATER = new InactiveComparisonChain(1);
+    private static final ThreadLocal<ComparisonChain> GREATER = ThreadLocal.withInitial(() -> new InactiveComparisonChain(1));
 
   private static final class InactiveComparisonChain extends ComparisonChain {
     final int result;

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -313,9 +313,8 @@ public abstract class BaseEncoding {
    */
   public abstract BaseEncoding lowerCase();
 
-  private static final BaseEncoding BASE64 =
-      new Base64Encoding(
-          "base64()", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", '=');
+  private static final ThreadLocal<BaseEncoding> BASE64 =
+      ThreadLocal.withInitial(() -> new Base64Encoding("base64()", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", '='));
 
   /**
    * The "base64" base encoding specified by
@@ -331,7 +330,7 @@ public abstract class BaseEncoding {
    * in Encoded Data. Line feeds may be added using {@link #withSeparator(String, int)}.
    */
   public static BaseEncoding base64() {
-    return BASE64;
+    return BASE64.get();
   }
 
   private static final BaseEncoding BASE64_URL =

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -374,8 +374,8 @@ public abstract class BaseEncoding {
     return BASE32;
   }
 
-  private static final BaseEncoding BASE32_HEX =
-      new StandardBaseEncoding("base32Hex()", "0123456789ABCDEFGHIJKLMNOPQRSTUV", '=');
+  private static final ThreadLocal<BaseEncoding> BASE32_HEX =
+      ThreadLocal.withInitial(() -> new StandardBaseEncoding("base32Hex()", "0123456789ABCDEFGHIJKLMNOPQRSTUV", '='));
 
   /**
    * The "base32hex" encoding specified by
@@ -390,10 +390,10 @@ public abstract class BaseEncoding {
    * in Encoded Data. Line feeds may be added using {@link #withSeparator(String, int)}.
    */
   public static BaseEncoding base32Hex() {
-    return BASE32_HEX;
+    return BASE32_HEX.get();
   }
 
-  private static final BaseEncoding BASE16 = new Base16Encoding("base16()", "0123456789ABCDEF");
+  private static final ThreadLocal<BaseEncoding> BASE16 = ThreadLocal.withInitial(() -> new Base16Encoding("base16()", "0123456789ABCDEF"));
 
   /**
    * The "base16" encoding specified by <a href="http://tools.ietf.org/html/rfc4648#section-8">RFC
@@ -409,7 +409,7 @@ public abstract class BaseEncoding {
    * in Encoded Data. Line feeds may be added using {@link #withSeparator(String, int)}.
    */
   public static BaseEncoding base16() {
-    return BASE16;
+    return BASE16.get();
   }
 
   private static final class Alphabet {


### PR DESCRIPTION
Such references can cause JVM-level deadlocks in multithreaded environment, when one thread tries to load superclass and another thread tries to load subclass at the same time.

My refactor will not change the method provided to outer space.