### PR TITLE
Remove unused org.checkerframework:checker-compat-qual dependencies

### DIFF
--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -26,10 +26,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-compat-qual</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -21,10 +21,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-compat-qual</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -26,10 +26,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-compat-qual</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -21,10 +21,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-compat-qual</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
     </dependency>


### PR DESCRIPTION
`org.checkerframework:checker-compat-qual` appears to be unused under both the jre and android flavors of `guava` and `guava-tests`. 

The `org.checkerframework:checker-compat-qual:2.0.0` jar contains `.class` files with either `org.checkerframework` or `afu.plume` in their packages. I see the following after making this change, so I believe it is safe, though I could of course be missing something:
```
$ grep -r -l "afu.plume" .
$ grep -r -l "org.checkerframework" .
./android/guava-testlib/pom.xml
./android/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
./android/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
./android/guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
./android/guava-testlib/src/com/google/common/testing/NullPointerTester.java
./android/guava-testlib/src/com/google/common/testing/TestLogHandler.java
./android/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
./android/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
./android/pom.xml
./guava-testlib/pom.xml
./guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
./guava-testlib/src/com/google/common/testing/ClassSanityTester.java
./guava-testlib/src/com/google/common/testing/CollectorTester.java
./guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
./guava-testlib/src/com/google/common/testing/NullPointerTester.java
./guava-testlib/src/com/google/common/testing/TestLogHandler.java
./guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
./guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
./pom.xml
```

---
This addresses https://github.com/google/guava/issues/3006.