### PR TITLE
Fix javadoc link by including package name.

### DIFF
--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -303,10 +303,11 @@ public final class MoreFiles {
     }
   }
 
-  /**
-   * Returns a predicate that returns the result of {@link Files#isDirectory(Path, LinkOption...)}
-   * on input paths with the given link options.
-   */
+    /**
+     * Returns a predicate that returns the result of
+     * {@link java.nio.file.Files#isDirectory(Path, LinkOption...)} on input paths with the given link
+     * options.
+     */
   public static Predicate<Path> isDirectory(LinkOption... options) {
     final LinkOption[] optionsCopy = options.clone();
     return new Predicate<Path>() {
@@ -322,10 +323,11 @@ public final class MoreFiles {
     };
   }
 
-  /**
-   * Returns a predicate that returns the result of
-   * {@link Files#isRegularFile(Path, LinkOption...)} on input paths with the given link options.
-   */
+    /**
+     * Returns a predicate that returns the result of
+     * {@link java.nio.file.Files#isRegularFile(Path, LinkOption...)} on input paths with the given link
+     * options.
+     */
   public static Predicate<Path> isRegularFile(LinkOption... options) {
     final LinkOption[] optionsCopy = options.clone();
     return new Predicate<Path>() {


### PR DESCRIPTION
In the javadoc for guava 23.0, the links are currently shown as text, and not generated as hyperlinks.  With this change, the links will be generated as hyperlinks.
