### PR TITLE
Remove a dangling closing bracket from Javadoc

### DIFF
--- a/android/guava/src/com/google/common/base/MoreObjects.java
+++ b/android/guava/src/com/google/common/base/MoreObjects.java
@@ -88,7 +88,7 @@ public final class MoreObjects {
    *       .add("x", 1)
    *       .add("y", null)
    *       .toString();
-   *   }}</pre>
+   *   }</pre>
    *
    * <p>Note that in GWT, class names are often obfuscated.
    *

--- a/guava/src/com/google/common/base/MoreObjects.java
+++ b/guava/src/com/google/common/base/MoreObjects.java
@@ -88,7 +88,7 @@ public final class MoreObjects {
    *       .add("x", 1)
    *       .add("y", null)
    *       .toString();
-   *   }}</pre>
+   *   }</pre>
    *
    * <p>Note that in GWT, class names are often obfuscated.
    *


### PR DESCRIPTION
There's a dangling closing curly bracket in the Javadoc example of
MoreObjects.toStringHelper(). Remove that in the main and the android
sources. See the incorrect rendering [here](
http://google.github.io/guava/releases/23.0/api/docs/com/google/common/base/MoreObjects.html#toStringHelper-java.lang.Class-)