### PR TITLE
Extended toMap

### DIFF
--- a/guava-tests/test/com/google/common/collect/FluentIterableTest.java
+++ b/guava-tests/test/com/google/common/collect/FluentIterableTest.java
@@ -16,35 +16,26 @@
 
 package com.google.common.collect;
 
-import static com.google.common.collect.FluentIterableTest.Help.assertThat;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.asList;
-
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Joiner;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
+import com.google.common.base.*;
 import com.google.common.collect.testing.IteratorFeature;
 import com.google.common.collect.testing.IteratorTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.IterableSubject;
 import com.google.common.truth.Truth;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.FluentIterableTest.Help.assertThat;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.asList;
 
 /**
  * Unit test for {@link FluentIterable}.
@@ -54,126 +45,130 @@ import junit.framework.TestCase;
 @GwtCompatible(emulated = true)
 public class FluentIterableTest extends TestCase {
 
-  @GwtIncompatible // NullPointerTester
-  public void testNullPointerExceptions() {
-    NullPointerTester tester = new NullPointerTester();
-    tester.testAllPublicStaticMethods(FluentIterable.class);
-  }
-
-  public void testFromArrayAndAppend() {
-    FluentIterable<TimeUnit> units =
-        FluentIterable.from(TimeUnit.values()).append(TimeUnit.SECONDS);
-  }
-
-  public void testFromArrayAndIteratorRemove() {
-    FluentIterable<TimeUnit> units = FluentIterable.from(TimeUnit.values());
-    try {
-      Iterables.removeIf(units, Predicates.equalTo(TimeUnit.SECONDS));
-      fail("Expected an UnsupportedOperationException to be thrown but it wasn't.");
-    } catch (UnsupportedOperationException expected) {
+    @GwtIncompatible // NullPointerTester
+    public void testNullPointerExceptions() {
+        NullPointerTester tester = new NullPointerTester();
+        tester.testAllPublicStaticMethods(FluentIterable.class);
     }
-  }
 
-  public void testFrom() {
-    assertEquals(ImmutableList.of(1, 2, 3, 4),
-        Lists.newArrayList(FluentIterable.from(ImmutableList.of(1, 2, 3, 4))));
-  }
-
-  @SuppressWarnings("deprecation") // test of deprecated method
-  public void testFrom_alreadyFluentIterable() {
-    FluentIterable<Integer> iterable = FluentIterable.from(asList(1));
-    assertSame(iterable, FluentIterable.from(iterable));
-  }
-
-  public void testOf() {
-    assertEquals(ImmutableList.of(1, 2, 3, 4),
-        Lists.newArrayList(FluentIterable.of(1, 2, 3, 4)));
-  }
-
-  public void testFromArray() {
-    assertEquals(ImmutableList.of("1", "2", "3", "4"),
-        Lists.newArrayList(FluentIterable.from(new Object[] {"1", "2", "3", "4"})));
-  }
-
-  public void testOf_empty() {
-    assertEquals(ImmutableList.of(), Lists.newArrayList(FluentIterable.of()));
-  }
-
-  // Exhaustive tests are in IteratorsTest. These are copied from IterablesTest.
-  public void testConcatIterable() {
-    List<Integer> list1 = newArrayList(1);
-    List<Integer> list2 = newArrayList(4);
-
-    @SuppressWarnings("unchecked")
-    List<List<Integer>> input = newArrayList(list1, list2);
-
-    FluentIterable<Integer> result = FluentIterable.concat(input);
-    assertEquals(asList(1, 4), newArrayList(result));
-
-    // Now change the inputs and see result dynamically change as well
-
-    list1.add(2);
-    List<Integer> list3 = newArrayList(3);
-    input.add(1, list3);
-
-    assertEquals(asList(1, 2, 3, 4), newArrayList(result));
-    assertEquals("[1, 2, 3, 4]", result.toString());
-  }
-
-  public void testConcatVarargs() {
-    List<Integer> list1 = newArrayList(1);
-    List<Integer> list2 = newArrayList(4);
-    List<Integer> list3 = newArrayList(7, 8);
-    List<Integer> list4 = newArrayList(9);
-    List<Integer> list5 = newArrayList(10);
-    @SuppressWarnings("unchecked")
-    FluentIterable<Integer> result = FluentIterable.concat(list1, list2, list3, list4, list5);
-    assertEquals(asList(1, 4, 7, 8, 9, 10), newArrayList(result));
-    assertEquals("[1, 4, 7, 8, 9, 10]", result.toString());
-  }
-
-  public void testConcatNullPointerException() {
-    List<Integer> list1 = newArrayList(1);
-    List<Integer> list2 = newArrayList(4);
-
-    try {
-      FluentIterable.concat(list1, null, list2);
-      fail();
-    } catch (NullPointerException expected) {
+    public void testFromArrayAndAppend() {
+        FluentIterable<TimeUnit> units =
+                FluentIterable.from(TimeUnit.values()).append(TimeUnit.SECONDS);
     }
-  }
 
-  public void testConcatPeformingFiniteCycle() {
-    Iterable<Integer> iterable = asList(1, 2, 3);
-    int n = 4;
-    FluentIterable<Integer> repeated = FluentIterable.concat(Collections.nCopies(n, iterable));
-    assertThat(repeated).containsExactly(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3).inOrder();
-  }
+    public void testFromArrayAndIteratorRemove() {
+        FluentIterable<TimeUnit> units = FluentIterable.from(TimeUnit.values());
+        try {
+            Iterables.removeIf(units, Predicates.equalTo(TimeUnit.SECONDS));
+            fail("Expected an UnsupportedOperationException to be thrown but it wasn't.");
+        } catch (UnsupportedOperationException expected) {
+        }
+    }
 
-  interface X {}
+    public void testFrom() {
+        assertEquals(ImmutableList.of(1, 2, 3, 4),
+                Lists.newArrayList(FluentIterable.from(ImmutableList.of(1, 2, 3, 4))));
+    }
 
-  interface Y {}
+    @SuppressWarnings("deprecation") // test of deprecated method
+    public void testFrom_alreadyFluentIterable() {
+        FluentIterable<Integer> iterable = FluentIterable.from(asList(1));
+        assertSame(iterable, FluentIterable.from(iterable));
+    }
 
-  static class A implements X, Y {}
+    public void testOf() {
+        assertEquals(ImmutableList.of(1, 2, 3, 4),
+                Lists.newArrayList(FluentIterable.of(1, 2, 3, 4)));
+    }
 
-  static class B implements X, Y {}
+    public void testFromArray() {
+        assertEquals(ImmutableList.of("1", "2", "3", "4"),
+                Lists.newArrayList(FluentIterable.from(new Object[]{"1", "2", "3", "4"})));
+    }
 
-  /**
-   * This test passes if the {@code concat(…).filter(…).filter(…)} statement at the end compiles.
-   * That statement compiles only if {@link FluentIterable#concat concat(aIterable, bIterable)}
-   * returns a {@link FluentIterable} of elements of an anonymous type whose supertypes are the
-   * <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.9">intersection</a>
-   * of the supertypes of {@code A} and the supertypes of {@code B}.
-   */
-  public void testConcatIntersectionType() {
-    Iterable<A> aIterable = ImmutableList.of();
-    Iterable<B> bIterable = ImmutableList.of();
+    public void testOf_empty() {
+        assertEquals(ImmutableList.of(), Lists.newArrayList(FluentIterable.of()));
+    }
 
-    Predicate<X> xPredicate = Predicates.alwaysTrue();
-    Predicate<Y> yPredicate = Predicates.alwaysTrue();
+    // Exhaustive tests are in IteratorsTest. These are copied from IterablesTest.
+    public void testConcatIterable() {
+        List<Integer> list1 = newArrayList(1);
+        List<Integer> list2 = newArrayList(4);
 
-    FluentIterable<?> unused =
-        FluentIterable.concat(aIterable, bIterable).filter(xPredicate).filter(yPredicate);
+        @SuppressWarnings("unchecked")
+        List<List<Integer>> input = newArrayList(list1, list2);
+
+        FluentIterable<Integer> result = FluentIterable.concat(input);
+        assertEquals(asList(1, 4), newArrayList(result));
+
+        // Now change the inputs and see result dynamically change as well
+
+        list1.add(2);
+        List<Integer> list3 = newArrayList(3);
+        input.add(1, list3);
+
+        assertEquals(asList(1, 2, 3, 4), newArrayList(result));
+        assertEquals("[1, 2, 3, 4]", result.toString());
+    }
+
+    public void testConcatVarargs() {
+        List<Integer> list1 = newArrayList(1);
+        List<Integer> list2 = newArrayList(4);
+        List<Integer> list3 = newArrayList(7, 8);
+        List<Integer> list4 = newArrayList(9);
+        List<Integer> list5 = newArrayList(10);
+        @SuppressWarnings("unchecked")
+        FluentIterable<Integer> result = FluentIterable.concat(list1, list2, list3, list4, list5);
+        assertEquals(asList(1, 4, 7, 8, 9, 10), newArrayList(result));
+        assertEquals("[1, 4, 7, 8, 9, 10]", result.toString());
+    }
+
+    public void testConcatNullPointerException() {
+        List<Integer> list1 = newArrayList(1);
+        List<Integer> list2 = newArrayList(4);
+
+        try {
+            FluentIterable.concat(list1, null, list2);
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testConcatPeformingFiniteCycle() {
+        Iterable<Integer> iterable = asList(1, 2, 3);
+        int n = 4;
+        FluentIterable<Integer> repeated = FluentIterable.concat(Collections.nCopies(n, iterable));
+        assertThat(repeated).containsExactly(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3).inOrder();
+    }
+
+    interface X {
+    }
+
+    interface Y {
+    }
+
+    static class A implements X, Y {
+    }
+
+    static class B implements X, Y {
+    }
+
+    /**
+     * This test passes if the {@code concat(…).filter(…).filter(…)} statement at the end compiles.
+     * That statement compiles only if {@link FluentIterable#concat concat(aIterable, bIterable)}
+     * returns a {@link FluentIterable} of elements of an anonymous type whose supertypes are the
+     * <a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.9">intersection</a>
+     * of the supertypes of {@code A} and the supertypes of {@code B}.
+     */
+    public void testConcatIntersectionType() {
+        Iterable<A> aIterable = ImmutableList.of();
+        Iterable<B> bIterable = ImmutableList.of();
+
+        Predicate<X> xPredicate = Predicates.alwaysTrue();
+        Predicate<Y> yPredicate = Predicates.alwaysTrue();
+
+        FluentIterable<?> unused =
+                FluentIterable.concat(aIterable, bIterable).filter(xPredicate).filter(yPredicate);
 
     /* The following fails to compile:
      *
@@ -181,161 +176,162 @@ public class FluentIterableTest extends TestCase {
      * FluentIterable<FluentIterableTest.A> is not applicable for the arguments
      * (Iterable<FluentIterableTest.B>)
      */
-    // FluentIterable.from(aIterable).append(bIterable);
+        // FluentIterable.from(aIterable).append(bIterable);
 
     /* The following fails to compile:
      *
      * The method filter(Predicate<? super Object>) in the type FluentIterable<Object> is not
      * applicable for the arguments (Predicate<FluentIterableTest.X>)
      */
-    // FluentIterable.of().append(aIterable).append(bIterable).filter(xPredicate);
-  }
-
-  public void testSize0() {
-    assertEquals(0, FluentIterable.<String>of().size());
-  }
-
-  public void testSize1Collection() {
-    assertEquals(1, FluentIterable.from(asList("a")).size());
-  }
-
-  public void testSize2NonCollection() {
-    Iterable<Integer> iterable = new Iterable<Integer>() {
-      @Override
-      public Iterator<Integer> iterator() {
-        return asList(0, 1).iterator();
-      }
-    };
-    assertEquals(2, FluentIterable.from(iterable).size());
-  }
-
-  public void testSize_collectionDoesntIterate() {
-    List<Integer> nums = asList(1, 2, 3, 4, 5);
-    List<Integer> collection = new ArrayList<Integer>(nums) {
-      @Override public Iterator<Integer> iterator() {
-        throw new AssertionFailedError("Don't iterate me!");
-      }
-    };
-    assertEquals(5, FluentIterable.from(collection).size());
-  }
-
-  public void testContains_nullSetYes() {
-    Iterable<String> set = Sets.newHashSet("a", null, "b");
-    assertTrue(FluentIterable.from(set).contains(null));
-  }
-
-  public void testContains_nullSetNo() {
-    Iterable<String> set = ImmutableSortedSet.of("a", "b");
-    assertFalse(FluentIterable.from(set).contains(null));
-  }
-
-  public void testContains_nullIterableYes() {
-    Iterable<String> iterable = iterable("a", null, "b");
-    assertTrue(FluentIterable.from(iterable).contains(null));
-  }
-
-  public void testContains_nullIterableNo() {
-    Iterable<String> iterable = iterable("a", "b");
-    assertFalse(FluentIterable.from(iterable).contains(null));
-  }
-
-  public void testContains_nonNullSetYes() {
-    Iterable<String> set = Sets.newHashSet("a", null, "b");
-    assertTrue(FluentIterable.from(set).contains("b"));
-  }
-
-  public void testContains_nonNullSetNo() {
-    Iterable<String> set = Sets.newHashSet("a", "b");
-    assertFalse(FluentIterable.from(set).contains("c"));
-  }
-
-  public void testContains_nonNullIterableYes() {
-    Iterable<String> set = iterable("a", null, "b");
-    assertTrue(FluentIterable.from(set).contains("b"));
-  }
-
-  public void testContains_nonNullIterableNo() {
-    Iterable<String> iterable = iterable("a", "b");
-    assertFalse(FluentIterable.from(iterable).contains("c"));
-  }
-
-  public void testOfToString() {
-    assertEquals("[yam, bam, jam, ham]",
-        FluentIterable.of("yam", "bam", "jam", "ham").toString());
-  }
-
-  public void testToString() {
-    assertEquals("[]", FluentIterable.from(Collections.emptyList()).toString());
-    assertEquals("[]", FluentIterable.<String>of().toString());
-
-    assertEquals("[yam, bam, jam, ham]",
-        FluentIterable.from(asList("yam", "bam", "jam", "ham")).toString());
-  }
-
-  public void testCycle() {
-    FluentIterable<String> cycle = FluentIterable.from(asList("a", "b")).cycle();
-
-    int howManyChecked = 0;
-    for (String string : cycle) {
-      String expected = (howManyChecked % 2 == 0) ? "a" : "b";
-      assertEquals(expected, string);
-      if (howManyChecked++ == 5) {
-        break;
-      }
+        // FluentIterable.of().append(aIterable).append(bIterable).filter(xPredicate);
     }
 
-    // We left the last iterator pointing to "b". But a new iterator should
-    // always point to "a".
-    assertEquals("a", cycle.iterator().next());
-  }
-
-  public void testCycle_emptyIterable() {
-    FluentIterable<Integer> cycle = FluentIterable.<Integer>of().cycle();
-    assertFalse(cycle.iterator().hasNext());
-  }
-
-  public void testCycle_removingAllElementsStopsCycle() {
-    FluentIterable<Integer> cycle = fluent(1, 2).cycle();
-    Iterator<Integer> iterator = cycle.iterator();
-    iterator.next();
-    iterator.remove();
-    iterator.next();
-    iterator.remove();
-    assertFalse(iterator.hasNext());
-    assertFalse(cycle.iterator().hasNext());
-  }
-
-  public void testAppend() {
-    FluentIterable<Integer> result =
-        FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.newArrayList(4, 5, 6));
-    assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
-    assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
-
-    result = FluentIterable.<Integer>from(asList(1, 2, 3)).append(4, 5, 6);
-    assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
-    assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
-  }
-
-  public void testAppend_toEmpty() {
-    FluentIterable<Integer> result =
-        FluentIterable.<Integer>of().append(Lists.newArrayList(1, 2, 3));
-    assertEquals(asList(1, 2, 3), Lists.newArrayList(result));
-  }
-
-  public void testAppend_emptyList() {
-    FluentIterable<Integer> result =
-        FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.<Integer>newArrayList());
-    assertEquals(asList(1, 2, 3), Lists.newArrayList(result));
-  }
-
-  public void testAppend_nullPointerException() {
-    try {
-      FluentIterable<Integer> unused =
-          FluentIterable.<Integer>from(asList(1, 2)).append((List<Integer>) null);
-      fail("Appending null iterable should throw NPE.");
-    } catch (NullPointerException expected) {
+    public void testSize0() {
+        assertEquals(0, FluentIterable.<String>of().size());
     }
-  }
+
+    public void testSize1Collection() {
+        assertEquals(1, FluentIterable.from(asList("a")).size());
+    }
+
+    public void testSize2NonCollection() {
+        Iterable<Integer> iterable = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return asList(0, 1).iterator();
+            }
+        };
+        assertEquals(2, FluentIterable.from(iterable).size());
+    }
+
+    public void testSize_collectionDoesntIterate() {
+        List<Integer> nums = asList(1, 2, 3, 4, 5);
+        List<Integer> collection = new ArrayList<Integer>(nums) {
+            @Override
+            public Iterator<Integer> iterator() {
+                throw new AssertionFailedError("Don't iterate me!");
+            }
+        };
+        assertEquals(5, FluentIterable.from(collection).size());
+    }
+
+    public void testContains_nullSetYes() {
+        Iterable<String> set = Sets.newHashSet("a", null, "b");
+        assertTrue(FluentIterable.from(set).contains(null));
+    }
+
+    public void testContains_nullSetNo() {
+        Iterable<String> set = ImmutableSortedSet.of("a", "b");
+        assertFalse(FluentIterable.from(set).contains(null));
+    }
+
+    public void testContains_nullIterableYes() {
+        Iterable<String> iterable = iterable("a", null, "b");
+        assertTrue(FluentIterable.from(iterable).contains(null));
+    }
+
+    public void testContains_nullIterableNo() {
+        Iterable<String> iterable = iterable("a", "b");
+        assertFalse(FluentIterable.from(iterable).contains(null));
+    }
+
+    public void testContains_nonNullSetYes() {
+        Iterable<String> set = Sets.newHashSet("a", null, "b");
+        assertTrue(FluentIterable.from(set).contains("b"));
+    }
+
+    public void testContains_nonNullSetNo() {
+        Iterable<String> set = Sets.newHashSet("a", "b");
+        assertFalse(FluentIterable.from(set).contains("c"));
+    }
+
+    public void testContains_nonNullIterableYes() {
+        Iterable<String> set = iterable("a", null, "b");
+        assertTrue(FluentIterable.from(set).contains("b"));
+    }
+
+    public void testContains_nonNullIterableNo() {
+        Iterable<String> iterable = iterable("a", "b");
+        assertFalse(FluentIterable.from(iterable).contains("c"));
+    }
+
+    public void testOfToString() {
+        assertEquals("[yam, bam, jam, ham]",
+                FluentIterable.of("yam", "bam", "jam", "ham").toString());
+    }
+
+    public void testToString() {
+        assertEquals("[]", FluentIterable.from(Collections.emptyList()).toString());
+        assertEquals("[]", FluentIterable.<String>of().toString());
+
+        assertEquals("[yam, bam, jam, ham]",
+                FluentIterable.from(asList("yam", "bam", "jam", "ham")).toString());
+    }
+
+    public void testCycle() {
+        FluentIterable<String> cycle = FluentIterable.from(asList("a", "b")).cycle();
+
+        int howManyChecked = 0;
+        for (String string : cycle) {
+            String expected = (howManyChecked % 2 == 0) ? "a" : "b";
+            assertEquals(expected, string);
+            if (howManyChecked++ == 5) {
+                break;
+            }
+        }
+
+        // We left the last iterator pointing to "b". But a new iterator should
+        // always point to "a".
+        assertEquals("a", cycle.iterator().next());
+    }
+
+    public void testCycle_emptyIterable() {
+        FluentIterable<Integer> cycle = FluentIterable.<Integer>of().cycle();
+        assertFalse(cycle.iterator().hasNext());
+    }
+
+    public void testCycle_removingAllElementsStopsCycle() {
+        FluentIterable<Integer> cycle = fluent(1, 2).cycle();
+        Iterator<Integer> iterator = cycle.iterator();
+        iterator.next();
+        iterator.remove();
+        iterator.next();
+        iterator.remove();
+        assertFalse(iterator.hasNext());
+        assertFalse(cycle.iterator().hasNext());
+    }
+
+    public void testAppend() {
+        FluentIterable<Integer> result =
+                FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.newArrayList(4, 5, 6));
+        assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
+        assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
+
+        result = FluentIterable.<Integer>from(asList(1, 2, 3)).append(4, 5, 6);
+        assertEquals(asList(1, 2, 3, 4, 5, 6), Lists.newArrayList(result));
+        assertEquals("[1, 2, 3, 4, 5, 6]", result.toString());
+    }
+
+    public void testAppend_toEmpty() {
+        FluentIterable<Integer> result =
+                FluentIterable.<Integer>of().append(Lists.newArrayList(1, 2, 3));
+        assertEquals(asList(1, 2, 3), Lists.newArrayList(result));
+    }
+
+    public void testAppend_emptyList() {
+        FluentIterable<Integer> result =
+                FluentIterable.<Integer>from(asList(1, 2, 3)).append(Lists.<Integer>newArrayList());
+        assertEquals(asList(1, 2, 3), Lists.newArrayList(result));
+    }
+
+    public void testAppend_nullPointerException() {
+        try {
+            FluentIterable<Integer> unused =
+                    FluentIterable.<Integer>from(asList(1, 2)).append((List<Integer>) null);
+            fail("Appending null iterable should throw NPE.");
+        } catch (NullPointerException expected) {
+        }
+    }
 
   /*
    * Tests for partition(int size) method.
@@ -345,605 +341,719 @@ public class FluentIterableTest extends TestCase {
    * Tests for partitionWithPadding(int size) method.
    */
 
-  public void testFilter() {
-    FluentIterable<String> filtered =
-        FluentIterable.from(asList("foo", "bar")).filter(Predicates.equalTo("foo"));
+    public void testFilter() {
+        FluentIterable<String> filtered =
+                FluentIterable.from(asList("foo", "bar")).filter(Predicates.equalTo("foo"));
 
-    List<String> expected = Collections.singletonList("foo");
-    List<String> actual = Lists.newArrayList(filtered);
-    assertEquals(expected, actual);
-    assertCanIterateAgain(filtered);
-    assertEquals("[foo]", filtered.toString());
-  }
-
-  private static class TypeA {}
-  private interface TypeB {}
-  private static class HasBoth extends TypeA implements TypeB {}
-
-  @GwtIncompatible // Iterables.filter(Iterable, Class)
-  public void testFilterByType() throws Exception {
-    HasBoth hasBoth = new HasBoth();
-    FluentIterable<TypeA> alist =
-        FluentIterable.from(asList(new TypeA(), new TypeA(), hasBoth, new TypeA()));
-    Iterable<TypeB> blist = alist.filter(TypeB.class);
-    assertThat(blist).containsExactly(hasBoth).inOrder();
-  }
-
-  public void testAnyMatch() {
-    ArrayList<String> list = Lists.newArrayList();
-    FluentIterable<String> iterable = FluentIterable.<String>from(list);
-    Predicate<String> predicate = Predicates.equalTo("pants");
-
-    assertFalse(iterable.anyMatch(predicate));
-    list.add("cool");
-    assertFalse(iterable.anyMatch(predicate));
-    list.add("pants");
-    assertTrue(iterable.anyMatch(predicate));
-  }
-
-  public void testAllMatch() {
-    List<String> list = Lists.newArrayList();
-    FluentIterable<String> iterable = FluentIterable.<String>from(list);
-    Predicate<String> predicate = Predicates.equalTo("cool");
-
-    assertTrue(iterable.allMatch(predicate));
-    list.add("cool");
-    assertTrue(iterable.allMatch(predicate));
-    list.add("pants");
-    assertFalse(iterable.allMatch(predicate));
-  }
-
-  public void testFirstMatch() {
-    FluentIterable<String> iterable = FluentIterable.from(Lists.newArrayList("cool", "pants"));
-    assertThat(iterable.firstMatch(Predicates.equalTo("cool"))).hasValue("cool");
-    assertThat(iterable.firstMatch(Predicates.equalTo("pants"))).hasValue("pants");
-    assertThat(iterable.firstMatch(Predicates.alwaysFalse())).isAbsent();
-    assertThat(iterable.firstMatch(Predicates.alwaysTrue())).hasValue("cool");
-  }
-
-  private static final class IntegerValueOfFunction implements Function<String, Integer> {
-    @Override
-    public Integer apply(String from) {
-      return Integer.valueOf(from);
+        List<String> expected = Collections.singletonList("foo");
+        List<String> actual = Lists.newArrayList(filtered);
+        assertEquals(expected, actual);
+        assertCanIterateAgain(filtered);
+        assertEquals("[foo]", filtered.toString());
     }
-  }
 
-  public void testTransformWith() {
-    List<String> input = asList("1", "2", "3");
-    Iterable<Integer> iterable =
-        FluentIterable.from(input).transform(new IntegerValueOfFunction());
-
-    assertEquals(asList(1, 2, 3), Lists.newArrayList(iterable));
-    assertCanIterateAgain(iterable);
-    assertEquals("[1, 2, 3]", iterable.toString());
-  }
-
-  public void testTransformWith_poorlyBehavedTransform() {
-    List<String> input = asList("1", null, "3");
-    Iterable<Integer> iterable =
-        FluentIterable.from(input).transform(new IntegerValueOfFunction());
-
-    Iterator<Integer> resultIterator = iterable.iterator();
-    resultIterator.next();
-
-    try {
-      resultIterator.next();
-      fail("Transforming null to int should throw NumberFormatException");
-    } catch (NumberFormatException expected) {
+    private static class TypeA {
     }
-  }
 
-  private static final class StringValueOfFunction implements Function<Integer, String> {
-    @Override
-    public String apply(Integer from) {
-      return String.valueOf(from);
+    private interface TypeB {
     }
-  }
 
-  public void testTransformWith_nullFriendlyTransform() {
-    List<Integer> input = asList(1, 2, null, 3);
-    Iterable<String> result = FluentIterable.from(input).transform(new StringValueOfFunction());
-
-    assertEquals(asList("1", "2", "null", "3"), Lists.newArrayList(result));
-  }
-
-  private static final class RepeatedStringValueOfFunction
-      implements Function<Integer, List<String>> {
-    @Override
-    public List<String> apply(Integer from) {
-      String value = String.valueOf(from);
-      return ImmutableList.of(value, value);
+    private static class HasBoth extends TypeA implements TypeB {
     }
-  }
 
-  public void testTransformAndConcat() {
-    List<Integer> input = asList(1, 2, 3);
-    Iterable<String> result =
-        FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfFunction());
-    assertEquals(asList("1", "1", "2", "2", "3", "3"), Lists.newArrayList(result));
-  }
-
-  private static final class RepeatedStringValueOfWildcardFunction
-      implements Function<Integer, List<? extends String>> {
-    @Override
-    public List<String> apply(Integer from) {
-      String value = String.valueOf(from);
-      return ImmutableList.of(value, value);
+    @GwtIncompatible // Iterables.filter(Iterable, Class)
+    public void testFilterByType() throws Exception {
+        HasBoth hasBoth = new HasBoth();
+        FluentIterable<TypeA> alist =
+                FluentIterable.from(asList(new TypeA(), new TypeA(), hasBoth, new TypeA()));
+        Iterable<TypeB> blist = alist.filter(TypeB.class);
+        assertThat(blist).containsExactly(hasBoth).inOrder();
     }
-  }
 
-  public void testTransformAndConcat_wildcardFunctionGenerics() {
-    List<Integer> input = asList(1, 2, 3);
-    FluentIterable<String> unused =
-        FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfWildcardFunction());
-  }
+    public void testAnyMatch() {
+        ArrayList<String> list = Lists.newArrayList();
+        FluentIterable<String> iterable = FluentIterable.<String>from(list);
+        Predicate<String> predicate = Predicates.equalTo("pants");
 
-  public void testFirst_list() {
-    List<String> list = Lists.newArrayList("a", "b", "c");
-    assertThat(FluentIterable.from(list).first()).hasValue("a");
-  }
-
-  public void testFirst_null() {
-    List<String> list = Lists.newArrayList(null, "a", "b");
-    try {
-      FluentIterable.from(list).first();
-      fail();
-    } catch (NullPointerException expected) {
+        assertFalse(iterable.anyMatch(predicate));
+        list.add("cool");
+        assertFalse(iterable.anyMatch(predicate));
+        list.add("pants");
+        assertTrue(iterable.anyMatch(predicate));
     }
-  }
 
-  public void testFirst_emptyList() {
-    List<String> list = Collections.emptyList();
-    assertThat(FluentIterable.from(list).first()).isAbsent();
-  }
+    public void testAllMatch() {
+        List<String> list = Lists.newArrayList();
+        FluentIterable<String> iterable = FluentIterable.<String>from(list);
+        Predicate<String> predicate = Predicates.equalTo("cool");
 
-  public void testFirst_sortedSet() {
-    SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
-    assertThat(FluentIterable.from(sortedSet).first()).hasValue("a");
-  }
-
-  public void testFirst_emptySortedSet() {
-    SortedSet<String> sortedSet = ImmutableSortedSet.of();
-    assertThat(FluentIterable.from(sortedSet).first()).isAbsent();
-  }
-
-  public void testFirst_iterable() {
-    Set<String> set = ImmutableSet.of("a", "b", "c");
-    assertThat(FluentIterable.from(set).first()).hasValue("a");
-  }
-
-  public void testFirst_emptyIterable() {
-    Set<String> set = Sets.newHashSet();
-    assertThat(FluentIterable.from(set).first()).isAbsent();
-  }
-
-  public void testLast_list() {
-    List<String> list = Lists.newArrayList("a", "b", "c");
-    assertThat(FluentIterable.from(list).last()).hasValue("c");
-  }
-
-  public void testLast_null() {
-    List<String> list = Lists.newArrayList("a", "b", null);
-    try {
-      FluentIterable.from(list).last();
-      fail();
-    } catch (NullPointerException expected) {
+        assertTrue(iterable.allMatch(predicate));
+        list.add("cool");
+        assertTrue(iterable.allMatch(predicate));
+        list.add("pants");
+        assertFalse(iterable.allMatch(predicate));
     }
-  }
 
-  public void testLast_emptyList() {
-    List<String> list = Collections.emptyList();
-    assertThat(FluentIterable.from(list).last()).isAbsent();
-  }
-
-  public void testLast_sortedSet() {
-    SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
-    assertThat(FluentIterable.from(sortedSet).last()).hasValue("c");
-  }
-
-  public void testLast_emptySortedSet() {
-    SortedSet<String> sortedSet = ImmutableSortedSet.of();
-    assertThat(FluentIterable.from(sortedSet).last()).isAbsent();
-  }
-
-  public void testLast_iterable() {
-    Set<String> set = ImmutableSet.of("a", "b", "c");
-    assertThat(FluentIterable.from(set).last()).hasValue("c");
-  }
-
-  public void testLast_emptyIterable() {
-    Set<String> set = Sets.newHashSet();
-    assertThat(FluentIterable.from(set).last()).isAbsent();
-  }
-
-  public void testSkip_simple() {
-    Collection<String> set = ImmutableSet.of("a", "b", "c", "d", "e");
-    assertEquals(Lists.newArrayList("c", "d", "e"),
-        Lists.newArrayList(FluentIterable.from(set).skip(2)));
-    assertEquals("[c, d, e]", FluentIterable.from(set).skip(2).toString());
-  }
-
-  public void testSkip_simpleList() {
-    Collection<String> list = Lists.newArrayList("a", "b", "c", "d", "e");
-    assertEquals(Lists.newArrayList("c", "d", "e"),
-        Lists.newArrayList(FluentIterable.from(list).skip(2)));
-    assertEquals("[c, d, e]", FluentIterable.from(list).skip(2).toString());
-  }
-
-  public void testSkip_pastEnd() {
-    Collection<String> set = ImmutableSet.of("a", "b");
-    assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(set).skip(20)));
-  }
-
-  public void testSkip_pastEndList() {
-    Collection<String> list = Lists.newArrayList("a", "b");
-    assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(list).skip(20)));
-  }
-
-  public void testSkip_skipNone() {
-    Collection<String> set = ImmutableSet.of("a", "b");
-    assertEquals(Lists.newArrayList("a", "b"),
-        Lists.newArrayList(FluentIterable.from(set).skip(0)));
-  }
-
-  public void testSkip_skipNoneList() {
-    Collection<String> list = Lists.newArrayList("a", "b");
-    assertEquals(Lists.newArrayList("a", "b"),
-        Lists.newArrayList(FluentIterable.from(list).skip(0)));
-  }
-
-  public void testSkip_iterator() throws Exception {
-    new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
-        IteratorTester.KnownOrder.KNOWN_ORDER) {
-      @Override protected Iterator<Integer> newTargetIterator() {
-        Collection<Integer> collection = Sets.newLinkedHashSet();
-        Collections.addAll(collection, 1, 2, 3);
-        return FluentIterable.from(collection).skip(1).iterator();
-      }
-    }.test();
-  }
-
-  public void testSkip_iteratorList() throws Exception {
-    new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
-        IteratorTester.KnownOrder.KNOWN_ORDER) {
-      @Override protected Iterator<Integer> newTargetIterator() {
-        return FluentIterable.from(Lists.newArrayList(1, 2, 3)).skip(1).iterator();
-      }
-    }.test();
-  }
-
-  public void testSkip_nonStructurallyModifiedList() throws Exception {
-    List<String> list = Lists.newArrayList("a", "b", "c");
-    FluentIterable<String> tail = FluentIterable.from(list).skip(1);
-    Iterator<String> tailIterator = tail.iterator();
-    list.set(2, "c2");
-    assertEquals("b", tailIterator.next());
-    assertEquals("c2", tailIterator.next());
-    assertFalse(tailIterator.hasNext());
-  }
-
-  public void testSkip_structurallyModifiedSkipSome() throws Exception {
-    Collection<String> set = Sets.newLinkedHashSet();
-    Collections.addAll(set, "a", "b", "c");
-    FluentIterable<String> tail = FluentIterable.from(set).skip(1);
-    set.remove("b");
-    set.addAll(Lists.newArrayList("X", "Y", "Z"));
-    assertThat(tail).containsExactly("c", "X", "Y", "Z").inOrder();
-  }
-
-  public void testSkip_structurallyModifiedSkipSomeList() throws Exception {
-    List<String> list = Lists.newArrayList("a", "b", "c");
-    FluentIterable<String> tail = FluentIterable.from(list).skip(1);
-    list.subList(1, 3).clear();
-    list.addAll(0, Lists.newArrayList("X", "Y", "Z"));
-    assertThat(tail).containsExactly("Y", "Z", "a").inOrder();
-  }
-
-  public void testSkip_structurallyModifiedSkipAll() throws Exception {
-    Collection<String> set = Sets.newLinkedHashSet();
-    Collections.addAll(set, "a", "b", "c");
-    FluentIterable<String> tail = FluentIterable.from(set).skip(2);
-    set.remove("a");
-    set.remove("b");
-    assertFalse(tail.iterator().hasNext());
-  }
-
-  public void testSkip_structurallyModifiedSkipAllList() throws Exception {
-    List<String> list = Lists.newArrayList("a", "b", "c");
-    FluentIterable<String> tail = FluentIterable.from(list).skip(2);
-    list.subList(0, 2).clear();
-    assertThat(tail).isEmpty();
-  }
-
-  public void testSkip_illegalArgument() {
-    try {
-      FluentIterable.from(asList("a", "b", "c")).skip(-1);
-      fail("Skipping negative number of elements should throw IllegalArgumentException.");
-    } catch (IllegalArgumentException expected) {
+    public void testFirstMatch() {
+        FluentIterable<String> iterable = FluentIterable.from(Lists.newArrayList("cool", "pants"));
+        assertThat(iterable.firstMatch(Predicates.equalTo("cool"))).hasValue("cool");
+        assertThat(iterable.firstMatch(Predicates.equalTo("pants"))).hasValue("pants");
+        assertThat(iterable.firstMatch(Predicates.alwaysFalse())).isAbsent();
+        assertThat(iterable.firstMatch(Predicates.alwaysTrue())).hasValue("cool");
     }
-  }
 
-  public void testLimit() {
-    Iterable<String> iterable = Lists.newArrayList("foo", "bar", "baz");
-    FluentIterable<String> limited = FluentIterable.from(iterable).limit(2);
-
-    assertEquals(ImmutableList.of("foo", "bar"), Lists.newArrayList(limited));
-    assertCanIterateAgain(limited);
-    assertEquals("[foo, bar]", limited.toString());
-  }
-
-  public void testLimit_illegalArgument() {
-    try {
-      FluentIterable<String> unused =
-          FluentIterable.from(Lists.newArrayList("a", "b", "c")).limit(-1);
-      fail("Passing negative number to limit(...) method should throw IllegalArgumentException");
-    } catch (IllegalArgumentException expected) {
+    private static final class IntegerValueOfFunction implements Function<String, Integer> {
+        @Override
+        public Integer apply(String from) {
+            return Integer.valueOf(from);
+        }
     }
-  }
 
-  public void testIsEmpty() {
-    assertTrue(FluentIterable.<String>from(Collections.<String>emptyList()).isEmpty());
-    assertFalse(FluentIterable.<String>from(Lists.newArrayList("foo")).isEmpty());
-  }
+    public void testTransformWith() {
+        List<String> input = asList("1", "2", "3");
+        Iterable<Integer> iterable =
+                FluentIterable.from(input).transform(new IntegerValueOfFunction());
 
-  public void testToList() {
-    assertEquals(Lists.newArrayList(1, 2, 3, 4), fluent(1, 2, 3, 4).toList());
-  }
-
-  public void testToList_empty() {
-    assertTrue(fluent().toList().isEmpty());
-  }
-
-  public void testToSortedList_withComparator() {
-    assertEquals(Lists.newArrayList(4, 3, 2, 1),
-        fluent(4, 1, 3, 2).toSortedList(Ordering.<Integer>natural().reverse()));
-  }
-
-  public void testToSortedList_withDuplicates() {
-    assertEquals(Lists.newArrayList(4, 3, 1, 1),
-        fluent(1, 4, 1, 3).toSortedList(Ordering.<Integer>natural().reverse()));
-  }
-
-  public void testToSet() {
-    assertThat(fluent(1, 2, 3, 4).toSet()).containsExactly(1, 2, 3, 4).inOrder();
-  }
-
-  public void testToSet_removeDuplicates() {
-    assertThat(fluent(1, 2, 1, 2).toSet()).containsExactly(1, 2).inOrder();
-  }
-
-  public void testToSet_empty() {
-    assertTrue(fluent().toSet().isEmpty());
-  }
-
-  public void testToSortedSet() {
-    assertThat(fluent(1, 4, 2, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
-        .containsExactly(4, 3, 2, 1).inOrder();
-  }
-
-  public void testToSortedSet_removeDuplicates() {
-    assertThat(fluent(1, 4, 1, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
-        .containsExactly(4, 3, 1).inOrder();
-  }
-
-  public void testToMultiset() {
-    assertThat(fluent(1, 2, 1, 3, 2, 4).toMultiset()).containsExactly(1, 1, 2, 2, 3, 4).inOrder();
-  }
-
-  public void testToMultiset_empty() {
-    assertThat(fluent().toMultiset()).isEmpty();
-  }
-
-  public void testToMap() {
-    assertThat(fluent(1, 2, 3).toMap(Functions.toStringFunction()).entrySet())
-        .containsExactly(
-            Maps.immutableEntry(1, "1"),
-            Maps.immutableEntry(2, "2"),
-            Maps.immutableEntry(3, "3")).inOrder();
-  }
-
-  public void testToMap_nullKey() {
-    try {
-      fluent(1, null, 2).toMap(Functions.constant("foo"));
-      fail();
-    } catch (NullPointerException expected) {
+        assertEquals(asList(1, 2, 3), Lists.newArrayList(iterable));
+        assertCanIterateAgain(iterable);
+        assertEquals("[1, 2, 3]", iterable.toString());
     }
-  }
 
-  public void testToMap_nullValue() {
-    try {
-      fluent(1, 2, 3).toMap(Functions.constant(null));
-      fail();
-    } catch (NullPointerException expected) {
+    public void testTransformWith_poorlyBehavedTransform() {
+        List<String> input = asList("1", null, "3");
+        Iterable<Integer> iterable =
+                FluentIterable.from(input).transform(new IntegerValueOfFunction());
+
+        Iterator<Integer> resultIterator = iterable.iterator();
+        resultIterator.next();
+
+        try {
+            resultIterator.next();
+            fail("Transforming null to int should throw NumberFormatException");
+        } catch (NumberFormatException expected) {
+        }
     }
-  }
 
-  public void testIndex() {
-    ImmutableListMultimap<Integer, String> expected =
-        ImmutableListMultimap.<Integer, String>builder()
-            .putAll(3, "one", "two")
-            .put(5, "three")
-            .put(4, "four")
-            .build();
-    ImmutableListMultimap<Integer, String> index =
-        FluentIterable.from(asList("one", "two", "three", "four")).index(
-            new Function<String, Integer>() {
-              @Override
-              public Integer apply(String input) {
-                return input.length();
-              }
+    private static final class StringValueOfFunction implements Function<Integer, String> {
+        @Override
+        public String apply(Integer from) {
+            return String.valueOf(from);
+        }
+    }
+
+    public void testTransformWith_nullFriendlyTransform() {
+        List<Integer> input = asList(1, 2, null, 3);
+        Iterable<String> result = FluentIterable.from(input).transform(new StringValueOfFunction());
+
+        assertEquals(asList("1", "2", "null", "3"), Lists.newArrayList(result));
+    }
+
+    private static final class RepeatedStringValueOfFunction
+            implements Function<Integer, List<String>> {
+        @Override
+        public List<String> apply(Integer from) {
+            String value = String.valueOf(from);
+            return ImmutableList.of(value, value);
+        }
+    }
+
+    public void testTransformAndConcat() {
+        List<Integer> input = asList(1, 2, 3);
+        Iterable<String> result =
+                FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfFunction());
+        assertEquals(asList("1", "1", "2", "2", "3", "3"), Lists.newArrayList(result));
+    }
+
+    private static final class RepeatedStringValueOfWildcardFunction
+            implements Function<Integer, List<? extends String>> {
+        @Override
+        public List<String> apply(Integer from) {
+            String value = String.valueOf(from);
+            return ImmutableList.of(value, value);
+        }
+    }
+
+    public void testTransformAndConcat_wildcardFunctionGenerics() {
+        List<Integer> input = asList(1, 2, 3);
+        FluentIterable<String> unused =
+                FluentIterable.from(input).transformAndConcat(new RepeatedStringValueOfWildcardFunction());
+    }
+
+    public void testFirst_list() {
+        List<String> list = Lists.newArrayList("a", "b", "c");
+        assertThat(FluentIterable.from(list).first()).hasValue("a");
+    }
+
+    public void testFirst_null() {
+        List<String> list = Lists.newArrayList(null, "a", "b");
+        try {
+            FluentIterable.from(list).first();
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testFirst_emptyList() {
+        List<String> list = Collections.emptyList();
+        assertThat(FluentIterable.from(list).first()).isAbsent();
+    }
+
+    public void testFirst_sortedSet() {
+        SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
+        assertThat(FluentIterable.from(sortedSet).first()).hasValue("a");
+    }
+
+    public void testFirst_emptySortedSet() {
+        SortedSet<String> sortedSet = ImmutableSortedSet.of();
+        assertThat(FluentIterable.from(sortedSet).first()).isAbsent();
+    }
+
+    public void testFirst_iterable() {
+        Set<String> set = ImmutableSet.of("a", "b", "c");
+        assertThat(FluentIterable.from(set).first()).hasValue("a");
+    }
+
+    public void testFirst_emptyIterable() {
+        Set<String> set = Sets.newHashSet();
+        assertThat(FluentIterable.from(set).first()).isAbsent();
+    }
+
+    public void testLast_list() {
+        List<String> list = Lists.newArrayList("a", "b", "c");
+        assertThat(FluentIterable.from(list).last()).hasValue("c");
+    }
+
+    public void testLast_null() {
+        List<String> list = Lists.newArrayList("a", "b", null);
+        try {
+            FluentIterable.from(list).last();
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testLast_emptyList() {
+        List<String> list = Collections.emptyList();
+        assertThat(FluentIterable.from(list).last()).isAbsent();
+    }
+
+    public void testLast_sortedSet() {
+        SortedSet<String> sortedSet = ImmutableSortedSet.of("b", "c", "a");
+        assertThat(FluentIterable.from(sortedSet).last()).hasValue("c");
+    }
+
+    public void testLast_emptySortedSet() {
+        SortedSet<String> sortedSet = ImmutableSortedSet.of();
+        assertThat(FluentIterable.from(sortedSet).last()).isAbsent();
+    }
+
+    public void testLast_iterable() {
+        Set<String> set = ImmutableSet.of("a", "b", "c");
+        assertThat(FluentIterable.from(set).last()).hasValue("c");
+    }
+
+    public void testLast_emptyIterable() {
+        Set<String> set = Sets.newHashSet();
+        assertThat(FluentIterable.from(set).last()).isAbsent();
+    }
+
+    public void testSkip_simple() {
+        Collection<String> set = ImmutableSet.of("a", "b", "c", "d", "e");
+        assertEquals(Lists.newArrayList("c", "d", "e"),
+                Lists.newArrayList(FluentIterable.from(set).skip(2)));
+        assertEquals("[c, d, e]", FluentIterable.from(set).skip(2).toString());
+    }
+
+    public void testSkip_simpleList() {
+        Collection<String> list = Lists.newArrayList("a", "b", "c", "d", "e");
+        assertEquals(Lists.newArrayList("c", "d", "e"),
+                Lists.newArrayList(FluentIterable.from(list).skip(2)));
+        assertEquals("[c, d, e]", FluentIterable.from(list).skip(2).toString());
+    }
+
+    public void testSkip_pastEnd() {
+        Collection<String> set = ImmutableSet.of("a", "b");
+        assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(set).skip(20)));
+    }
+
+    public void testSkip_pastEndList() {
+        Collection<String> list = Lists.newArrayList("a", "b");
+        assertEquals(Collections.emptyList(), Lists.newArrayList(FluentIterable.from(list).skip(20)));
+    }
+
+    public void testSkip_skipNone() {
+        Collection<String> set = ImmutableSet.of("a", "b");
+        assertEquals(Lists.newArrayList("a", "b"),
+                Lists.newArrayList(FluentIterable.from(set).skip(0)));
+    }
+
+    public void testSkip_skipNoneList() {
+        Collection<String> list = Lists.newArrayList("a", "b");
+        assertEquals(Lists.newArrayList("a", "b"),
+                Lists.newArrayList(FluentIterable.from(list).skip(0)));
+    }
+
+    public void testSkip_iterator() throws Exception {
+        new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
+                IteratorTester.KnownOrder.KNOWN_ORDER) {
+            @Override
+            protected Iterator<Integer> newTargetIterator() {
+                Collection<Integer> collection = Sets.newLinkedHashSet();
+                Collections.addAll(collection, 1, 2, 3);
+                return FluentIterable.from(collection).skip(1).iterator();
+            }
+        }.test();
+    }
+
+    public void testSkip_iteratorList() throws Exception {
+        new IteratorTester<Integer>(5, IteratorFeature.MODIFIABLE, Lists.newArrayList(2, 3),
+                IteratorTester.KnownOrder.KNOWN_ORDER) {
+            @Override
+            protected Iterator<Integer> newTargetIterator() {
+                return FluentIterable.from(Lists.newArrayList(1, 2, 3)).skip(1).iterator();
+            }
+        }.test();
+    }
+
+    public void testSkip_nonStructurallyModifiedList() throws Exception {
+        List<String> list = Lists.newArrayList("a", "b", "c");
+        FluentIterable<String> tail = FluentIterable.from(list).skip(1);
+        Iterator<String> tailIterator = tail.iterator();
+        list.set(2, "c2");
+        assertEquals("b", tailIterator.next());
+        assertEquals("c2", tailIterator.next());
+        assertFalse(tailIterator.hasNext());
+    }
+
+    public void testSkip_structurallyModifiedSkipSome() throws Exception {
+        Collection<String> set = Sets.newLinkedHashSet();
+        Collections.addAll(set, "a", "b", "c");
+        FluentIterable<String> tail = FluentIterable.from(set).skip(1);
+        set.remove("b");
+        set.addAll(Lists.newArrayList("X", "Y", "Z"));
+        assertThat(tail).containsExactly("c", "X", "Y", "Z").inOrder();
+    }
+
+    public void testSkip_structurallyModifiedSkipSomeList() throws Exception {
+        List<String> list = Lists.newArrayList("a", "b", "c");
+        FluentIterable<String> tail = FluentIterable.from(list).skip(1);
+        list.subList(1, 3).clear();
+        list.addAll(0, Lists.newArrayList("X", "Y", "Z"));
+        assertThat(tail).containsExactly("Y", "Z", "a").inOrder();
+    }
+
+    public void testSkip_structurallyModifiedSkipAll() throws Exception {
+        Collection<String> set = Sets.newLinkedHashSet();
+        Collections.addAll(set, "a", "b", "c");
+        FluentIterable<String> tail = FluentIterable.from(set).skip(2);
+        set.remove("a");
+        set.remove("b");
+        assertFalse(tail.iterator().hasNext());
+    }
+
+    public void testSkip_structurallyModifiedSkipAllList() throws Exception {
+        List<String> list = Lists.newArrayList("a", "b", "c");
+        FluentIterable<String> tail = FluentIterable.from(list).skip(2);
+        list.subList(0, 2).clear();
+        assertThat(tail).isEmpty();
+    }
+
+    public void testSkip_illegalArgument() {
+        try {
+            FluentIterable.from(asList("a", "b", "c")).skip(-1);
+            fail("Skipping negative number of elements should throw IllegalArgumentException.");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void testLimit() {
+        Iterable<String> iterable = Lists.newArrayList("foo", "bar", "baz");
+        FluentIterable<String> limited = FluentIterable.from(iterable).limit(2);
+
+        assertEquals(ImmutableList.of("foo", "bar"), Lists.newArrayList(limited));
+        assertCanIterateAgain(limited);
+        assertEquals("[foo, bar]", limited.toString());
+    }
+
+    public void testLimit_illegalArgument() {
+        try {
+            FluentIterable<String> unused =
+                    FluentIterable.from(Lists.newArrayList("a", "b", "c")).limit(-1);
+            fail("Passing negative number to limit(...) method should throw IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void testIsEmpty() {
+        assertTrue(FluentIterable.<String>from(Collections.<String>emptyList()).isEmpty());
+        assertFalse(FluentIterable.<String>from(Lists.newArrayList("foo")).isEmpty());
+    }
+
+    public void testToList() {
+        assertEquals(Lists.newArrayList(1, 2, 3, 4), fluent(1, 2, 3, 4).toList());
+    }
+
+    public void testToList_empty() {
+        assertTrue(fluent().toList().isEmpty());
+    }
+
+    public void testToSortedList_withComparator() {
+        assertEquals(Lists.newArrayList(4, 3, 2, 1),
+                fluent(4, 1, 3, 2).toSortedList(Ordering.<Integer>natural().reverse()));
+    }
+
+    public void testToSortedList_withDuplicates() {
+        assertEquals(Lists.newArrayList(4, 3, 1, 1),
+                fluent(1, 4, 1, 3).toSortedList(Ordering.<Integer>natural().reverse()));
+    }
+
+    public void testToSet() {
+        assertThat(fluent(1, 2, 3, 4).toSet()).containsExactly(1, 2, 3, 4).inOrder();
+    }
+
+    public void testToSet_removeDuplicates() {
+        assertThat(fluent(1, 2, 1, 2).toSet()).containsExactly(1, 2).inOrder();
+    }
+
+    public void testToSet_empty() {
+        assertTrue(fluent().toSet().isEmpty());
+    }
+
+    public void testToSortedSet() {
+        assertThat(fluent(1, 4, 2, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
+                .containsExactly(4, 3, 2, 1).inOrder();
+    }
+
+    public void testToSortedSet_removeDuplicates() {
+        assertThat(fluent(1, 4, 1, 3).toSortedSet(Ordering.<Integer>natural().reverse()))
+                .containsExactly(4, 3, 1).inOrder();
+    }
+
+    public void testToMultiset() {
+        assertThat(fluent(1, 2, 1, 3, 2, 4).toMultiset()).containsExactly(1, 1, 2, 2, 3, 4).inOrder();
+    }
+
+    public void testToMultiset_empty() {
+        assertThat(fluent().toMultiset()).isEmpty();
+    }
+
+    public void testToMap() {
+        assertThat(fluent(1, 2, 3).toMap(Functions.toStringFunction()).entrySet())
+                .containsExactly(
+                        Maps.immutableEntry(1, "1"),
+                        Maps.immutableEntry(2, "2"),
+                        Maps.immutableEntry(3, "3")).inOrder();
+    }
+
+    public void testToMap_nullKey() {
+        try {
+            fluent(1, null, 2).toMap(Functions.constant("foo"));
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testToMap_nullValue() {
+        try {
+            fluent(1, 2, 3).toMap(Functions.constant(null));
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testIndex() {
+        ImmutableListMultimap<Integer, String> expected =
+                ImmutableListMultimap.<Integer, String>builder()
+                        .putAll(3, "one", "two")
+                        .put(5, "three")
+                        .put(4, "four")
+                        .build();
+        ImmutableListMultimap<Integer, String> index =
+                FluentIterable.from(asList("one", "two", "three", "four")).index(
+                        new Function<String, Integer>() {
+                            @Override
+                            public Integer apply(String input) {
+                                return input.length();
+                            }
+                        });
+        assertEquals(expected, index);
+    }
+
+    public void testIndex_nullKey() {
+        try {
+            ImmutableListMultimap<Object, Integer> unused =
+                    fluent(1, 2, 3).index(Functions.constant(null));
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testIndex_nullValue() {
+        try {
+            ImmutableListMultimap<String, Integer> unused =
+                    fluent(1, null, 2).index(Functions.constant("foo"));
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testUniqueIndex() {
+        ImmutableMap<Integer, String> expected =
+                ImmutableMap.of(3, "two", 5, "three", 4, "four");
+        ImmutableMap<Integer, String> index =
+                FluentIterable.from(asList("two", "three", "four")).uniqueIndex(
+                        new Function<String, Integer>() {
+                            @Override
+                            public Integer apply(String input) {
+                                return input.length();
+                            }
+                        });
+        assertEquals(expected, index);
+    }
+
+    public void testUniqueIndex_duplicateKey() {
+        try {
+            ImmutableMap<Integer, String> unused =
+                    FluentIterable.from(asList("one", "two", "three", "four"))
+                                  .uniqueIndex(
+                                          new Function<String, Integer>() {
+                                              @Override
+                                              public Integer apply(String input) {
+                                                  return input.length();
+                                              }
+                                          });
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    public void testUniqueIndex_nullKey() {
+        try {
+            fluent(1, 2, 3).uniqueIndex(Functions.constant(null));
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testUniqueIndex_nullValue() {
+        try {
+            ImmutableMap<Object, Integer> unused =
+                    fluent(1, null, 2)
+                            .uniqueIndex(
+                                    new Function<Integer, Object>() {
+                                        @Override
+                                        public Object apply(@Nullable Integer input) {
+                                            return String.valueOf(input);
+                                        }
+                                    });
+            fail();
+        } catch (NullPointerException expected) {
+        }
+    }
+
+    public void testCopyInto_List() {
+        assertThat(fluent(1, 3, 5).copyInto(Lists.newArrayList(1, 2)))
+                .containsExactly(1, 2, 1, 3, 5).inOrder();
+    }
+
+    public void testCopyInto_Set() {
+        assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2)))
+                .containsExactly(1, 2, 3, 5);
+    }
+
+    public void testCopyInto_SetAllDuplicates() {
+        assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2, 3, 5)))
+                .containsExactly(1, 2, 3, 5);
+    }
+
+    public void testCopyInto_NonCollection() {
+        final ArrayList<Integer> list = Lists.newArrayList(1, 2, 3);
+
+        final ArrayList<Integer> iterList = Lists.newArrayList(9, 8, 7);
+        Iterable<Integer> iterable = new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return iterList.iterator();
+            }
+        };
+
+        assertThat(FluentIterable.from(iterable).copyInto(list))
+                .containsExactly(1, 2, 3, 9, 8, 7).inOrder();
+    }
+
+    public void testJoin() {
+        assertEquals("2,1,3,4", fluent(2, 1, 3, 4).join(Joiner.on(",")));
+    }
+
+    public void testJoin_empty() {
+        assertEquals("", fluent().join(Joiner.on(",")));
+    }
+
+    public void testGet() {
+        assertEquals("a", FluentIterable
+                .from(Lists.newArrayList("a", "b", "c")).get(0));
+        assertEquals("b", FluentIterable
+                .from(Lists.newArrayList("a", "b", "c")).get(1));
+        assertEquals("c", FluentIterable
+                .from(Lists.newArrayList("a", "b", "c")).get(2));
+    }
+
+    public void testGet_outOfBounds() {
+        try {
+            FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(-1);
+            fail();
+        } catch (IndexOutOfBoundsException expected) {
+        }
+
+        try {
+            FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(3);
+            fail();
+        } catch (IndexOutOfBoundsException expected) {
+        }
+    }
+
+    /*
+     * Full and proper black-box testing of a Stream-returning method is extremely involved, and is
+     * overkill when nearly all Streams are produced using well-tested JDK calls. So, we cheat and
+     * just test that the toArray() contents are as expected.
+     */
+    public void testStream() {
+        assertThat(FluentIterable.of().stream()).isEmpty();
+        assertThat(FluentIterable.of("a").stream()).containsExactly("a");
+        assertThat(FluentIterable.of(1, 2, 3).stream().filter(n -> n > 1)).containsExactly(2, 3);
+    }
+
+    /*
+     * test toMap with two args
+     */
+    public void testToMapWithDefaultMergeFunction() {
+        Map<String, Integer> actualMap = FluentIterable.from(Lists.newArrayList(
+                new Foo("a", 1),
+                new Foo("b", 2)
+        )).toMap(new Function<Foo, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Foo foo) {
+                return foo.getKey();
+            }
+        }, new Function<Foo, Integer>() {
+            @Nullable
+            @Override
+            public Integer apply(@Nullable Foo foo) {
+                return foo.getValue();
+            }
+        });
+
+        Map<String, Integer> expectedMap = Maps.newHashMap();
+        expectedMap.put("a",1);
+        expectedMap.put("b",2);
+        assertEquals(expectedMap, actualMap);
+    }
+
+    /*
+     * test toMap with two args
+     */
+    public void testToMapWithDefaultMergeFunction_keyConflict() {
+        try {
+            FluentIterable.from(Lists.newArrayList(
+                    new Foo("a", 1),
+                    new Foo("a", 2)
+            )).toMap(new Function<Foo, String>() {
+                @Nullable
+                @Override
+                public String apply(@Nullable Foo foo) {
+                    return foo.getKey();
+                }
+            }, new Function<Foo, Integer>() {
+                @Nullable
+                @Override
+                public Integer apply(@Nullable Foo foo) {
+                    return foo.getValue();
+                }
             });
-    assertEquals(expected, index);
-  }
-
-  public void testIndex_nullKey() {
-    try {
-      ImmutableListMultimap<Object, Integer> unused =
-          fluent(1, 2, 3).index(Functions.constant(null));
-      fail();
-    } catch (NullPointerException expected) {
-    }
-  }
-
-  public void testIndex_nullValue() {
-    try {
-      ImmutableListMultimap<String, Integer> unused =
-          fluent(1, null, 2).index(Functions.constant("foo"));
-      fail();
-    } catch (NullPointerException expected) {
-    }
-  }
-
-  public void testUniqueIndex() {
-    ImmutableMap<Integer, String> expected =
-        ImmutableMap.of(3, "two", 5, "three", 4, "four");
-    ImmutableMap<Integer, String> index =
-        FluentIterable.from(asList("two", "three", "four")).uniqueIndex(
-            new Function<String, Integer>() {
-              @Override
-              public Integer apply(String input) {
-                return input.length();
-              }
-            });
-    assertEquals(expected, index);
-  }
-
-  public void testUniqueIndex_duplicateKey() {
-    try {
-      ImmutableMap<Integer, String> unused =
-          FluentIterable.from(asList("one", "two", "three", "four"))
-              .uniqueIndex(
-                  new Function<String, Integer>() {
-                    @Override
-                    public Integer apply(String input) {
-                      return input.length();
-                    }
-                  });
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
-  }
-
-  public void testUniqueIndex_nullKey() {
-    try {
-      fluent(1, 2, 3).uniqueIndex(Functions.constant(null));
-      fail();
-    } catch (NullPointerException expected) {
-    }
-  }
-
-  public void testUniqueIndex_nullValue() {
-    try {
-      ImmutableMap<Object, Integer> unused =
-          fluent(1, null, 2)
-              .uniqueIndex(
-                  new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(@Nullable Integer input) {
-                      return String.valueOf(input);
-                    }
-                  });
-      fail();
-    } catch (NullPointerException expected) {
-    }
-  }
-
-  public void testCopyInto_List() {
-    assertThat(fluent(1, 3, 5).copyInto(Lists.newArrayList(1, 2)))
-        .containsExactly(1, 2, 1, 3, 5).inOrder();
-  }
-
-  public void testCopyInto_Set() {
-    assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2)))
-        .containsExactly(1, 2, 3, 5);
-  }
-
-  public void testCopyInto_SetAllDuplicates() {
-    assertThat(fluent(1, 3, 5).copyInto(Sets.newHashSet(1, 2, 3, 5)))
-        .containsExactly(1, 2, 3, 5);
-  }
-
-  public void testCopyInto_NonCollection() {
-    final ArrayList<Integer> list = Lists.newArrayList(1, 2, 3);
-
-    final ArrayList<Integer> iterList = Lists.newArrayList(9, 8, 7);
-    Iterable<Integer> iterable = new Iterable<Integer>() {
-      @Override
-      public Iterator<Integer> iterator() {
-        return iterList.iterator();
-      }
-    };
-
-    assertThat(FluentIterable.from(iterable).copyInto(list))
-        .containsExactly(1, 2, 3, 9, 8, 7).inOrder();
-  }
-
-  public void testJoin() {
-    assertEquals("2,1,3,4", fluent(2, 1, 3, 4).join(Joiner.on(",")));
-  }
-
-  public void testJoin_empty() {
-    assertEquals("", fluent().join(Joiner.on(",")));
-  }
-
-  public void testGet() {
-    assertEquals("a", FluentIterable
-        .from(Lists.newArrayList("a", "b", "c")).get(0));
-    assertEquals("b", FluentIterable
-        .from(Lists.newArrayList("a", "b", "c")).get(1));
-    assertEquals("c", FluentIterable
-        .from(Lists.newArrayList("a", "b", "c")).get(2));
-  }
-
-  public void testGet_outOfBounds() {
-    try {
-      FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(-1);
-      fail();
-    } catch (IndexOutOfBoundsException expected) {
+        } catch (IllegalStateException e) {
+            assertTrue(true);
+            return;
+        }
+        fail();
     }
 
-    try {
-      FluentIterable.from(Lists.newArrayList("a", "b", "c")).get(3);
-      fail();
-    } catch (IndexOutOfBoundsException expected) {
+    /*
+     * test toMap with three args
+     */
+    public void testToMapWithMergeFunction_keyConflict() {
+        Map<String, Integer> actualMap = FluentIterable.from(Lists.newArrayList(
+                new Foo("a", 1),
+                new Foo("a", 2)
+        )).toMap(new Function<Foo, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable Foo foo) {
+                return foo.getKey();
+            }
+        }, new Function<Foo, Integer>() {
+            @Nullable
+            @Override
+            public Integer apply(@Nullable Foo foo) {
+                return foo.getValue();
+            }
+        }, new MergeFunction<Integer>() {
+            @Override
+            public Integer apply(Integer oldValue, Integer newValue) {
+                return oldValue + newValue;
+            }
+        });
+
+        Map<String, Integer> expectedMap = Maps.newHashMap();
+        expectedMap.put("a",3);
+        assertEquals(expectedMap, actualMap);
     }
-  }
 
-  /*
-   * Full and proper black-box testing of a Stream-returning method is extremely involved, and is
-   * overkill when nearly all Streams are produced using well-tested JDK calls. So, we cheat and
-   * just test that the toArray() contents are as expected.
-   */
-  public void testStream() {
-    assertThat(FluentIterable.of().stream()).isEmpty();
-    assertThat(FluentIterable.of("a").stream()).containsExactly("a");
-    assertThat(FluentIterable.of(1, 2, 3).stream().filter(n -> n > 1)).containsExactly(2, 3);
-  }
+    private class Foo {
 
-  // TODO(kevinb): add assertThat(Stream) to Truth?
-  static class Help {
-    static IterableSubject assertThat(Stream<?> stream) {
-      return Truth.assertThat(stream.toArray()).asList();
+        private String key;
+
+        private Integer value;
+
+
+        public Foo(String key, Integer value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public Integer getValue() {
+            return value;
+        }
     }
-  }
 
-  private static void assertCanIterateAgain(Iterable<?> iterable) {
-    for (Object unused : iterable) {
-      // do nothing
+    // TODO(kevinb): add assertThat(Stream) to Truth?
+    static class Help {
+        static IterableSubject assertThat(Stream<?> stream) {
+            return Truth.assertThat(stream.toArray()).asList();
+        }
     }
-  }
 
-  private static FluentIterable<Integer> fluent(Integer... elements) {
-    return FluentIterable.from(Lists.newArrayList(elements));
-  }
+    private static void assertCanIterateAgain(Iterable<?> iterable) {
+        for (Object unused : iterable) {
+            // do nothing
+        }
+    }
 
-  private static Iterable<String> iterable(String... elements) {
-    final List<String> list = asList(elements);
-    return new Iterable<String>() {
-      @Override
-      public Iterator<String> iterator() {
-        return list.iterator();
-      }
-    };
-  }
+    private static FluentIterable<Integer> fluent(Integer... elements) {
+        return FluentIterable.from(Lists.newArrayList(elements));
+    }
+
+    private static Iterable<String> iterable(String... elements) {
+        final List<String> list = asList(elements);
+        return new Iterable<String>() {
+            @Override
+            public Iterator<String> iterator() {
+                return list.iterator();
+            }
+        };
+    }
 }

--- a/guava/src/com/google/common/base/BiFunction.java
+++ b/guava/src/com/google/common/base/BiFunction.java
@@ -1,0 +1,11 @@
+package com.google.common.base;
+
+/**
+ * Imitate java8 implementation of BiFunction.
+ * Represents a function that accepts two arguments and produces a result.
+ * Created by lizhibo on 2017/8/12.
+ */
+public interface BiFunction<T, U, R> {
+
+    R apply(T t,U u);
+}

--- a/guava/src/com/google/common/base/MergeFunction.java
+++ b/guava/src/com/google/common/base/MergeFunction.java
@@ -1,0 +1,19 @@
+package com.google.common.base;
+
+/**
+ * When the toMap occurs when the key conflict,
+ * will call this interface to deal with the conflict,
+ * the interface receives two values, the old value and the new value,
+ * return the value after the combination of key
+ * Created by lizhibo on 2017/8/12.
+ */
+public interface MergeFunction<V> extends BiFunction<V,V,V>  {
+
+    /**
+     *
+     * @param oldValue
+     * @param newValue
+     * @return The combined value
+     */
+    V apply(V oldValue,V newValue);
+}

--- a/guava/src/com/google/common/collect/FluentIterable.java
+++ b/guava/src/com/google/common/collect/FluentIterable.java
@@ -19,67 +19,62 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
+import com.google.common.base.*;
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.SortedSet;
+
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
  * A discouraged (but not deprecated) precursor to Java's superior {@link Stream} library.
- *
+ * <p>
  * <p>The following types of methods are provided:
- *
+ * <p>
  * <ul>
  * <li>chaining methods which return a new {@code FluentIterable} based in some way on the contents
- *     of the current one (for example {@link #transform})
+ * of the current one (for example {@link #transform})
  * <li>element extraction methods which facilitate the retrieval of certain elements (for example
- *     {@link #last})
+ * {@link #last})
  * <li>query methods which answer questions about the {@code FluentIterable}'s contents (for example
- *     {@link #anyMatch})
+ * {@link #anyMatch})
  * <li>conversion methods which copy the {@code FluentIterable}'s contents into a new collection or
- *     array (for example {@link #toList})
+ * array (for example {@link #toList})
  * </ul>
- *
+ * <p>
  * <p>Several lesser-used features are currently available only as static methods on the {@link
  * Iterables} class.
- *
+ * <p>
  * <a name="streams"></a>
  * <h3>Comparison to streams</h3>
- *
+ * <p>
  * <p>{@link Stream} is similar to this class, but generally more powerful, and certainly more
  * standard. Key differences include:
- *
+ * <p>
  * <ul>
  * <li>A stream is <i>single-use</i>; it becomes invalid as soon as any "terminal operation" such as
- *     {@code findFirst()} or {@code iterator()} is invoked. (Even though {@code Stream} contains
- *     all the right method <i>signatures</i> to implement {@link Iterable}, it does not actually do
- *     so, to avoid implying repeat-iterability.) {@code FluentIterable}, on the other hand, is
- *     multiple-use, and does implement {@link Iterable}.
+ * {@code findFirst()} or {@code iterator()} is invoked. (Even though {@code Stream} contains
+ * all the right method <i>signatures</i> to implement {@link Iterable}, it does not actually do
+ * so, to avoid implying repeat-iterability.) {@code FluentIterable}, on the other hand, is
+ * multiple-use, and does implement {@link Iterable}.
  * <li>Streams offer many features not found here, including {@code min/max}, {@code distinct},
- *     {@code reduce}, {@code sorted}, the very powerful {@code collect}, and built-in support for
- *     parallelizing stream operations.
+ * {@code reduce}, {@code sorted}, the very powerful {@code collect}, and built-in support for
+ * parallelizing stream operations.
  * <li>{@code FluentIterable} contains several features not available on {@code Stream}, which are
- *     noted in the method descriptions below.
+ * noted in the method descriptions below.
  * <li>Streams include primitive-specialized variants such as {@code IntStream}, the use of which is
- *     strongly recommended.
+ * strongly recommended.
  * <li>Streams are standard Java, not requiring a third-party dependency.
  * </ul>
- *
+ * <p>
  * <h3>Example</h3>
- *
+ * <p>
  * <p>Here is an example that accepts a list from a database call, filters it based on a predicate,
  * transforms it by invoking {@code toString()} on each element, and returns the first 10 elements
  * as a {@code List}:
- *
+ * <p>
  * <pre>{@code
  * ImmutableList<String> results =
  *     FluentIterable.from(database.getClientList())
@@ -88,9 +83,9 @@ import javax.annotation.Nullable;
  *         .limit(10)
  *         .toList();
  * }</pre>
- *
+ * <p>
  * The approximate stream equivalent is:
- *
+ * <p>
  * <pre>{@code
  * List<String> results =
  *     database.getClientList()
@@ -106,748 +101,797 @@ import javax.annotation.Nullable;
  */
 @GwtCompatible(emulated = true)
 public abstract class FluentIterable<E> implements Iterable<E> {
-  // We store 'iterable' and use it instead of 'this' to allow Iterables to perform instanceof
-  // checks on the _original_ iterable when FluentIterable.from is used.
-  // To avoid a self retain cycle under j2objc, we store Optional.absent() instead of
-  // Optional.of(this). To access the iterator delegate, call #getDelegate(), which converts to
-  // absent() back to 'this'.
-  private final Optional<Iterable<E>> iterableDelegate;
+    // We store 'iterable' and use it instead of 'this' to allow Iterables to perform instanceof
+    // checks on the _original_ iterable when FluentIterable.from is used.
+    // To avoid a self retain cycle under j2objc, we store Optional.absent() instead of
+    // Optional.of(this). To access the iterator delegate, call #getDelegate(), which converts to
+    // absent() back to 'this'.
+    private final Optional<Iterable<E>> iterableDelegate;
 
-  /** Constructor for use by subclasses. */
-  protected FluentIterable() {
-    this.iterableDelegate = Optional.absent();
-  }
+    /**
+     * Constructor for use by subclasses.
+     */
+    protected FluentIterable() {
+        this.iterableDelegate = Optional.absent();
+    }
 
-  FluentIterable(Iterable<E> iterable) {
-    checkNotNull(iterable);
-    this.iterableDelegate = Optional.fromNullable(this != iterable ? iterable : null);
-  }
+    FluentIterable(Iterable<E> iterable) {
+        checkNotNull(iterable);
+        this.iterableDelegate = Optional.fromNullable(this != iterable ? iterable : null);
+    }
 
-  private Iterable<E> getDelegate() {
-    return iterableDelegate.or(this);
-  }
+    private Iterable<E> getDelegate() {
+        return iterableDelegate.or(this);
+    }
 
-  /**
-   * Returns a fluent iterable that wraps {@code iterable}, or {@code iterable} itself if it is
-   * already a {@code FluentIterable}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Collection#stream} if {@code iterable} is a
-   * {@link Collection}; {@link Streams#stream(Iterable)} otherwise.
-   */
-  public static <E> FluentIterable<E> from(final Iterable<E> iterable) {
-    return (iterable instanceof FluentIterable)
-        ? (FluentIterable<E>) iterable
-        : new FluentIterable<E>(iterable) {
-          @Override
-          public Iterator<E> iterator() {
-            return iterable.iterator();
-          }
+    /**
+     * Returns a fluent iterable that wraps {@code iterable}, or {@code iterable} itself if it is
+     * already a {@code FluentIterable}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Collection#stream} if {@code iterable} is a
+     * {@link Collection}; {@link Streams#stream(Iterable)} otherwise.
+     */
+    public static <E> FluentIterable<E> from(final Iterable<E> iterable) {
+        return (iterable instanceof FluentIterable)
+                ? (FluentIterable<E>) iterable
+                : new FluentIterable<E>(iterable) {
+            @Override
+            public Iterator<E> iterator() {
+                return iterable.iterator();
+            }
         };
-  }
-
-  /**
-   * Returns a fluent iterable containing {@code elements} in the specified order.
-   *
-   * <p>The returned iterable is an unmodifiable view of the input array.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link java.util.stream.Stream#of(Object[])
-   * Stream.of(T...)}.
-   *
-   * @since 20.0 (since 18.0 as an overload of {@code of})
-   */
-  @Beta
-  public static <E> FluentIterable<E> from(E[] elements) {
-    return from(Arrays.asList(elements));
-  }
-
-  /**
-   * Construct a fluent iterable from another fluent iterable. This is obviously never necessary,
-   * but is intended to help call out cases where one migration from {@code Iterable} to
-   * {@code FluentIterable} has obviated the need to explicitly convert to a {@code FluentIterable}.
-   *
-   * @deprecated instances of {@code FluentIterable} don't need to be converted to
-   *     {@code FluentIterable}
-   */
-  @Deprecated
-  public static <E> FluentIterable<E> from(FluentIterable<E> iterable) {
-    return checkNotNull(iterable);
-  }
-
-  /**
-   * Returns a fluent iterable that combines two iterables. The returned iterable has an iterator
-   * that traverses the elements in {@code a}, followed by the elements in {@code b}. The source
-   * iterators are not polled until necessary.
-   *
-   * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
-   * iterator supports it.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#concat}.
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <T> FluentIterable<T> concat(Iterable<? extends T> a, Iterable<? extends T> b) {
-    return concatNoDefensiveCopy(a, b);
-  }
-
-  /**
-   * Returns a fluent iterable that combines three iterables. The returned iterable has an iterator
-   * that traverses the elements in {@code a}, followed by the elements in {@code b}, followed by
-   * the elements in {@code c}. The source iterators are not polled until necessary.
-   *
-   * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
-   * iterator supports it.
-   *
-   * <p><b>{@code Stream} equivalent:</b> use nested calls to {@link Stream#concat}, or see the
-   * advice in {@link #concat(Iterable...)}.
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <T> FluentIterable<T> concat(
-      Iterable<? extends T> a, Iterable<? extends T> b, Iterable<? extends T> c) {
-    return concatNoDefensiveCopy(a, b, c);
-  }
-
-  /**
-   * Returns a fluent iterable that combines four iterables. The returned iterable has an iterator
-   * that traverses the elements in {@code a}, followed by the elements in {@code b}, followed by
-   * the elements in {@code c}, followed by the elements in {@code d}. The source iterators are not
-   * polled until necessary.
-   *
-   * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
-   * iterator supports it.
-   *
-   * <p><b>{@code Stream} equivalent:</b> use nested calls to {@link Stream#concat}, or see the
-   * advice in {@link #concat(Iterable...)}.
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <T> FluentIterable<T> concat(
-      Iterable<? extends T> a,
-      Iterable<? extends T> b,
-      Iterable<? extends T> c,
-      Iterable<? extends T> d) {
-    return concatNoDefensiveCopy(a, b, c, d);
-  }
-
-  /**
-   * Returns a fluent iterable that combines several iterables. The returned iterable has an
-   * iterator that traverses the elements of each iterable in {@code inputs}. The input iterators
-   * are not polled until necessary.
-   *
-   * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
-   * iterator supports it.
-   *
-   * <p><b>{@code Stream} equivalent:</b> to concatenate an arbitrary number of streams, use {@code
-   * Stream.of(stream1, stream2, ...).flatMap(s -> s)}. If the sources are iterables, use {@code
-   * Stream.of(iter1, iter2, ...).flatMap(Streams::stream)}.
-   *
-   * @throws NullPointerException if any of the provided iterables is {@code null}
-   * @since 20.0
-   */
-  @Beta
-  public static <T> FluentIterable<T> concat(Iterable<? extends T>... inputs) {
-    return concatNoDefensiveCopy(Arrays.copyOf(inputs, inputs.length));
-  }
-
-  /** Concatenates a varargs array of iterables without making a defensive copy of the array. */
-  private static <T> FluentIterable<T> concatNoDefensiveCopy(
-      final Iterable<? extends T>... inputs) {
-    for (Iterable<? extends T> input : inputs) {
-      checkNotNull(input);
     }
-    return new FluentIterable<T>() {
-      @Override
-      public Iterator<T> iterator() {
-        return Iterators.concat(
+
+    /**
+     * Returns a fluent iterable containing {@code elements} in the specified order.
+     * <p>
+     * <p>The returned iterable is an unmodifiable view of the input array.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link java.util.stream.Stream#of(Object[])
+     * Stream.of(T...)}.
+     *
+     * @since 20.0 (since 18.0 as an overload of {@code of})
+     */
+    @Beta
+    public static <E> FluentIterable<E> from(E[] elements) {
+        return from(Arrays.asList(elements));
+    }
+
+    /**
+     * Construct a fluent iterable from another fluent iterable. This is obviously never necessary,
+     * but is intended to help call out cases where one migration from {@code Iterable} to
+     * {@code FluentIterable} has obviated the need to explicitly convert to a {@code FluentIterable}.
+     *
+     * @deprecated instances of {@code FluentIterable} don't need to be converted to
+     * {@code FluentIterable}
+     */
+    @Deprecated
+    public static <E> FluentIterable<E> from(FluentIterable<E> iterable) {
+        return checkNotNull(iterable);
+    }
+
+    /**
+     * Returns a fluent iterable that combines two iterables. The returned iterable has an iterator
+     * that traverses the elements in {@code a}, followed by the elements in {@code b}. The source
+     * iterators are not polled until necessary.
+     * <p>
+     * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
+     * iterator supports it.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#concat}.
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <T> FluentIterable<T> concat(Iterable<? extends T> a, Iterable<? extends T> b) {
+        return concatNoDefensiveCopy(a, b);
+    }
+
+    /**
+     * Returns a fluent iterable that combines three iterables. The returned iterable has an iterator
+     * that traverses the elements in {@code a}, followed by the elements in {@code b}, followed by
+     * the elements in {@code c}. The source iterators are not polled until necessary.
+     * <p>
+     * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
+     * iterator supports it.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> use nested calls to {@link Stream#concat}, or see the
+     * advice in {@link #concat(Iterable...)}.
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <T> FluentIterable<T> concat(
+            Iterable<? extends T> a, Iterable<? extends T> b, Iterable<? extends T> c) {
+        return concatNoDefensiveCopy(a, b, c);
+    }
+
+    /**
+     * Returns a fluent iterable that combines four iterables. The returned iterable has an iterator
+     * that traverses the elements in {@code a}, followed by the elements in {@code b}, followed by
+     * the elements in {@code c}, followed by the elements in {@code d}. The source iterators are not
+     * polled until necessary.
+     * <p>
+     * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
+     * iterator supports it.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> use nested calls to {@link Stream#concat}, or see the
+     * advice in {@link #concat(Iterable...)}.
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <T> FluentIterable<T> concat(
+            Iterable<? extends T> a,
+            Iterable<? extends T> b,
+            Iterable<? extends T> c,
+            Iterable<? extends T> d) {
+        return concatNoDefensiveCopy(a, b, c, d);
+    }
+
+    /**
+     * Returns a fluent iterable that combines several iterables. The returned iterable has an
+     * iterator that traverses the elements of each iterable in {@code inputs}. The input iterators
+     * are not polled until necessary.
+     * <p>
+     * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
+     * iterator supports it.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> to concatenate an arbitrary number of streams, use {@code
+     * Stream.of(stream1, stream2, ...).flatMap(s -> s)}. If the sources are iterables, use {@code
+     * Stream.of(iter1, iter2, ...).flatMap(Streams::stream)}.
+     *
+     * @throws NullPointerException if any of the provided iterables is {@code null}
+     * @since 20.0
+     */
+    @Beta
+    public static <T> FluentIterable<T> concat(Iterable<? extends T>... inputs) {
+        return concatNoDefensiveCopy(Arrays.copyOf(inputs, inputs.length));
+    }
+
+    /**
+     * Concatenates a varargs array of iterables without making a defensive copy of the array.
+     */
+    private static <T> FluentIterable<T> concatNoDefensiveCopy(
+            final Iterable<? extends T>... inputs) {
+        for (Iterable<? extends T> input : inputs) {
+            checkNotNull(input);
+        }
+        return new FluentIterable<T>() {
+            @Override
+            public Iterator<T> iterator() {
+                return Iterators.concat(
             /* lazily generate the iterators on each input only as needed */
-            new AbstractIndexedListIterator<Iterator<? extends T>>(inputs.length) {
-              @Override
-              public Iterator<? extends T> get(int i) {
-                return inputs[i].iterator();
-              }
-            });
-      }
-    };
-  }
-
-  /**
-   * Returns a fluent iterable that combines several iterables. The returned iterable has an
-   * iterator that traverses the elements of each iterable in {@code inputs}. The input iterators
-   * are not polled until necessary.
-   *
-   * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
-   * iterator supports it. The methods of the returned iterable may throw {@code
-   * NullPointerException} if any of the input iterators is {@code null}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code streamOfStreams.flatMap(s -> s)} or {@code
-   * streamOfIterables.flatMap(Streams::stream)}. (See {@link Streams#stream}.)
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <T> FluentIterable<T> concat(
-      final Iterable<? extends Iterable<? extends T>> inputs) {
-    checkNotNull(inputs);
-    return new FluentIterable<T>() {
-      @Override
-      public Iterator<T> iterator() {
-        return Iterators.concat(Iterators.transform(inputs.iterator(), Iterables.<T>toIterator()));
-      }
-    };
-  }
-
-  /**
-   * Returns a fluent iterable containing no elements.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#empty}.
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <E> FluentIterable<E> of() {
-    return FluentIterable.from(ImmutableList.<E>of());
-  }
-
-  /**
-   * Returns a fluent iterable containing the specified elements in order.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link java.util.stream.Stream#of(Object[])
-   * Stream.of(T...)}.
-   *
-   * @since 20.0
-   */
-  @Beta
-  public static <E> FluentIterable<E> of(@Nullable E element, E... elements) {
-    return from(Lists.asList(element, elements));
-  }
-
-  /**
-   * Returns a string representation of this fluent iterable, with the format {@code [e1, e2, ...,
-   * en]}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.collect(Collectors.joining(", ", "[", "]"))}
-   * or (less efficiently) {@code stream.collect(Collectors.toList()).toString()}.
-   */
-  @Override
-  public String toString() {
-    return Iterables.toString(getDelegate());
-  }
-
-  /**
-   * Returns the number of elements in this fluent iterable.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#count}.
-   */
-  public final int size() {
-    return Iterables.size(getDelegate());
-  }
-
-  /**
-   * Returns {@code true} if this fluent iterable contains any object for which
-   * {@code equals(target)} is true.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.anyMatch(Predicate.isEqual(target))}.
-   */
-  public final boolean contains(@Nullable Object target) {
-    return Iterables.contains(getDelegate(), target);
-  }
-
-  /**
-   * Returns a fluent iterable whose {@code Iterator} cycles indefinitely over the elements of this
-   * fluent iterable.
-   *
-   * <p>That iterator supports {@code remove()} if {@code iterable.iterator()} does. After
-   * {@code remove()} is called, subsequent cycles omit the removed element, which is no longer in
-   * this fluent iterable. The iterator's {@code hasNext()} method returns {@code true} until this
-   * fluent iterable is empty.
-   *
-   * <p><b>Warning:</b> Typical uses of the resulting iterator may produce an infinite loop. You
-   * should use an explicit {@code break} or be certain that you will eventually remove all the
-   * elements.
-   *
-   * <p><b>{@code Stream} equivalent:</b> if the source iterable has only a single element {@code
-   * e}, use {@code Stream.generate(() -> e)}. Otherwise, collect your stream into a collection and
-   * use {@code Stream.generate(() -> collection).flatMap(Collection::stream)}.
-   */
-  public final FluentIterable<E> cycle() {
-    return from(Iterables.cycle(getDelegate()));
-  }
-
-  /**
-   * Returns a fluent iterable whose iterators traverse first the elements of this fluent iterable,
-   * followed by those of {@code other}. The iterators are not polled until necessary.
-   *
-   * <p>The returned iterable's {@code Iterator} supports {@code remove()} when the corresponding
-   * {@code Iterator} supports it.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#concat}.
-   *
-   * @since 18.0
-   */
-  @Beta
-  public final FluentIterable<E> append(Iterable<? extends E> other) {
-    return FluentIterable.concat(getDelegate(), other);
-  }
-
-  /**
-   * Returns a fluent iterable whose iterators traverse first the elements of this fluent iterable,
-   * followed by {@code elements}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code Stream.concat(thisStream, Stream.of(elements))}.
-   *
-   * @since 18.0
-   */
-  @Beta
-  public final FluentIterable<E> append(E... elements) {
-    return FluentIterable.concat(getDelegate(), Arrays.asList(elements));
-  }
-
-  /**
-   * Returns the elements from this fluent iterable that satisfy a predicate. The resulting fluent
-   * iterable's iterator does not support {@code remove()}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#filter} (same).
-   */
-  public final FluentIterable<E> filter(Predicate<? super E> predicate) {
-    return from(Iterables.filter(getDelegate(), predicate));
-  }
-
-  /**
-   * Returns the elements from this fluent iterable that are instances of class {@code type}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.filter(type::isInstance).map(type::cast)}.
-   * This does perform a little more work than necessary, so another option is to insert an
-   * unchecked cast at some later point:
-   *
-   * <pre>
-   * {@code @SuppressWarnings("unchecked") // safe because of ::isInstance check
-   * ImmutableList<NewType> result =
-   *     (ImmutableList) stream.filter(NewType.class::isInstance).collect(toImmutableList());}
-   * </pre>
-   */
-  @GwtIncompatible // Class.isInstance
-  public final <T> FluentIterable<T> filter(Class<T> type) {
-    return from(Iterables.filter(getDelegate(), type));
-  }
-
-  /**
-   * Returns {@code true} if any element in this fluent iterable satisfies the predicate.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#anyMatch} (same).
-   */
-  public final boolean anyMatch(Predicate<? super E> predicate) {
-    return Iterables.any(getDelegate(), predicate);
-  }
-
-  /**
-   * Returns {@code true} if every element in this fluent iterable satisfies the predicate. If this
-   * fluent iterable is empty, {@code true} is returned.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#allMatch} (same).
-   */
-  public final boolean allMatch(Predicate<? super E> predicate) {
-    return Iterables.all(getDelegate(), predicate);
-  }
-
-  /**
-   * Returns an {@link Optional} containing the first element in this fluent iterable that satisfies
-   * the given predicate, if such an element exists.
-   *
-   * <p><b>Warning:</b> avoid using a {@code predicate} that matches {@code null}. If {@code null}
-   * is matched in this fluent iterable, a {@link NullPointerException} will be thrown.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.filter(predicate).findFirst()}.
-   */
-  public final Optional<E> firstMatch(Predicate<? super E> predicate) {
-    return Iterables.tryFind(getDelegate(), predicate);
-  }
-
-  /**
-   * Returns a fluent iterable that applies {@code function} to each element of this fluent
-   * iterable.
-   *
-   * <p>The returned fluent iterable's iterator supports {@code remove()} if this iterable's
-   * iterator does. After a successful {@code remove()} call, this fluent iterable no longer
-   * contains the corresponding element.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#map}.
-   */
-  public final <T> FluentIterable<T> transform(Function<? super E, T> function) {
-    return from(Iterables.transform(getDelegate(), function));
-  }
-
-  /**
-   * Applies {@code function} to each element of this fluent iterable and returns a fluent iterable
-   * with the concatenated combination of results. {@code function} returns an Iterable of results.
-   *
-   * <p>The returned fluent iterable's iterator supports {@code remove()} if this function-returned
-   * iterables' iterator does. After a successful {@code remove()} call, the returned fluent
-   * iterable no longer contains the corresponding element.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#flatMap} (using a function that produces
-   * streams, not iterables).
-   *
-   * @since 13.0 (required {@code Function<E, Iterable<T>>} until 14.0)
-   */
-  public <T> FluentIterable<T> transformAndConcat(
-      Function<? super E, ? extends Iterable<? extends T>> function) {
-    return FluentIterable.concat(transform(function));
-  }
-
-  /**
-   * Returns an {@link Optional} containing the first element in this fluent iterable. If the
-   * iterable is empty, {@code Optional.absent()} is returned.
-   *
-   * <p><b>{@code Stream} equivalent:</b> if the goal is to obtain any element, {@link
-   * Stream#findAny}; if it must specifically be the <i>first</i> element, {@code Stream#findFirst}.
-   *
-   * @throws NullPointerException if the first element is null; if this is a possibility, use {@code
-   *     iterator().next()} or {@link Iterables#getFirst} instead.
-   */
-  public final Optional<E> first() {
-    Iterator<E> iterator = getDelegate().iterator();
-    return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.<E>absent();
-  }
-
-  /**
-   * Returns an {@link Optional} containing the last element in this fluent iterable. If the
-   * iterable is empty, {@code Optional.absent()} is returned. If the underlying {@code iterable}
-   * is a {@link List} with {@link java.util.RandomAccess} support, then this operation is
-   * guaranteed to be {@code O(1)}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.reduce((a, b) -> b)}.
-   *
-   * @throws NullPointerException if the last element is null; if this is a possibility, use
-   *     {@link Iterables#getLast} instead.
-   */
-  public final Optional<E> last() {
-    // Iterables#getLast was inlined here so we don't have to throw/catch a NSEE
-
-    // TODO(kevinb): Support a concurrently modified collection?
-    Iterable<E> iterable = getDelegate();
-    if (iterable instanceof List) {
-      List<E> list = (List<E>) iterable;
-      if (list.isEmpty()) {
-        return Optional.absent();
-      }
-      return Optional.of(list.get(list.size() - 1));
+                        new AbstractIndexedListIterator<Iterator<? extends T>>(inputs.length) {
+                            @Override
+                            public Iterator<? extends T> get(int i) {
+                                return inputs[i].iterator();
+                            }
+                        });
+            }
+        };
     }
-    Iterator<E> iterator = iterable.iterator();
-    if (!iterator.hasNext()) {
-      return Optional.absent();
+
+    /**
+     * Returns a fluent iterable that combines several iterables. The returned iterable has an
+     * iterator that traverses the elements of each iterable in {@code inputs}. The input iterators
+     * are not polled until necessary.
+     * <p>
+     * <p>The returned iterable's iterator supports {@code remove()} when the corresponding input
+     * iterator supports it. The methods of the returned iterable may throw {@code
+     * NullPointerException} if any of the input iterators is {@code null}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code streamOfStreams.flatMap(s -> s)} or {@code
+     * streamOfIterables.flatMap(Streams::stream)}. (See {@link Streams#stream}.)
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <T> FluentIterable<T> concat(
+            final Iterable<? extends Iterable<? extends T>> inputs) {
+        checkNotNull(inputs);
+        return new FluentIterable<T>() {
+            @Override
+            public Iterator<T> iterator() {
+                return Iterators.concat(Iterators.transform(inputs.iterator(), Iterables.<T>toIterator()));
+            }
+        };
     }
+
+    /**
+     * Returns a fluent iterable containing no elements.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#empty}.
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <E> FluentIterable<E> of() {
+        return FluentIterable.from(ImmutableList.<E>of());
+    }
+
+    /**
+     * Returns a fluent iterable containing the specified elements in order.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link java.util.stream.Stream#of(Object[])
+     * Stream.of(T...)}.
+     *
+     * @since 20.0
+     */
+    @Beta
+    public static <E> FluentIterable<E> of(@Nullable E element, E... elements) {
+        return from(Lists.asList(element, elements));
+    }
+
+    /**
+     * Returns a string representation of this fluent iterable, with the format {@code [e1, e2, ...,
+     * en]}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.collect(Collectors.joining(", ", "[", "]"))}
+     * or (less efficiently) {@code stream.collect(Collectors.toList()).toString()}.
+     */
+    @Override
+    public String toString() {
+        return Iterables.toString(getDelegate());
+    }
+
+    /**
+     * Returns the number of elements in this fluent iterable.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#count}.
+     */
+    public final int size() {
+        return Iterables.size(getDelegate());
+    }
+
+    /**
+     * Returns {@code true} if this fluent iterable contains any object for which
+     * {@code equals(target)} is true.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.anyMatch(Predicate.isEqual(target))}.
+     */
+    public final boolean contains(@Nullable Object target) {
+        return Iterables.contains(getDelegate(), target);
+    }
+
+    /**
+     * Returns a fluent iterable whose {@code Iterator} cycles indefinitely over the elements of this
+     * fluent iterable.
+     * <p>
+     * <p>That iterator supports {@code remove()} if {@code iterable.iterator()} does. After
+     * {@code remove()} is called, subsequent cycles omit the removed element, which is no longer in
+     * this fluent iterable. The iterator's {@code hasNext()} method returns {@code true} until this
+     * fluent iterable is empty.
+     * <p>
+     * <p><b>Warning:</b> Typical uses of the resulting iterator may produce an infinite loop. You
+     * should use an explicit {@code break} or be certain that you will eventually remove all the
+     * elements.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> if the source iterable has only a single element {@code
+     * e}, use {@code Stream.generate(() -> e)}. Otherwise, collect your stream into a collection and
+     * use {@code Stream.generate(() -> collection).flatMap(Collection::stream)}.
+     */
+    public final FluentIterable<E> cycle() {
+        return from(Iterables.cycle(getDelegate()));
+    }
+
+    /**
+     * Returns a fluent iterable whose iterators traverse first the elements of this fluent iterable,
+     * followed by those of {@code other}. The iterators are not polled until necessary.
+     * <p>
+     * <p>The returned iterable's {@code Iterator} supports {@code remove()} when the corresponding
+     * {@code Iterator} supports it.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#concat}.
+     *
+     * @since 18.0
+     */
+    @Beta
+    public final FluentIterable<E> append(Iterable<? extends E> other) {
+        return FluentIterable.concat(getDelegate(), other);
+    }
+
+    /**
+     * Returns a fluent iterable whose iterators traverse first the elements of this fluent iterable,
+     * followed by {@code elements}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code Stream.concat(thisStream, Stream.of(elements))}.
+     *
+     * @since 18.0
+     */
+    @Beta
+    public final FluentIterable<E> append(E... elements) {
+        return FluentIterable.concat(getDelegate(), Arrays.asList(elements));
+    }
+
+    /**
+     * Returns the elements from this fluent iterable that satisfy a predicate. The resulting fluent
+     * iterable's iterator does not support {@code remove()}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#filter} (same).
+     */
+    public final FluentIterable<E> filter(Predicate<? super E> predicate) {
+        return from(Iterables.filter(getDelegate(), predicate));
+    }
+
+    /**
+     * Returns the elements from this fluent iterable that are instances of class {@code type}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.filter(type::isInstance).map(type::cast)}.
+     * This does perform a little more work than necessary, so another option is to insert an
+     * unchecked cast at some later point:
+     * <p>
+     * <pre>
+     * {@code @SuppressWarnings("unchecked") // safe because of ::isInstance check
+     * ImmutableList<NewType> result =
+     *     (ImmutableList) stream.filter(NewType.class::isInstance).collect(toImmutableList());}
+     * </pre>
+     */
+    @GwtIncompatible // Class.isInstance
+    public final <T> FluentIterable<T> filter(Class<T> type) {
+        return from(Iterables.filter(getDelegate(), type));
+    }
+
+    /**
+     * Returns {@code true} if any element in this fluent iterable satisfies the predicate.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#anyMatch} (same).
+     */
+    public final boolean anyMatch(Predicate<? super E> predicate) {
+        return Iterables.any(getDelegate(), predicate);
+    }
+
+    /**
+     * Returns {@code true} if every element in this fluent iterable satisfies the predicate. If this
+     * fluent iterable is empty, {@code true} is returned.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#allMatch} (same).
+     */
+    public final boolean allMatch(Predicate<? super E> predicate) {
+        return Iterables.all(getDelegate(), predicate);
+    }
+
+    /**
+     * Returns an {@link Optional} containing the first element in this fluent iterable that satisfies
+     * the given predicate, if such an element exists.
+     * <p>
+     * <p><b>Warning:</b> avoid using a {@code predicate} that matches {@code null}. If {@code null}
+     * is matched in this fluent iterable, a {@link NullPointerException} will be thrown.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.filter(predicate).findFirst()}.
+     */
+    public final Optional<E> firstMatch(Predicate<? super E> predicate) {
+        return Iterables.tryFind(getDelegate(), predicate);
+    }
+
+    /**
+     * Returns a fluent iterable that applies {@code function} to each element of this fluent
+     * iterable.
+     * <p>
+     * <p>The returned fluent iterable's iterator supports {@code remove()} if this iterable's
+     * iterator does. After a successful {@code remove()} call, this fluent iterable no longer
+     * contains the corresponding element.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#map}.
+     */
+    public final <T> FluentIterable<T> transform(Function<? super E, T> function) {
+        return from(Iterables.transform(getDelegate(), function));
+    }
+
+    /**
+     * Applies {@code function} to each element of this fluent iterable and returns a fluent iterable
+     * with the concatenated combination of results. {@code function} returns an Iterable of results.
+     * <p>
+     * <p>The returned fluent iterable's iterator supports {@code remove()} if this function-returned
+     * iterables' iterator does. After a successful {@code remove()} call, the returned fluent
+     * iterable no longer contains the corresponding element.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#flatMap} (using a function that produces
+     * streams, not iterables).
+     *
+     * @since 13.0 (required {@code Function<E, Iterable<T>>} until 14.0)
+     */
+    public <T> FluentIterable<T> transformAndConcat(
+            Function<? super E, ? extends Iterable<? extends T>> function) {
+        return FluentIterable.concat(transform(function));
+    }
+
+    /**
+     * Returns an {@link Optional} containing the first element in this fluent iterable. If the
+     * iterable is empty, {@code Optional.absent()} is returned.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> if the goal is to obtain any element, {@link
+     * Stream#findAny}; if it must specifically be the <i>first</i> element, {@code Stream#findFirst}.
+     *
+     * @throws NullPointerException if the first element is null; if this is a possibility, use {@code
+     *                              iterator().next()} or {@link Iterables#getFirst} instead.
+     */
+    public final Optional<E> first() {
+        Iterator<E> iterator = getDelegate().iterator();
+        return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.<E>absent();
+    }
+
+    /**
+     * Returns an {@link Optional} containing the last element in this fluent iterable. If the
+     * iterable is empty, {@code Optional.absent()} is returned. If the underlying {@code iterable}
+     * is a {@link List} with {@link java.util.RandomAccess} support, then this operation is
+     * guaranteed to be {@code O(1)}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.reduce((a, b) -> b)}.
+     *
+     * @throws NullPointerException if the last element is null; if this is a possibility, use
+     *                              {@link Iterables#getLast} instead.
+     */
+    public final Optional<E> last() {
+        // Iterables#getLast was inlined here so we don't have to throw/catch a NSEE
+
+        // TODO(kevinb): Support a concurrently modified collection?
+        Iterable<E> iterable = getDelegate();
+        if (iterable instanceof List) {
+            List<E> list = (List<E>) iterable;
+            if (list.isEmpty()) {
+                return Optional.absent();
+            }
+            return Optional.of(list.get(list.size() - 1));
+        }
+        Iterator<E> iterator = iterable.iterator();
+        if (!iterator.hasNext()) {
+            return Optional.absent();
+        }
 
     /*
      * TODO(kevinb): consider whether this "optimization" is worthwhile. Users with SortedSets tend
      * to know they are SortedSets and probably would not call this method.
      */
-    if (iterable instanceof SortedSet) {
-      SortedSet<E> sortedSet = (SortedSet<E>) iterable;
-      return Optional.of(sortedSet.last());
+        if (iterable instanceof SortedSet) {
+            SortedSet<E> sortedSet = (SortedSet<E>) iterable;
+            return Optional.of(sortedSet.last());
+        }
+
+        while (true) {
+            E current = iterator.next();
+            if (!iterator.hasNext()) {
+                return Optional.of(current);
+            }
+        }
     }
 
-    while (true) {
-      E current = iterator.next();
-      if (!iterator.hasNext()) {
-        return Optional.of(current);
-      }
+    /**
+     * Returns a view of this fluent iterable that skips its first {@code numberToSkip} elements. If
+     * this fluent iterable contains fewer than {@code numberToSkip} elements, the returned fluent
+     * iterable skips all of its elements.
+     * <p>
+     * <p>Modifications to this fluent iterable before a call to {@code iterator()} are reflected in
+     * the returned fluent iterable. That is, the its iterator skips the first {@code numberToSkip}
+     * elements that exist when the iterator is created, not when {@code skip()} is called.
+     * <p>
+     * <p>The returned fluent iterable's iterator supports {@code remove()} if the {@code Iterator} of
+     * this fluent iterable supports it. Note that it is <i>not</i> possible to delete the last
+     * skipped element by immediately calling {@code remove()} on the returned fluent iterable's
+     * iterator, as the {@code Iterator} contract states that a call to {@code * remove()} before a
+     * call to {@code next()} will throw an {@link IllegalStateException}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#skip} (same).
+     */
+    public final FluentIterable<E> skip(int numberToSkip) {
+        return from(Iterables.skip(getDelegate(), numberToSkip));
     }
-  }
 
-  /**
-   * Returns a view of this fluent iterable that skips its first {@code numberToSkip} elements. If
-   * this fluent iterable contains fewer than {@code numberToSkip} elements, the returned fluent
-   * iterable skips all of its elements.
-   *
-   * <p>Modifications to this fluent iterable before a call to {@code iterator()} are reflected in
-   * the returned fluent iterable. That is, the its iterator skips the first {@code numberToSkip}
-   * elements that exist when the iterator is created, not when {@code skip()} is called.
-   *
-   * <p>The returned fluent iterable's iterator supports {@code remove()} if the {@code Iterator} of
-   * this fluent iterable supports it. Note that it is <i>not</i> possible to delete the last
-   * skipped element by immediately calling {@code remove()} on the returned fluent iterable's
-   * iterator, as the {@code Iterator} contract states that a call to {@code * remove()} before a
-   * call to {@code next()} will throw an {@link IllegalStateException}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#skip} (same).
-   */
-  public final FluentIterable<E> skip(int numberToSkip) {
-    return from(Iterables.skip(getDelegate(), numberToSkip));
-  }
-
-  /**
-   * Creates a fluent iterable with the first {@code size} elements of this fluent iterable. If this
-   * fluent iterable does not contain that many elements, the returned fluent iterable will have the
-   * same behavior as this fluent iterable. The returned fluent iterable's iterator supports {@code
-   * remove()} if this fluent iterable's iterator does.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@link Stream#limit} (same).
-   *
-   * @param maxSize the maximum number of elements in the returned fluent iterable
-   * @throws IllegalArgumentException if {@code size} is negative
-   */
-  public final FluentIterable<E> limit(int maxSize) {
-    return from(Iterables.limit(getDelegate(), maxSize));
-  }
-
-  /**
-   * Determines whether this fluent iterable is empty.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code !stream.findAny().isPresent()}.
-   */
-  public final boolean isEmpty() {
-    return !getDelegate().iterator().hasNext();
-  }
-
-  /**
-   * Returns an {@code ImmutableList} containing all of the elements from this fluent iterable in
-   * proper sequence.
-   *
-   * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableList#toImmutableList} to {@code
-   * stream.collect()}.
-   *
-   * @throws NullPointerException if any element is {@code null}
-   * @since 14.0 (since 12.0 as {@code toImmutableList()}).
-   */
-  public final ImmutableList<E> toList() {
-    return ImmutableList.copyOf(getDelegate());
-  }
-
-  /**
-   * Returns an {@code ImmutableList} containing all of the elements from this {@code
-   * FluentIterable} in the order specified by {@code comparator}. To produce an {@code
-   * ImmutableList} sorted by its natural ordering, use {@code toSortedList(Ordering.natural())}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableList#toImmutableList} to {@code
-   * stream.sorted(comparator).collect()}.
-   *
-   * @param comparator the function by which to sort list elements
-   * @throws NullPointerException if any element of this iterable is {@code null}
-   * @since 14.0 (since 13.0 as {@code toSortedImmutableList()}).
-   */
-  public final ImmutableList<E> toSortedList(Comparator<? super E> comparator) {
-    return Ordering.from(comparator).immutableSortedCopy(getDelegate());
-  }
-
-  /**
-   * Returns an {@code ImmutableSet} containing all of the elements from this fluent iterable with
-   * duplicates removed.
-   *
-   * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableSet#toImmutableSet} to {@code
-   * stream.collect()}.
-   *
-   * @throws NullPointerException if any element is {@code null}
-   * @since 14.0 (since 12.0 as {@code toImmutableSet()}).
-   */
-  public final ImmutableSet<E> toSet() {
-    return ImmutableSet.copyOf(getDelegate());
-  }
-
-  /**
-   * Returns an {@code ImmutableSortedSet} containing all of the elements from this {@code
-   * FluentIterable} in the order specified by {@code comparator}, with duplicates (determined by
-   * {@code comparator.compare(x, y) == 0}) removed. To produce an {@code ImmutableSortedSet} sorted
-   * by its natural ordering, use {@code toSortedSet(Ordering.natural())}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> pass {@link
-   * ImmutableSortedSet#toImmutableSortedSet} to {@code stream.collect()}.
-   *
-   * @param comparator the function by which to sort set elements
-   * @throws NullPointerException if any element of this iterable is {@code null}
-   * @since 14.0 (since 12.0 as {@code toImmutableSortedSet()}).
-   */
-  public final ImmutableSortedSet<E> toSortedSet(Comparator<? super E> comparator) {
-    return ImmutableSortedSet.copyOf(comparator, getDelegate());
-  }
-
-  /**
-   * Returns an {@code ImmutableMultiset} containing all of the elements from this fluent iterable.
-   *
-   * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableMultiset#toImmutableMultiset} to
-   * {@code
-   * stream.collect()}.
-   *
-   * @throws NullPointerException if any element is null
-   * @since 19.0
-   */
-  public final ImmutableMultiset<E> toMultiset() {
-    return ImmutableMultiset.copyOf(getDelegate());
-  }
-
-  /**
-   * Returns an immutable map whose keys are the distinct elements of this {@code FluentIterable}
-   * and whose value for each key was computed by {@code valueFunction}. The map's iteration order
-   * is the order of the first appearance of each key in this iterable.
-   *
-   * <p>When there are multiple instances of a key in this iterable, it is unspecified whether
-   * {@code valueFunction} will be applied to more than one instance of that key and, if it is,
-   * which result will be mapped to that key in the returned map.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code
-   * stream.collect(ImmutableMap.toImmutableMap(k -> k, valueFunction))}.
-   *
-   * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code
-   *     valueFunction} produces {@code null} for any key
-   * @since 14.0
-   */
-  public final <V> ImmutableMap<E, V> toMap(Function<? super E, V> valueFunction) {
-    return Maps.toMap(getDelegate(), valueFunction);
-  }
-
-  /**
-   * Creates an index {@code ImmutableListMultimap} that contains the results of applying a
-   * specified function to each item in this {@code FluentIterable} of values. Each element of this
-   * iterable will be stored as a value in the resulting multimap, yielding a multimap with the same
-   * size as this iterable. The key used to store that value in the multimap will be the result of
-   * calling the function on that value. The resulting multimap is created as an immutable snapshot.
-   * In the returned multimap, keys appear in the order they are first encountered, and the values
-   * corresponding to each key appear in the same order as they are encountered.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.collect(Collectors.groupingBy(keyFunction))}
-   * behaves similarly, but returns a mutable {@code Map<K, List<E>>} instead, and may not preserve
-   * the order of entries).
-   *
-   * @param keyFunction the function used to produce the key for each value
-   * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code
-   *     keyFunction} produces {@code null} for any key
-   * @since 14.0
-   */
-  public final <K> ImmutableListMultimap<K, E> index(Function<? super E, K> keyFunction) {
-    return Multimaps.index(getDelegate(), keyFunction);
-  }
-
-  /**
-   * Returns a map with the contents of this {@code FluentIterable} as its {@code values}, indexed
-   * by keys derived from those values. In other words, each input value produces an entry in the
-   * map whose key is the result of applying {@code keyFunction} to that value. These entries appear
-   * in the same order as they appeared in this fluent iterable. Example usage:
-   *
-   * <pre>{@code
-   * Color red = new Color("red", 255, 0, 0);
-   * ...
-   * FluentIterable<Color> allColors = FluentIterable.from(ImmutableSet.of(red, green, blue));
-   *
-   * Map<String, Color> colorForName = allColors.uniqueIndex(toStringFunction());
-   * assertThat(colorForName).containsEntry("red", red);
-   * }</pre>
-   *
-   * <p>If your index may associate multiple values with each key, use {@link #index(Function)
-   * index}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code
-   * stream.collect(ImmutableMap.toImmutableMap(keyFunction, v -> v))}.
-   *
-   * @param keyFunction the function used to produce the key for each value
-   * @return a map mapping the result of evaluating the function {@code keyFunction} on each value
-   *     in this fluent iterable to that value
-   * @throws IllegalArgumentException if {@code keyFunction} produces the same key for more than one
-   *     value in this fluent iterable
-   * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code
-   *     keyFunction} produces {@code null} for any key
-   * @since 14.0
-   */
-  public final <K> ImmutableMap<K, E> uniqueIndex(Function<? super E, K> keyFunction) {
-    return Maps.uniqueIndex(getDelegate(), keyFunction);
-  }
-
-  /**
-   * Returns an array containing all of the elements from this fluent iterable in iteration order.
-   *
-   * <p><b>{@code Stream} equivalent:</b> if an object array is acceptable, use
-   * {@code stream.toArray()}; if {@code type} is a class literal such as {@code MyType.class}, use
-   * {@code stream.toArray(MyType[]::new)}. Otherwise use {@code stream.toArray(
-   * len -> (E[]) Array.newInstance(type, len))}.
-   *
-   * @param type the type of the elements
-   * @return a newly-allocated array into which all the elements of this fluent iterable have been
-   *     copied
-   */
-  @GwtIncompatible // Array.newArray(Class, int)
-  public final E[] toArray(Class<E> type) {
-    return Iterables.toArray(getDelegate(), type);
-  }
-
-  /**
-   * Copies all the elements from this fluent iterable to {@code collection}. This is equivalent to
-   * calling {@code Iterables.addAll(collection, this)}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.forEachOrdered(collection::add)} or
-   * {@code stream.forEach(collection::add)}.
-   *
-   * @param collection the collection to copy elements to
-   * @return {@code collection}, for convenience
-   * @since 14.0
-   */
-  @CanIgnoreReturnValue
-  public final <C extends Collection<? super E>> C copyInto(C collection) {
-    checkNotNull(collection);
-    Iterable<E> iterable = getDelegate();
-    if (iterable instanceof Collection) {
-      collection.addAll(Collections2.cast(iterable));
-    } else {
-      for (E item : iterable) {
-        collection.add(item);
-      }
+    /**
+     * Creates a fluent iterable with the first {@code size} elements of this fluent iterable. If this
+     * fluent iterable does not contain that many elements, the returned fluent iterable will have the
+     * same behavior as this fluent iterable. The returned fluent iterable's iterator supports {@code
+     * remove()} if this fluent iterable's iterator does.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@link Stream#limit} (same).
+     *
+     * @param maxSize the maximum number of elements in the returned fluent iterable
+     * @throws IllegalArgumentException if {@code size} is negative
+     */
+    public final FluentIterable<E> limit(int maxSize) {
+        return from(Iterables.limit(getDelegate(), maxSize));
     }
-    return collection;
-  }
 
-  /**
-   * Returns a {@link String} containing all of the elements of this fluent iterable joined with
-   * {@code joiner}.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code joiner.join(stream.iterator())}, or, if you are not
-   * using any optional {@code Joiner} features,
-   * {@code stream.collect(Collectors.joining(delimiter)}.
-   *
-   * @since 18.0
-   */
-  @Beta
-  public final String join(Joiner joiner) {
-    return joiner.join(this);
-  }
-
-  /**
-   * Returns the element at the specified position in this fluent iterable.
-   *
-   * <p><b>{@code Stream} equivalent:</b> {@code stream.skip(position).findFirst().get()} (but note
-   * that this throws different exception types, and throws an exception if {@code null} would be
-   * returned).
-   *
-   * @param position position of the element to return
-   * @return the element at the specified position in this fluent iterable
-   * @throws IndexOutOfBoundsException if {@code position} is negative or greater than or equal to
-   *     the size of this fluent iterable
-   */
-  // TODO(kevinb): add @Nullable?
-  public final E get(int position) {
-    return Iterables.get(getDelegate(), position);
-  }
-
-  /**
-   * Returns a stream of this fluent iterable's contents (similar to calling {@link
-   * Collection#stream} on a collection).
-   *
-   * <p><b>Note:</b> the earlier in the chain you can switch to {@code Stream} usage (ideally not
-   * going through {@code FluentIterable} at all), the more performant and idiomatic your code will
-   * be. This method is a transitional aid, to be used only when really necessary.
-   *
-   * @since 21.0
-   */
-  public final Stream<E> stream() {
-    return Streams.stream(getDelegate());
-  }
-
-  /**
-   * Function that transforms {@code Iterable<E>} into a fluent iterable.
-   */
-  private static class FromIterableFunction<E> implements Function<Iterable<E>, FluentIterable<E>> {
-    @Override
-    public FluentIterable<E> apply(Iterable<E> fromObject) {
-      return FluentIterable.from(fromObject);
+    /**
+     * Determines whether this fluent iterable is empty.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code !stream.findAny().isPresent()}.
+     */
+    public final boolean isEmpty() {
+        return !getDelegate().iterator().hasNext();
     }
-  }
+
+    /**
+     * Returns an {@code ImmutableList} containing all of the elements from this fluent iterable in
+     * proper sequence.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableList#toImmutableList} to {@code
+     * stream.collect()}.
+     *
+     * @throws NullPointerException if any element is {@code null}
+     * @since 14.0 (since 12.0 as {@code toImmutableList()}).
+     */
+    public final ImmutableList<E> toList() {
+        return ImmutableList.copyOf(getDelegate());
+    }
+
+    /**
+     * Returns an {@code ImmutableList} containing all of the elements from this {@code
+     * FluentIterable} in the order specified by {@code comparator}. To produce an {@code
+     * ImmutableList} sorted by its natural ordering, use {@code toSortedList(Ordering.natural())}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableList#toImmutableList} to {@code
+     * stream.sorted(comparator).collect()}.
+     *
+     * @param comparator the function by which to sort list elements
+     * @throws NullPointerException if any element of this iterable is {@code null}
+     * @since 14.0 (since 13.0 as {@code toSortedImmutableList()}).
+     */
+    public final ImmutableList<E> toSortedList(Comparator<? super E> comparator) {
+        return Ordering.from(comparator).immutableSortedCopy(getDelegate());
+    }
+
+    /**
+     * Returns an {@code ImmutableSet} containing all of the elements from this fluent iterable with
+     * duplicates removed.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableSet#toImmutableSet} to {@code
+     * stream.collect()}.
+     *
+     * @throws NullPointerException if any element is {@code null}
+     * @since 14.0 (since 12.0 as {@code toImmutableSet()}).
+     */
+    public final ImmutableSet<E> toSet() {
+        return ImmutableSet.copyOf(getDelegate());
+    }
+
+    /**
+     * Returns an {@code ImmutableSortedSet} containing all of the elements from this {@code
+     * FluentIterable} in the order specified by {@code comparator}, with duplicates (determined by
+     * {@code comparator.compare(x, y) == 0}) removed. To produce an {@code ImmutableSortedSet} sorted
+     * by its natural ordering, use {@code toSortedSet(Ordering.natural())}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> pass {@link
+     * ImmutableSortedSet#toImmutableSortedSet} to {@code stream.collect()}.
+     *
+     * @param comparator the function by which to sort set elements
+     * @throws NullPointerException if any element of this iterable is {@code null}
+     * @since 14.0 (since 12.0 as {@code toImmutableSortedSet()}).
+     */
+    public final ImmutableSortedSet<E> toSortedSet(Comparator<? super E> comparator) {
+        return ImmutableSortedSet.copyOf(comparator, getDelegate());
+    }
+
+    /**
+     * Returns an {@code ImmutableMultiset} containing all of the elements from this fluent iterable.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> pass {@link ImmutableMultiset#toImmutableMultiset} to
+     * {@code
+     * stream.collect()}.
+     *
+     * @throws NullPointerException if any element is null
+     * @since 19.0
+     */
+    public final ImmutableMultiset<E> toMultiset() {
+        return ImmutableMultiset.copyOf(getDelegate());
+    }
+
+    /**
+     * Returns an immutable map whose keys are the distinct elements of this {@code FluentIterable}
+     * and whose value for each key was computed by {@code valueFunction}. The map's iteration order
+     * is the order of the first appearance of each key in this iterable.
+     * <p>
+     * <p>When there are multiple instances of a key in this iterable, it is unspecified whether
+     * {@code valueFunction} will be applied to more than one instance of that key and, if it is,
+     * which result will be mapped to that key in the returned map.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code
+     * stream.collect(ImmutableMap.toImmutableMap(k -> k, valueFunction))}.
+     *
+     * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code
+     *                              valueFunction} produces {@code null} for any key
+     * @since 14.0
+     */
+    public final <V> ImmutableMap<E, V> toMap(Function<? super E, V> valueFunction) {
+        return Maps.toMap(getDelegate(), valueFunction);
+    }
+
+    /**
+     * Creates an index {@code ImmutableListMultimap} that contains the results of applying a
+     * specified function to each item in this {@code FluentIterable} of values. Each element of this
+     * iterable will be stored as a value in the resulting multimap, yielding a multimap with the same
+     * size as this iterable. The key used to store that value in the multimap will be the result of
+     * calling the function on that value. The resulting multimap is created as an immutable snapshot.
+     * In the returned multimap, keys appear in the order they are first encountered, and the values
+     * corresponding to each key appear in the same order as they are encountered.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.collect(Collectors.groupingBy(keyFunction))}
+     * behaves similarly, but returns a mutable {@code Map<K, List<E>>} instead, and may not preserve
+     * the order of entries).
+     *
+     * @param keyFunction the function used to produce the key for each value
+     * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code
+     *                              keyFunction} produces {@code null} for any key
+     * @since 14.0
+     */
+    public final <K> ImmutableListMultimap<K, E> index(Function<? super E, K> keyFunction) {
+        return Multimaps.index(getDelegate(), keyFunction);
+    }
+
+    /**
+     * Returns a map with the contents of this {@code FluentIterable} as its {@code values}, indexed
+     * by keys derived from those values. In other words, each input value produces an entry in the
+     * map whose key is the result of applying {@code keyFunction} to that value. These entries appear
+     * in the same order as they appeared in this fluent iterable. Example usage:
+     * <p>
+     * <pre>{@code
+     * Color red = new Color("red", 255, 0, 0);
+     * ...
+     * FluentIterable<Color> allColors = FluentIterable.from(ImmutableSet.of(red, green, blue));
+     *
+     * Map<String, Color> colorForName = allColors.uniqueIndex(toStringFunction());
+     * assertThat(colorForName).containsEntry("red", red);
+     * }</pre>
+     * <p>
+     * <p>If your index may associate multiple values with each key, use {@link #index(Function)
+     * index}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code
+     * stream.collect(ImmutableMap.toImmutableMap(keyFunction, v -> v))}.
+     *
+     * @param keyFunction the function used to produce the key for each value
+     * @return a map mapping the result of evaluating the function {@code keyFunction} on each value
+     * in this fluent iterable to that value
+     * @throws IllegalArgumentException if {@code keyFunction} produces the same key for more than one
+     *                                  value in this fluent iterable
+     * @throws NullPointerException     if any element of this iterable is {@code null}, or if {@code
+     *                                  keyFunction} produces {@code null} for any key
+     * @since 14.0
+     */
+    public final <K> ImmutableMap<K, E> uniqueIndex(Function<? super E, K> keyFunction) {
+        return Maps.uniqueIndex(getDelegate(), keyFunction);
+    }
+
+    /**
+     * Returns an array containing all of the elements from this fluent iterable in iteration order.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> if an object array is acceptable, use
+     * {@code stream.toArray()}; if {@code type} is a class literal such as {@code MyType.class}, use
+     * {@code stream.toArray(MyType[]::new)}. Otherwise use {@code stream.toArray(
+     * len -> (E[]) Array.newInstance(type, len))}.
+     *
+     * @param type the type of the elements
+     * @return a newly-allocated array into which all the elements of this fluent iterable have been
+     * copied
+     */
+    @GwtIncompatible // Array.newArray(Class, int)
+    public final E[] toArray(Class<E> type) {
+        return Iterables.toArray(getDelegate(), type);
+    }
+
+    /**
+     * Returns a map with the contents of this {@code FluentIterable}.
+     * Similar to uniqueIndex, but you can specify how to produce value
+     * @param keyFunction the function used to produce the key for each value
+     * @param valueFunction the function used to produce the value for each key
+     * @param <K>
+     * @param <V>
+     * @return
+     */
+    public final <K, V> Map<K, V> toMap(Function<E, K> keyFunction, Function<E, V> valueFunction) {
+        return toMap(keyFunction, valueFunction, new MergeFunction<V>() {
+
+            @Override
+            public V apply(V oldValue, V newValue) {
+                throw new IllegalStateException(String.format("Duplicate key %s", oldValue));
+            }
+        });
+    }
+
+    /**
+     * Returns a map with the contents of this {@code FluentIterable}.
+     * Similar to toMap, but you can specify how to handle key conflicts
+     * @param keyFunction the function used to produce the key for each value
+     * @param valueFunction the function used to produce the value for each key
+     * @param mergeFunction  When a key conflict occurs, call this interface to handle conflicts,
+     *                      accept oldValue and newValue, and return the value of the processed conflict
+     * @param <K>
+     * @param <V>
+     * @return
+     */
+    public final <K, V> Map<K, V> toMap(Function<E, K> keyFunction, Function<E, V> valueFunction, MergeFunction<V> mergeFunction) {
+        Iterable<E> iterable = getDelegate();
+        Map<K, V> map = Maps.newHashMap();
+        for (E e : iterable) {
+            K key = keyFunction.apply(e);
+            V value = valueFunction.apply(e);
+            V oldValue = map.put(key, value);
+            if (oldValue != null) {
+                V newValue = mergeFunction.apply(oldValue, value);
+                map.put(key, newValue);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Copies all the elements from this fluent iterable to {@code collection}. This is equivalent to
+     * calling {@code Iterables.addAll(collection, this)}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.forEachOrdered(collection::add)} or
+     * {@code stream.forEach(collection::add)}.
+     *
+     * @param collection the collection to copy elements to
+     * @return {@code collection}, for convenience
+     * @since 14.0
+     */
+    @CanIgnoreReturnValue
+    public final <C extends Collection<? super E>> C copyInto(C collection) {
+        checkNotNull(collection);
+        Iterable<E> iterable = getDelegate();
+        if (iterable instanceof Collection) {
+            collection.addAll(Collections2.cast(iterable));
+        } else {
+            for (E item : iterable) {
+                collection.add(item);
+            }
+        }
+        return collection;
+    }
+
+    /**
+     * Returns a {@link String} containing all of the elements of this fluent iterable joined with
+     * {@code joiner}.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code joiner.join(stream.iterator())}, or, if you are not
+     * using any optional {@code Joiner} features,
+     * {@code stream.collect(Collectors.joining(delimiter)}.
+     *
+     * @since 18.0
+     */
+    @Beta
+    public final String join(Joiner joiner) {
+        return joiner.join(this);
+    }
+
+    /**
+     * Returns the element at the specified position in this fluent iterable.
+     * <p>
+     * <p><b>{@code Stream} equivalent:</b> {@code stream.skip(position).findFirst().get()} (but note
+     * that this throws different exception types, and throws an exception if {@code null} would be
+     * returned).
+     *
+     * @param position position of the element to return
+     * @return the element at the specified position in this fluent iterable
+     * @throws IndexOutOfBoundsException if {@code position} is negative or greater than or equal to
+     *                                   the size of this fluent iterable
+     */
+    // TODO(kevinb): add @Nullable?
+    public final E get(int position) {
+        return Iterables.get(getDelegate(), position);
+    }
+
+    /**
+     * Returns a stream of this fluent iterable's contents (similar to calling {@link
+     * Collection#stream} on a collection).
+     * <p>
+     * <p><b>Note:</b> the earlier in the chain you can switch to {@code Stream} usage (ideally not
+     * going through {@code FluentIterable} at all), the more performant and idiomatic your code will
+     * be. This method is a transitional aid, to be used only when really necessary.
+     *
+     * @since 21.0
+     */
+    public final Stream<E> stream() {
+        return Streams.stream(getDelegate());
+    }
+
+    /**
+     * Function that transforms {@code Iterable<E>} into a fluent iterable.
+     */
+    private static class FromIterableFunction<E> implements Function<Iterable<E>, FluentIterable<E>> {
+        @Override
+        public FluentIterable<E> apply(Iterable<E> fromObject) {
+            return FluentIterable.from(fromObject);
+        }
+    }
 }


### PR DESCRIPTION
I have extended a toMap function in the FluentIterable, you can flexibly specify the key and value, you can also specify the key conflict strategy