### PR TITLE
Extend Uninterruptibles with methods allowing awaiting on Condition

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
@@ -95,16 +95,6 @@ public class UninterruptiblesTest extends TestCase {
   // CountDownLatch.await() tests
 
   // Condition.await() tests
-  public void testConditionAwait() {
-    Stopwatch stopwatch = Stopwatch.createStarted();
-    Condition condition = TestCondition.createAndSignalAfter(500, MILLISECONDS);
-
-    awaitUninterruptibly(condition);
-
-    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
-    assertNotInterrupted();
-  }
-
   public void testConditionAwaitTimeoutExceeded() {
     Stopwatch stopwatch = Stopwatch.createStarted();
     Condition condition = TestCondition.create();

--- a/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
@@ -17,6 +17,8 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.util.concurrent.InterruptionUtil.repeatedlyInterruptTestThread;
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUntilUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.joinUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.putUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.takeUninterruptibly;
@@ -28,10 +30,17 @@ import com.google.common.base.Stopwatch;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.TearDown;
 import com.google.common.testing.TearDownStack;
+import java.util.Date;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import junit.framework.TestCase;
 
 /**
@@ -84,6 +93,113 @@ public class UninterruptiblesTest extends TestCase {
   // IncrementableCountDownLatch.await() tests
 
   // CountDownLatch.await() tests
+
+  // Condition.await() tests
+  public void testConditionAwait() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.createAndSignalAfter(500, MILLISECONDS);
+
+    awaitUninterruptibly(condition);
+
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertNotInterrupted();
+  }
+
+  public void testConditionAwaitTimeoutExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.create();
+
+    boolean signaledBeforeTimeout = awaitUninterruptibly(condition, 500, MILLISECONDS);
+
+    assertFalse(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertNotInterrupted();
+  }
+
+  public void testConditionAwaitTimeoutNotExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.createAndSignalAfter(500, MILLISECONDS);
+
+    boolean signaledBeforeTimeout = awaitUninterruptibly(condition, 1500, MILLISECONDS);
+
+    assertTrue(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertNotInterrupted();
+  }
+
+  public void testConditionAwaitInterruptedTimeoutExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.create();
+    requestInterruptIn(500);
+
+    boolean signaledBeforeTimeout = awaitUninterruptibly(condition, 1000, MILLISECONDS);
+
+    assertFalse(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertInterrupted();
+  }
+
+  public void testConditionAwaitInterruptedTimeoutNotExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.createAndSignalAfter(1000, MILLISECONDS);
+    requestInterruptIn(500);
+
+    boolean signaledBeforeTimeout = awaitUninterruptibly(condition, 1500, MILLISECONDS);
+
+    assertTrue(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertInterrupted();
+  }
+
+  public void testConditionAwaitUntilDateTimeoutExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.create();
+    Date deadline = nowPlusMillis(500);
+
+    boolean signaledBeforeTimeout = awaitUntilUninterruptibly(condition, deadline);
+
+    assertFalse(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertNotInterrupted();
+  }
+
+  public void testConditionAwaitUntilDateTimeoutNotExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.createAndSignalAfter(500, MILLISECONDS);
+    Date deadline = nowPlusMillis(1500);
+
+    boolean signaledBeforeTimeout = awaitUntilUninterruptibly(condition, deadline);
+
+    assertTrue(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertNotInterrupted();
+  }
+
+  public void testConditionAwaitUntilDateInterruptedTimeoutExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.create();
+    requestInterruptIn(500);
+    Date deadline = nowPlusMillis(1000);
+
+    boolean signaledBeforeTimeout = awaitUntilUninterruptibly(condition, deadline);
+
+    assertFalse(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertInterrupted();
+  }
+
+  public void testConditionAwaitUntilDateInterruptedTimeoutNotExceeded() {
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    Condition condition = TestCondition.createAndSignalAfter(1000, MILLISECONDS);
+    requestInterruptIn(500);
+    Date deadline = nowPlusMillis(1500);
+
+    boolean signaledBeforeTimeout = awaitUntilUninterruptibly(condition, deadline);
+
+    assertTrue(signaledBeforeTimeout);
+    assertTimeNotPassed(stopwatch, LONG_DELAY_MS);
+    assertInterrupted();
+  }
 
   // BlockingQueue.put() tests
   public void testPutWithNoWait() {
@@ -671,5 +787,105 @@ public class UninterruptiblesTest extends TestCase {
 
   private static void requestInterruptIn(long millis) {
     InterruptionUtil.requestInterruptIn(millis, MILLISECONDS);
+  }
+
+  private static Date nowPlusMillis(int millis) {
+    long deadlineMillis = System.currentTimeMillis() + millis;
+    return new Date(deadlineMillis);
+  }
+
+  private static class TestCondition implements Condition {
+    private final Lock lock;
+    private final Condition condition;
+
+    private TestCondition(Lock lock, Condition condition) {
+      this.lock = lock;
+      this.condition = condition;
+    }
+
+    static TestCondition createAndSignalAfter(long delay, TimeUnit unit) {
+      TestCondition testCondition = create();
+
+      ScheduledExecutorService scheduledPool = Executors.newScheduledThreadPool(1);
+      scheduledPool.schedule(testCondition::signal, delay, unit);
+
+      return testCondition;
+    }
+
+    static TestCondition create() {
+      Lock lock = new ReentrantLock();
+      Condition condition = lock.newCondition();
+      return new TestCondition(lock, condition);
+    }
+
+    @Override
+    public void await() throws InterruptedException {
+      lock.lock();
+      try {
+        condition.await();
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public void awaitUninterruptibly() {
+      lock.lock();
+      try {
+        condition.awaitUninterruptibly();
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public long awaitNanos(long nanosTimeout) throws InterruptedException {
+      lock.lock();
+      try {
+        return condition.awaitNanos(nanosTimeout);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public boolean await(long time, TimeUnit unit) throws InterruptedException {
+      lock.lock();
+      try {
+        return condition.await(time, unit);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public boolean awaitUntil(Date deadline) throws InterruptedException {
+      lock.lock();
+      try {
+        return condition.awaitUntil(deadline);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public void signal() {
+      lock.lock();
+      try {
+        condition.signal();
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    @Override
+    public void signalAll() {
+      lock.lock();
+      try {
+        condition.signalAll();
+      } finally {
+        lock.unlock();
+      }
+    }
   }
 }

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Date;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Condition;
 
 /**
  * Utilities for treating interruptible operations as uninterruptible. In all cases, if a thread is
@@ -84,6 +86,62 @@ public final class Uninterruptibles {
         } catch (InterruptedException e) {
           interrupted = true;
           remainingNanos = end - System.nanoTime();
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /** Invokes {@code condition.}{@link Condition#await() await()} uninterruptibly. */
+  @GwtIncompatible // concurrency
+  public static void awaitUninterruptibly(Condition condition) {
+    condition.awaitUninterruptibly();
+  }
+
+  /**
+   * Invokes {@code condition.}{@link Condition#await(long, TimeUnit) await(timeout, unit)}
+   * uninterruptibly.
+   */
+  @CanIgnoreReturnValue
+  @GwtIncompatible // concurrency
+  public static boolean awaitUninterruptibly(Condition condition, long timeout, TimeUnit unit) {
+    boolean interrupted = false;
+    try {
+      long remainingNanos = unit.toNanos(timeout);
+      long end = System.nanoTime() + remainingNanos;
+
+      while (true) {
+        try {
+          return condition.await(remainingNanos, NANOSECONDS);
+        } catch (InterruptedException e) {
+          interrupted = true;
+          remainingNanos = end - System.nanoTime();
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Invokes {@code condition.}{@link Condition#awaitUntil(Date)} awaitUntil(Date)}
+   * uninterruptibly.
+   */
+  @CanIgnoreReturnValue
+  @GwtIncompatible // concurrency
+  public static boolean awaitUntilUninterruptibly(Condition condition, Date date) {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          return condition.awaitUntil(date);
+        } catch (InterruptedException e) {
+          interrupted = true;
         }
       }
     } finally {

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -95,12 +95,6 @@ public final class Uninterruptibles {
     }
   }
 
-  /** Invokes {@code condition.}{@link Condition#await() await()} uninterruptibly. */
-  @GwtIncompatible // concurrency
-  public static void awaitUninterruptibly(Condition condition) {
-    condition.awaitUninterruptibly();
-  }
-
   /**
    * Invokes {@code condition.}{@link Condition#await(long, TimeUnit) await(timeout, unit)}
    * uninterruptibly.


### PR DESCRIPTION
Issue: #2870 

Condition class exposes a number of methods to await on it.
Most of them throw exception when executing thread gets interrupted.
In scope of this change utility methods are introduced to serve as uninterruptible proxies.

