### PR TITLE
Remove @GwtCompatible annotations from classes in the hash package,

### DIFF
--- a/guava/src/com/google/common/hash/LongAddable.java
+++ b/guava/src/com/google/common/hash/LongAddable.java
@@ -14,14 +14,11 @@
 
 package com.google.common.hash;
 
-import com.google.common.annotations.GwtCompatible;
-
 /**
  * Abstract interface for objects that can concurrently add longs.
  *
  * @author Louis Wasserman
  */
-@GwtCompatible
 interface LongAddable {
   void increment();
 

--- a/guava/src/com/google/common/hash/LongAddables.java
+++ b/guava/src/com/google/common/hash/LongAddables.java
@@ -14,7 +14,6 @@
 
 package com.google.common.hash;
 
-import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Supplier;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -23,7 +22,6 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author Louis Wasserman
  */
-@GwtCompatible(emulated = true)
 final class LongAddables {
   private static final Supplier<LongAddable> SUPPLIER;
 

--- a/guava/src/com/google/common/hash/LongAdder.java
+++ b/guava/src/com/google/common/hash/LongAdder.java
@@ -11,7 +11,6 @@
 
 package com.google.common.hash;
 
-import com.google.common.annotations.GwtCompatible;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -45,7 +44,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 1.8
  * @author Doug Lea
  */
-@GwtCompatible(emulated = true)
 final class LongAdder extends Striped64 implements Serializable, LongAddable {
     private static final long serialVersionUID = 7249069246863182397L;
 


### PR DESCRIPTION
which have no corresponding .gwt.xml file.

Alternatively, if these are expected to be gwt-compatible, I can add the .gwt.xml and the missing emulation for LongAdder (which references other presently gwt-incompatible classes).