### PR TITLE
Modifying Quantiles to return ordered HashMap

### DIFF
--- a/guava-tests/test/com/google/common/math/QuantilesTest.java
+++ b/guava-tests/test/com/google/common/math/QuantilesTest.java
@@ -37,7 +37,9 @@ import com.google.common.primitives.Longs;
 import com.google.common.truth.Correspondence;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import javax.annotation.Nullable;
 import junit.framework.TestCase;
@@ -287,6 +289,17 @@ public class QuantilesTest extends TestCase {
             5, SIXTEEN_SQUARES_MEDIAN,
             1, SIXTEEN_SQUARES_DECILE_1,
             8, SIXTEEN_SQUARES_DECILE_8);
+  }
+
+  public void testScale_indexes_varargs_compute_indexOrderIsMaintained() {
+    assertThat(Quantiles.scale(10).indexes(0, 10, 5, 1, 8, 1).compute(SIXTEEN_SQUARES_INTEGERS))
+        .comparingValuesUsing(QUANTILE_CORRESPONDENCE)
+        .containsExactly(
+            0, SIXTEEN_SQUARES_MIN,
+            10, SIXTEEN_SQUARES_MAX,
+            5, SIXTEEN_SQUARES_MEDIAN,
+            1, SIXTEEN_SQUARES_DECILE_1,
+            8, SIXTEEN_SQUARES_DECILE_8).inOrder();
   }
 
   public void testScale_indexes_varargs_compute_doubleVarargs() {

--- a/guava/src/com/google/common/math/Quantiles.java
+++ b/guava/src/com/google/common/math/Quantiles.java
@@ -27,7 +27,7 @@ import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Ints;
 import java.math.RoundingMode;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -331,8 +331,9 @@ public final class Quantiles {
      * @param dataset the dataset to do the calculation on, which must be non-empty, which will be
      *     cast to doubles (with any associated lost of precision), and which will not be mutated by
      *     this call (it is copied instead)
-     * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     * @return an unmodifiable ordered map of results: the keys will be the specified quantile indexes, and
+     *     the values the corresponding quantile values. Iteration on the resulting map will result in map entries in
+     *     the same order as the order in which the quantile indexes were passed in the constructor.
      */
     public Map<Integer, Double> compute(Collection<? extends Number> dataset) {
       return computeInPlace(Doubles.toArray(dataset));
@@ -344,7 +345,8 @@ public final class Quantiles {
      * @param dataset the dataset to do the calculation on, which must be non-empty, which will not
      *     be mutated by this call (it is copied instead)
      * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     *     the values the corresponding quantile values. Iteration on the resulting map will result in map entries in
+     *     the same order as the order in which the quantile indexes were passed in the constructor.
      */
     public Map<Integer, Double> compute(double... dataset) {
       return computeInPlace(dataset.clone());
@@ -357,7 +359,8 @@ public final class Quantiles {
      *     cast to doubles (with any associated lost of precision), and which will not be mutated by
      *     this call (it is copied instead)
      * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     *     the values the corresponding quantile values. Iteration on the resulting map will result in map entries in
+     *     the same order as the order in which the quantile indexes were passed in the constructor.
      */
     public Map<Integer, Double> compute(long... dataset) {
       return computeInPlace(longsToDoubles(dataset));
@@ -369,7 +372,8 @@ public final class Quantiles {
      * @param dataset the dataset to do the calculation on, which must be non-empty, which will be
      *     cast to doubles, and which will not be mutated by this call (it is copied instead)
      * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     *     the values the corresponding quantile values. Iteration on the resulting map will result in map entries in
+     *     the same order as the order in which the quantile indexes were passed in the constructor.
      */
     public Map<Integer, Double> compute(int... dataset) {
       return computeInPlace(intsToDoubles(dataset));
@@ -381,12 +385,13 @@ public final class Quantiles {
      * @param dataset the dataset to do the calculation on, which must be non-empty, and which will
      *     be arbitrarily reordered by this method call
      * @return an unmodifiable map of results: the keys will be the specified quantile indexes, and
-     *     the values the corresponding quantile values
+     *     the values the corresponding quantile values. Iteration on the resulting map will result in map entries in
+     *     the same order as the order in which the quantile indexes were passed in the constructor.
      */
     public Map<Integer, Double> computeInPlace(double... dataset) {
       checkArgument(dataset.length > 0, "Cannot calculate quantiles of an empty dataset");
       if (containsNaN(dataset)) {
-        Map<Integer, Double> nanMap = new HashMap<>();
+        Map<Integer, Double> nanMap = new LinkedHashMap<>();
         for (int index : indexes) {
           nanMap.put(index, NaN);
         }
@@ -425,7 +430,7 @@ public final class Quantiles {
       sort(requiredSelections, 0, requiredSelectionsCount);
       selectAllInPlace(
           requiredSelections, 0, requiredSelectionsCount - 1, dataset, 0, dataset.length - 1);
-      Map<Integer, Double> ret = new HashMap<>();
+      Map<Integer, Double> ret = new LinkedHashMap<>();
       for (int i = 0; i < indexes.length; i++) {
         int quotient = quotients[i];
         int remainder = remainders[i];


### PR DESCRIPTION
Usually, when someone computes percentiles, they would end up iterating over the resulting map to print the percentiles or store them somewhere. It is useful to return the percentiles in the order in which they were requested.
e.g,
If one computes `Quantiles.percentiles().indexes(50, 90, 99).compute(times)` and iterates over the result, it should be iterated in the order 50, 90, 99. Currently, we use HashMap, so the order is unpredictable. Making it a LinkedHashMap will ensure results in the expected order with very minimal perf impact.