### PR TITLE
Changed the ArrayIndexOutOfBoundsException to String...

### DIFF
--- a/guava-tests/test/com/google/common/base/StringsTest.java
+++ b/guava-tests/test/com/google/common/base/StringsTest.java
@@ -126,7 +126,7 @@ public class StringsTest extends TestCase {
       // Massive string
       Strings.repeat("12345678", (1 << 30) + 3);
       fail();
-    } catch (ArrayIndexOutOfBoundsException expected) {
+    } catch (StringIndexOutOfBoundsException expected) {
     }
   }
 

--- a/guava/src/com/google/common/base/Strings.java
+++ b/guava/src/com/google/common/base/Strings.java
@@ -152,7 +152,7 @@ public final class Strings {
     final long longSize = (long) len * (long) count;
     final int size = (int) longSize;
     if (size != longSize) {
-      throw new ArrayIndexOutOfBoundsException("Required array size too large: " + longSize);
+      throw new StringIndexOutOfBoundsException("Required string size too large: " + longSize);
     }
 
     final char[] array = new char[size];


### PR DESCRIPTION
In the repeat method of Strings class, if the length of the potential output string overflows, the exception to be thrown should be StringIndexOutOfBoundsException instead of ArrayIndexOutOfBoundsException.