### PR TITLE
Fix #2914 by switching -android version suffix to -ga; revert vanilla…

### DIFF
--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-android-SNAPSHOT</version>
+    <version>24.0-ga-SNAPSHOT</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-android-SNAPSHOT</version>
+    <version>24.0-ga-SNAPSHOT</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-android-SNAPSHOT</version>
+    <version>24.0-ga-SNAPSHOT</version>
   </parent>
   <artifactId>guava</artifactId>
   <packaging>bundle</packaging>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent</artifactId>
-  <version>24.0-android-SNAPSHOT</version>
+  <version>24.0-ga-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
   <url>https://github.com/google/guava</url>

--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-jre-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>guava-gwt</artifactId>
   <name>Guava GWT compatible libs</name>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-jre-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-jre-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>24.0-jre-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
   </parent>
   <artifactId>guava</artifactId>
   <packaging>bundle</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent</artifactId>
-  <version>24.0-jre-SNAPSHOT</version>
+  <version>24.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
   <url>https://github.com/google/guava</url>

--- a/util/set_version.sh
+++ b/util/set_version.sh
@@ -9,9 +9,9 @@ fi
 
 version="$1"
 if [[ "${version}" =~ ^(.+)-SNAPSHOT$ ]]; then
-  android_version="${BASH_REMATCH[1]}-android-SNAPSHOT"
+  android_version="${BASH_REMATCH[1]}-ga-SNAPSHOT"
 else
-  android_version="${version}-android"
+  android_version="${version}-ga"
 fi
 
 mvn versions:set versions:commit -DnewVersion="${version}"


### PR DESCRIPTION
This patch changes `-android` version suffix to `-ga` for Android / Java 7 flavored version of Guava, resolving #2914.

The resolution piggy-backs on documented Maven [`ComparableVersion`](http://maven.apache.org/ref/3.5.0/maven-artifact/apidocs/org/apache/maven/artifact/versioning/ComparableVersion.html) feature that equates `ga`-suffixed versions (e.g. `24.0-ga`) with non-suffixed ones (e.g. `24.0`) in the context of comparing / ordering / determining the latest version.

Note: This also reverts [the patch](https://github.com/google/guava/commit/61d2a6faec8b27d021b9f37f7dfb6655ae060fad) by @cpovirk, restoring the original vanilla (Java 8+) Guava versioning scheme (e.g. from patched `24.0-jre` back to `24.0`).

Note: [`README.md`](https://github.com/google/guava/blob/master/README.md#latest-release) text should be updated before releasing the next version to reflect the suffix change for the Android version.