### PR TITLE
Javadoc update when delegate throws exception

### DIFF
--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -87,7 +87,7 @@ public final class Suppliers {
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The delegate's {@code get()} method will be invoked at
-   * most once unless the underlying {@code get()} threw an exception. The supplier's serialized form 
+   * most once unless the underlying {@code get()} throws an exception. The supplier's serialized form 
    * does not contain the cached value, which will be recalculated when {@code get()} is called on the 
    * reserialized instance.
    *
@@ -187,9 +187,9 @@ public final class Suppliers {
    * <a href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the
-   * cached value, which will be recalculated when {@code
-   * get()} is called on the reserialized instance. The actual memoization does not happen when the
-   * underlying delegate throws an exception.
+   * cached value, which will be recalculated when {@code get()} is called on the reserialized 
+   * instance. The actual memoization does not happen when the underlying delegate throws an 
+   * exception.
    *
    * <p>When the underlying delegate throws an exception then this memoizing supplier will keep
    * delegating calls until it returns valid data. 

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -87,8 +87,12 @@ public final class Suppliers {
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The delegate's {@code get()} method will be invoked at
-   * most once. The supplier's serialized form does not contain the cached value, which will be
-   * recalculated when {@code get()} is called on the reserialized instance.
+   * most once unless the underlying {@code get()} threw an exception. The supplier's serialized form 
+   * does not contain the cached value, which will be recalculated when {@code get()} is called on the 
+   * reserialized instance.
+   *
+   * <p>When the underlying delegate throws an exception then this memoizing supplier will keep
+   * delegating calls until it returns valid data. 
    *
    * <p>If {@code delegate} is an instance created by an earlier call to {@code memoize}, it is
    * returned directly.
@@ -184,7 +188,11 @@ public final class Suppliers {
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the
    * cached value, which will be recalculated when {@code
-   * get()} is called on the reserialized instance.
+   * get()} is called on the reserialized instance. The actual memoization does not happen when the
+   * underlying delegate throws an exception.
+   *
+   * <p>When the underlying delegate throws an exception then this memoizing supplier will keep
+   * delegating calls until it returns valid data. 
    *
    * @param duration the length of time after a value is created that it should stop being returned
    *     by subsequent {@code get()} calls


### PR DESCRIPTION
Clarify javadoc about the delegate being called utmost once. This is not true if the get method on the delegate throws RuntimeException.