### PR TITLE
Add JPMS module name

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -39,6 +39,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.common</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <extensions>true</extensions>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,11 +114,6 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.3.1</version>
           <configuration>
-            <archive>
-              <manifestEntries>
-                <Automatic-Module-Name>com.google.common</Automatic-Module-Name>
-              </manifestEntries>
-            </archive>
             <excludes>
               <exclude>**/ForceGuavaCompilation*</exclude>
             </excludes>


### PR DESCRIPTION
Move to the correct pom.xml.

Fixes #2920
Commit 9feba7c949ef9fd2092c05c29dcbe0ddba7a7cf5 of #2846 placed the `Automatic-Module-Name` declaration in the wrong`pom.xml`. As such, Guava still isn't a valid module, which blocks a whole heap of projects from declaring `module-info.java`.

Feel free to make a separate change rather than merging this PR to satisfy any IP rules.