### PR TITLE
Fix Types.toString for arrays

### DIFF
--- a/guava-tests/test/com/google/common/reflect/TypesTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypesTest.java
@@ -404,9 +404,10 @@ public class TypesTest extends TestCase {
   }
 
   public void testToString() {
-    assertEquals(int[].class.getName(), Types.toString(int[].class));
-    assertEquals(int[][].class.getName(), Types.toString(int[][].class));
-    assertEquals(String[].class.getName(), Types.toString(String[].class));
+    assertEquals(String.class.getName(), Types.toString(String.class));
+    assertEquals(int.class.getName() + "[]", Types.toString(int[].class));
+    assertEquals(int.class.getName() + "[][]", Types.toString(int[][].class));
+    assertEquals(String.class.getName() + "[]", Types.toString(String[].class));
     Type elementType = List.class.getTypeParameters()[0];
     assertEquals(elementType.toString(), Types.toString(elementType));
   }

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -821,7 +821,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
 
   @Override
   public String toString() {
-    return Types.toString(runtimeType);
+    return runtimeType.getTypeName();
   }
 
   /** Implemented to support serialization of subclasses. */

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -174,7 +174,7 @@ final class Types {
    * </ul>
    */
   static String toString(Type type) {
-    return (type instanceof Class) ? ((Class<?>) type).getName() : type.toString();
+    return type.getTypeName();
   }
 
   @Nullable
@@ -243,7 +243,7 @@ final class Types {
 
     @Override
     public String toString() {
-      return Types.toString(componentType) + "[]";
+      return componentType.getTypeName() + "[]";
     }
 
     @Override
@@ -646,7 +646,7 @@ final class Types {
     abstract Type usedInGenericType(Type type);
 
     String typeName(Type type) {
-      return Types.toString(type);
+      return type.getTypeName();
     }
 
     boolean jdkTypeDuplicatesOwnerName() {


### PR DESCRIPTION
The current behaviour of `TypeToken.of(<array type>).toString()` mismatches with the `Types.toString()` javadoc: 

> For array type {@code Foo[]}, {@code "com.mypackage.Foo[]"} are returned

For example, `TypeToken.of(String[].class)` returns `[Ljava.lang.String;`.

Fortunately, a new java8 method `getTypeName()` has appeared whose behaviour is exactly the same as `Types.toString()` except that it can deal with arrays (including primitive ones).