### PR TITLE
POC: replace explicit null checks by automatic

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -37,10 +37,6 @@
       <artifactId>animal-sniffer-annotations</artifactId>
       <version>${animal.sniffer.version}</version>
     </dependency>
-    <dependency>
-      <groupId>tech.harmonysoft</groupId>
-      <artifactId>traute-javac</artifactId>
-    </dependency>
     <!-- TODO(cpovirk): does this comment belong on the <dependency> in <profiles>? -->
     <!-- TODO(cpovirk): want this only for dependency plugin but seems not to work there? Maven runs without failure, but the resulting Javadoc is missing the hoped-for inherited text -->
   </dependencies>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>animal-sniffer-annotations</artifactId>
       <version>${animal.sniffer.version}</version>
     </dependency>
+    <dependency>
+      <groupId>tech.harmonysoft</groupId>
+      <artifactId>traute-javac</artifactId>
+    </dependency>
     <!-- TODO(cpovirk): does this comment belong on the <dependency> in <profiles>? -->
     <!-- TODO(cpovirk): want this only for dependency plugin but seems not to work there? Maven runs without failure, but the resulting Javadoc is missing the hoped-for inherited text -->
   </dependencies>

--- a/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -569,7 +569,7 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
   ImmutableSortedMap(
       RegularImmutableSortedSet<K> keySet,
       ImmutableList<V> valueList,
-      ImmutableSortedMap<K, V> descendingMap) {
+      @NullableDecl ImmutableSortedMap<K, V> descendingMap) {
     this.keySet = keySet;
     this.valueList = valueList;
     this.descendingMap = descendingMap;

--- a/guava/src/com/google/common/collect/Iterables.java
+++ b/guava/src/com/google/common/collect/Iterables.java
@@ -17,7 +17,6 @@
 package com.google.common.collect;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.CollectPreconditions.checkRemove;
 
 import com.google.common.annotations.Beta;
@@ -69,7 +68,6 @@ public final class Iterables {
 
   /** Returns an unmodifiable view of {@code iterable}. */
   public static <T> Iterable<T> unmodifiableIterable(final Iterable<? extends T> iterable) {
-    checkNotNull(iterable);
     if (iterable instanceof UnmodifiableIterable || iterable instanceof ImmutableCollection) {
       @SuppressWarnings("unchecked") // Since it's unmodifiable, the covariant cast is safe
       Iterable<T> result = (Iterable<T>) iterable;
@@ -86,7 +84,7 @@ public final class Iterables {
    */
   @Deprecated
   public static <E> Iterable<E> unmodifiableIterable(ImmutableCollection<E> iterable) {
-    return checkNotNull(iterable);
+    return iterable;
   }
 
   private static final class UnmodifiableIterable<T> extends FluentIterable<T> {
@@ -153,7 +151,7 @@ public final class Iterables {
   @CanIgnoreReturnValue
   public static boolean removeAll(Iterable<?> removeFrom, Collection<?> elementsToRemove) {
     return (removeFrom instanceof Collection)
-        ? ((Collection<?>) removeFrom).removeAll(checkNotNull(elementsToRemove))
+        ? ((Collection<?>) removeFrom).removeAll(elementsToRemove)
         : Iterators.removeAll(removeFrom.iterator(), elementsToRemove);
   }
 
@@ -170,7 +168,7 @@ public final class Iterables {
   @CanIgnoreReturnValue
   public static boolean retainAll(Iterable<?> removeFrom, Collection<?> elementsToRetain) {
     return (removeFrom instanceof Collection)
-        ? ((Collection<?>) removeFrom).retainAll(checkNotNull(elementsToRetain))
+        ? ((Collection<?>) removeFrom).retainAll(elementsToRetain)
         : Iterators.retainAll(removeFrom.iterator(), elementsToRetain);
   }
 
@@ -201,7 +199,6 @@ public final class Iterables {
   /** Removes and returns the first matching element, or returns {@code null} if there is none. */
   @NullableDecl
   static <T> T removeFirstMatching(Iterable<T> removeFrom, Predicate<? super T> predicate) {
-    checkNotNull(predicate);
     Iterator<T> iterator = removeFrom.iterator();
     while (iterator.hasNext()) {
       T next = iterator.next();
@@ -317,7 +314,7 @@ public final class Iterables {
       Collection<? extends T> c = Collections2.cast(elementsToAdd);
       return addTo.addAll(c);
     }
-    return Iterators.addAll(addTo, checkNotNull(elementsToAdd).iterator());
+    return Iterators.addAll(addTo, elementsToAdd.iterator());
   }
 
   /**
@@ -359,7 +356,6 @@ public final class Iterables {
    * Stream.generate(() -> iterable).flatMap(Streams::stream)}.
    */
   public static <T> Iterable<T> cycle(final Iterable<T> iterable) {
-    checkNotNull(iterable);
     return new FluentIterable<T>() {
       @Override
       public Iterator<T> iterator() {
@@ -507,7 +503,6 @@ public final class Iterables {
    * @throws IllegalArgumentException if {@code size} is nonpositive
    */
   public static <T> Iterable<List<T>> partition(final Iterable<T> iterable, final int size) {
-    checkNotNull(iterable);
     checkArgument(size > 0);
     return new FluentIterable<List<T>>() {
       @Override
@@ -533,7 +528,6 @@ public final class Iterables {
    * @throws IllegalArgumentException if {@code size} is nonpositive
    */
   public static <T> Iterable<List<T>> paddedPartition(final Iterable<T> iterable, final int size) {
-    checkNotNull(iterable);
     checkArgument(size > 0);
     return new FluentIterable<List<T>>() {
       @Override
@@ -551,8 +545,6 @@ public final class Iterables {
    */
   public static <T> Iterable<T> filter(
       final Iterable<T> unfiltered, final Predicate<? super T> retainIfTrue) {
-    checkNotNull(unfiltered);
-    checkNotNull(retainIfTrue);
     return new FluentIterable<T>() {
       @Override
       public Iterator<T> iterator() {
@@ -561,7 +553,6 @@ public final class Iterables {
 
       @Override
       public void forEach(Consumer<? super T> action) {
-        checkNotNull(action);
         unfiltered.forEach(
             (T a) -> {
               if (retainIfTrue.test(a)) {
@@ -594,8 +585,6 @@ public final class Iterables {
   @SuppressWarnings("unchecked")
   @GwtIncompatible // Class.isInstance
   public static <T> Iterable<T> filter(final Iterable<?> unfiltered, final Class<T> desiredType) {
-    checkNotNull(unfiltered);
-    checkNotNull(desiredType);
     return (Iterable<T>) filter(unfiltered, Predicates.instanceOf(desiredType));
   }
 
@@ -693,8 +682,6 @@ public final class Iterables {
    */
   public static <F, T> Iterable<T> transform(
       final Iterable<F> fromIterable, final Function<? super F, ? extends T> function) {
-    checkNotNull(fromIterable);
-    checkNotNull(function);
     return new FluentIterable<T>() {
       @Override
       public Iterator<T> iterator() {
@@ -703,7 +690,6 @@ public final class Iterables {
 
       @Override
       public void forEach(Consumer<? super T> action) {
-        checkNotNull(action);
         fromIterable.forEach((F f) -> action.accept(function.apply(f)));
       }
 
@@ -726,7 +712,6 @@ public final class Iterables {
    *     the size of {@code iterable}
    */
   public static <T> T get(Iterable<T> iterable, int position) {
-    checkNotNull(iterable);
     return (iterable instanceof List)
         ? ((List<T>) iterable).get(position)
         : Iterators.get(iterable.iterator(), position);
@@ -750,7 +735,6 @@ public final class Iterables {
   @NullableDecl
   public static <T> T get(
       Iterable<? extends T> iterable, int position, @NullableDecl T defaultValue) {
-    checkNotNull(iterable);
     Iterators.checkNonnegative(position);
     if (iterable instanceof List) {
       List<? extends T> list = Lists.cast(iterable);
@@ -855,7 +839,6 @@ public final class Iterables {
    * @since 3.0
    */
   public static <T> Iterable<T> skip(final Iterable<T> iterable, final int numberToSkip) {
-    checkNotNull(iterable);
     checkArgument(numberToSkip >= 0, "number to skip cannot be negative");
 
     return new FluentIterable<T>() {
@@ -925,7 +908,6 @@ public final class Iterables {
    * @since 3.0
    */
   public static <T> Iterable<T> limit(final Iterable<T> iterable, final int limitSize) {
-    checkNotNull(iterable);
     checkArgument(limitSize >= 0, "limit is negative");
     return new FluentIterable<T>() {
       @Override
@@ -957,8 +939,6 @@ public final class Iterables {
    * @since 2.0
    */
   public static <T> Iterable<T> consumingIterable(final Iterable<T> iterable) {
-    checkNotNull(iterable);
-
     return new FluentIterable<T>() {
       @Override
       public Iterator<T> iterator() {
@@ -1010,8 +990,6 @@ public final class Iterables {
   public static <T> Iterable<T> mergeSorted(
       final Iterable<? extends Iterable<? extends T>> iterables,
       final Comparator<? super T> comparator) {
-    checkNotNull(iterables, "iterables");
-    checkNotNull(comparator, "comparator");
     Iterable<T> iterable =
         new FluentIterable<T>() {
           @Override

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -124,7 +124,6 @@ public final class Iterators {
   /** Returns an unmodifiable view of {@code iterator}. */
   public static <T> UnmodifiableIterator<T> unmodifiableIterator(
       final Iterator<? extends T> iterator) {
-    checkNotNull(iterator);
     if (iterator instanceof UnmodifiableIterator) {
       @SuppressWarnings("unchecked") // Since it's unmodifiable, the covariant cast is safe
       UnmodifiableIterator<T> result = (UnmodifiableIterator<T>) iterator;
@@ -151,7 +150,7 @@ public final class Iterators {
    */
   @Deprecated
   public static <T> UnmodifiableIterator<T> unmodifiableIterator(UnmodifiableIterator<T> iterator) {
-    return checkNotNull(iterator);
+    return iterator;
   }
 
   /**
@@ -195,7 +194,6 @@ public final class Iterators {
    */
   @CanIgnoreReturnValue
   public static boolean removeAll(Iterator<?> removeFrom, Collection<?> elementsToRemove) {
-    checkNotNull(elementsToRemove);
     boolean result = false;
     while (removeFrom.hasNext()) {
       if (elementsToRemove.contains(removeFrom.next())) {
@@ -217,7 +215,6 @@ public final class Iterators {
    */
   @CanIgnoreReturnValue
   public static <T> boolean removeIf(Iterator<T> removeFrom, Predicate<? super T> predicate) {
-    checkNotNull(predicate);
     boolean modified = false;
     while (removeFrom.hasNext()) {
       if (predicate.apply(removeFrom.next())) {
@@ -239,7 +236,6 @@ public final class Iterators {
    */
   @CanIgnoreReturnValue
   public static boolean retainAll(Iterator<?> removeFrom, Collection<?> elementsToRetain) {
-    checkNotNull(elementsToRetain);
     boolean result = false;
     while (removeFrom.hasNext()) {
       if (!elementsToRetain.contains(removeFrom.next())) {
@@ -351,8 +347,6 @@ public final class Iterators {
    */
   @CanIgnoreReturnValue
   public static <T> boolean addAll(Collection<T> addTo, Iterator<? extends T> iterator) {
-    checkNotNull(addTo);
-    checkNotNull(iterator);
     boolean wasModified = false;
     while (iterator.hasNext()) {
       wasModified |= addTo.add(iterator.next());
@@ -389,7 +383,6 @@ public final class Iterators {
    * elements.
    */
   public static <T> Iterator<T> cycle(final Iterable<T> iterable) {
-    checkNotNull(iterable);
     return new Iterator<T>() {
       Iterator<T> iterator = emptyModifiableIterator();
 
@@ -479,8 +472,6 @@ public final class Iterators {
    * supports it.
    */
   public static <T> Iterator<T> concat(Iterator<? extends T> a, Iterator<? extends T> b) {
-    checkNotNull(a);
-    checkNotNull(b);
     return concat(consumingForArray(a, b));
   }
 
@@ -494,9 +485,6 @@ public final class Iterators {
    */
   public static <T> Iterator<T> concat(
       Iterator<? extends T> a, Iterator<? extends T> b, Iterator<? extends T> c) {
-    checkNotNull(a);
-    checkNotNull(b);
-    checkNotNull(c);
     return concat(consumingForArray(a, b, c));
   }
 
@@ -514,10 +502,6 @@ public final class Iterators {
       Iterator<? extends T> b,
       Iterator<? extends T> c,
       Iterator<? extends T> d) {
-    checkNotNull(a);
-    checkNotNull(b);
-    checkNotNull(c);
-    checkNotNull(d);
     return concat(consumingForArray(a, b, c, d));
   }
 
@@ -537,7 +521,7 @@ public final class Iterators {
 
   /** Concats a varargs array of iterators without making a defensive copy of the array. */
   static <T> Iterator<T> concatNoDefensiveCopy(Iterator<? extends T>... inputs) {
-    for (Iterator<? extends T> input : checkNotNull(inputs)) {
+    for (Iterator<? extends T> input : inputs) {
       checkNotNull(input);
     }
     return concat(consumingForArray(inputs));
@@ -594,7 +578,6 @@ public final class Iterators {
 
   private static <T> UnmodifiableIterator<List<T>> partitionImpl(
       final Iterator<T> iterator, final int size, final boolean pad) {
-    checkNotNull(iterator);
     checkArgument(size > 0);
     return new UnmodifiableIterator<List<T>>() {
       @Override
@@ -629,8 +612,6 @@ public final class Iterators {
    */
   public static <T> UnmodifiableIterator<T> filter(
       final Iterator<T> unfiltered, final Predicate<? super T> retainIfTrue) {
-    checkNotNull(unfiltered);
-    checkNotNull(retainIfTrue);
     return new AbstractIterator<T>() {
       @Override
       protected T computeNext() {
@@ -668,7 +649,6 @@ public final class Iterators {
    * predicate. If {@code iterator} is empty, {@code true} is returned.
    */
   public static <T> boolean all(Iterator<T> iterator, Predicate<? super T> predicate) {
-    checkNotNull(predicate);
     while (iterator.hasNext()) {
       T element = iterator.next();
       if (!predicate.apply(element)) {
@@ -688,8 +668,6 @@ public final class Iterators {
    * @throws NoSuchElementException if no element in {@code iterator} matches the given predicate
    */
   public static <T> T find(Iterator<T> iterator, Predicate<? super T> predicate) {
-    checkNotNull(iterator);
-    checkNotNull(predicate);
     while (iterator.hasNext()) {
       T t = iterator.next();
       if (predicate.apply(t)) {
@@ -712,8 +690,6 @@ public final class Iterators {
       Iterator<? extends T> iterator,
       Predicate<? super T> predicate,
       @NullableDecl T defaultValue) {
-    checkNotNull(iterator);
-    checkNotNull(predicate);
     while (iterator.hasNext()) {
       T t = iterator.next();
       if (predicate.apply(t)) {
@@ -735,8 +711,6 @@ public final class Iterators {
    * @since 11.0
    */
   public static <T> Optional<T> tryFind(Iterator<T> iterator, Predicate<? super T> predicate) {
-    checkNotNull(iterator);
-    checkNotNull(predicate);
     while (iterator.hasNext()) {
       T t = iterator.next();
       if (predicate.apply(t)) {
@@ -761,7 +735,6 @@ public final class Iterators {
    * @since 2.0
    */
   public static <T> int indexOf(Iterator<T> iterator, Predicate<? super T> predicate) {
-    checkNotNull(predicate, "predicate");
     for (int i = 0; iterator.hasNext(); i++) {
       T current = iterator.next();
       if (predicate.apply(current)) {
@@ -781,7 +754,6 @@ public final class Iterators {
    */
   public static <F, T> Iterator<T> transform(
       final Iterator<F> fromIterator, final Function<? super F, ? extends T> function) {
-    checkNotNull(function);
     return new TransformedIterator<F, T>(fromIterator) {
       @Override
       T transform(F from) {
@@ -889,7 +861,6 @@ public final class Iterators {
    */
   @CanIgnoreReturnValue
   public static int advance(Iterator<?> iterator, int numberToAdvance) {
-    checkNotNull(iterator);
     checkArgument(numberToAdvance >= 0, "numberToAdvance must be nonnegative");
 
     int i;
@@ -910,7 +881,6 @@ public final class Iterators {
    * @since 3.0
    */
   public static <T> Iterator<T> limit(final Iterator<T> iterator, final int limitSize) {
-    checkNotNull(iterator);
     checkArgument(limitSize >= 0, "limit is negative");
     return new Iterator<T>() {
       private int count;
@@ -948,7 +918,6 @@ public final class Iterators {
    * @since 2.0
    */
   public static <T> Iterator<T> consumingIterator(final Iterator<T> iterator) {
-    checkNotNull(iterator);
     return new UnmodifiableIterator<T>() {
       @Override
       public boolean hasNext() {
@@ -988,7 +957,6 @@ public final class Iterators {
 
   /** Clears the iterator using its remove method. */
   static void clear(Iterator<?> iterator) {
-    checkNotNull(iterator);
     while (iterator.hasNext()) {
       iterator.next();
       iterator.remove();
@@ -1082,7 +1050,6 @@ public final class Iterators {
    * using {@link Collections#list}.
    */
   public static <T> UnmodifiableIterator<T> forEnumeration(final Enumeration<T> enumeration) {
-    checkNotNull(enumeration);
     return new UnmodifiableIterator<T>() {
       @Override
       public boolean hasNext() {
@@ -1103,7 +1070,6 @@ public final class Iterators {
    * you have a {@link Collection}), or {@code Iterators.asEnumeration(collection.iterator())}.
    */
   public static <T> Enumeration<T> asEnumeration(final Iterator<T> iterator) {
-    checkNotNull(iterator);
     return new Enumeration<T>() {
       @Override
       public boolean hasMoreElements() {
@@ -1125,7 +1091,7 @@ public final class Iterators {
     private E peekedElement;
 
     public PeekingImpl(Iterator<? extends E> iterator) {
-      this.iterator = checkNotNull(iterator);
+      this.iterator = iterator;
     }
 
     @Override
@@ -1215,7 +1181,7 @@ public final class Iterators {
    */
   @Deprecated
   public static <T> PeekingIterator<T> peekingIterator(PeekingIterator<T> iterator) {
-    return checkNotNull(iterator);
+    return iterator;
   }
 
   /**
@@ -1233,9 +1199,6 @@ public final class Iterators {
   @Beta
   public static <T> UnmodifiableIterator<T> mergeSorted(
       Iterable<? extends Iterator<? extends T>> iterators, Comparator<? super T> comparator) {
-    checkNotNull(iterators, "iterators");
-    checkNotNull(comparator, "comparator");
-
     return new MergingIterator<T>(iterators, comparator);
   }
 
@@ -1310,7 +1273,7 @@ public final class Iterators {
 
     ConcatenatedIterator(Iterator<? extends Iterator<? extends T>> metaIterator) {
       iterator = emptyIterator();
-      topMetaIterator = checkNotNull(metaIterator);
+      topMetaIterator = metaIterator;
     }
 
     // Returns a nonempty meta-iterator or, if all meta-iterators are empty, null.

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -3660,7 +3660,7 @@ public final class Maps {
   }
 
   /** An implementation of {@link Map#equals}. */
-  static boolean equalsImpl(Map<?, ?> map, Object object) {
+  static boolean equalsImpl(Map<?, ?> map, @NullableDecl Object object) {
     if (map == object) {
       return true;
     } else if (object instanceof Map) {

--- a/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.primitives.Primitives;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -156,7 +158,7 @@ public final class MutableClassToInstanceMap<B> extends ForwardingMap<Class<? ex
   }
 
   @CanIgnoreReturnValue
-  private static <B, T extends B> T cast(Class<T> type, B value) {
+  private static <B, T extends B> T cast(Class<T> type, @NullableDecl B value) {
     return Primitives.wrap(type).cast(value);
   }
 

--- a/guava/src/com/google/common/collect/ObjectArrays.java
+++ b/guava/src/com/google/common/collect/ObjectArrays.java
@@ -220,7 +220,7 @@ public final class ObjectArrays {
   // We do this instead of Preconditions.checkNotNull to save boxing and array
   // creation cost.
   @CanIgnoreReturnValue
-  static Object checkElementNotNull(Object element, int index) {
+  static Object checkElementNotNull(@NullableDecl Object element, int index) {
     if (element == null) {
       throw new NullPointerException("at index " + index);
     }

--- a/guava/src/com/google/common/collect/RegularImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableBiMap.java
@@ -111,8 +111,8 @@ class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
   }
 
   private RegularImmutableBiMap(
-      ImmutableMapEntry<K, V>[] keyTable,
-      ImmutableMapEntry<K, V>[] valueTable,
+      @NullableDecl ImmutableMapEntry<K, V>[] keyTable,
+      @NullableDecl ImmutableMapEntry<K, V>[] valueTable,
       Entry<K, V>[] entries,
       int mask,
       int hashCode) {

--- a/guava/src/com/google/common/collect/RegularImmutableMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableMap.java
@@ -97,7 +97,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     return new RegularImmutableMap<>(entries, table, mask);
   }
 
-  private RegularImmutableMap(Entry<K, V>[] entries, ImmutableMapEntry<K, V>[] table, int mask) {
+  private RegularImmutableMap(Entry<K, V>[] entries, @NullableDecl ImmutableMapEntry<K, V>[] table, int mask) {
     this.entries = entries;
     this.table = table;
     this.mask = mask;

--- a/guava/src/com/google/common/collect/RegularImmutableSet.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSet.java
@@ -40,7 +40,7 @@ final class RegularImmutableSet<E> extends ImmutableSet<E> {
   private final transient int mask;
   private final transient int hashCode;
 
-  RegularImmutableSet(Object[] elements, int hashCode, Object[] table, int mask) {
+  RegularImmutableSet(Object[] elements, int hashCode, @NullableDecl Object[] table, int mask) {
     this.elements = elements;
     this.table = table;
     this.mask = mask;

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -384,7 +384,7 @@ final class Types {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    public Object invoke(Object proxy, Method method, @NullableDecl Object[] args) throws Throwable {
       String methodName = method.getName();
       Method typeVariableMethod = typeVariableMethods.get(methodName);
       if (typeVariableMethod == null) {

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -188,7 +188,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
 
     // non-volatile write to the next field. Should be made visible by subsequent CAS on waiters
     // field.
-    void setNext(Waiter next) {
+    void setNext(@NullableDecl Waiter next) {
       ATOMIC_HELPER.putNext(this, next);
     }
 
@@ -252,7 +252,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     // writes to next are made visible by subsequent CAS's on the listeners field
     @NullableDecl Listener next;
 
-    Listener(Runnable task, Executor executor) {
+    Listener(@NullableDecl Runnable task, @NullableDecl Executor executor) {
       this.task = task;
       this.executor = executor;
     }
@@ -923,7 +923,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    * Clears the {@link #listeners} list and prepends its contents to {@code onto}, least recently
    * added first.
    */
-  private Listener clearListeners(Listener onto) {
+  private Listener clearListeners(@NullableDecl Listener onto) {
     // We need to
     // 1. atomically swap the listeners with TOMBSTONE, this is because addListener uses that to
     //    to synchronize with us
@@ -1029,7 +1029,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     abstract void putThread(Waiter waiter, Thread newValue);
 
     /** Non volatile write of the waiter to the {@link Waiter#next} field. */
-    abstract void putNext(Waiter waiter, Waiter newValue);
+    abstract void putNext(Waiter waiter, @NullableDecl Waiter newValue);
 
     /** Performs a CAS operation on the {@link #waiters} field. */
     abstract boolean casWaiters(AbstractFuture<?> future, Waiter expect, Waiter update);
@@ -1101,25 +1101,25 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     }
 
     @Override
-    void putNext(Waiter waiter, Waiter newValue) {
+    void putNext(Waiter waiter, @NullableDecl Waiter newValue) {
       UNSAFE.putObject(waiter, WAITER_NEXT_OFFSET, newValue);
     }
 
     /** Performs a CAS operation on the {@link #waiters} field. */
     @Override
-    boolean casWaiters(AbstractFuture<?> future, Waiter expect, Waiter update) {
+    boolean casWaiters(AbstractFuture<?> future, @NullableDecl Waiter expect, @NullableDecl Waiter update) {
       return UNSAFE.compareAndSwapObject(future, WAITERS_OFFSET, expect, update);
     }
 
     /** Performs a CAS operation on the {@link #listeners} field. */
     @Override
-    boolean casListeners(AbstractFuture<?> future, Listener expect, Listener update) {
+    boolean casListeners(AbstractFuture<?> future, @NullableDecl Listener expect, Listener update) {
       return UNSAFE.compareAndSwapObject(future, LISTENERS_OFFSET, expect, update);
     }
 
     /** Performs a CAS operation on the {@link #value} field. */
     @Override
-    boolean casValue(AbstractFuture<?> future, Object expect, Object update) {
+    boolean casValue(AbstractFuture<?> future, @NullableDecl Object expect, Object update) {
       return UNSAFE.compareAndSwapObject(future, VALUE_OFFSET, expect, update);
     }
   }
@@ -1151,7 +1151,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     }
 
     @Override
-    void putNext(Waiter waiter, Waiter newValue) {
+    void putNext(Waiter waiter, @NullableDecl Waiter newValue) {
       waiterNextUpdater.lazySet(waiter, newValue);
     }
 
@@ -1184,7 +1184,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     }
 
     @Override
-    void putNext(Waiter waiter, Waiter newValue) {
+    void putNext(Waiter waiter, @NullableDecl Waiter newValue) {
       waiter.next = newValue;
     }
 

--- a/guava/src/com/google/common/util/concurrent/AbstractListeningExecutorService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractListeningExecutorService.java
@@ -41,7 +41,7 @@ public abstract class AbstractListeningExecutorService extends AbstractExecutorS
 
   /** @since 19.0 (present with return type {@code ListenableFutureTask} since 14.0) */
   @Override
-  protected final <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+  protected final <T> RunnableFuture<T> newTaskFor(Runnable runnable, @NullableDecl T value) {
     return TrustedListenableFutureTask.create(runnable, value);
   }
 

--- a/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
+++ b/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
@@ -126,7 +126,7 @@ class TrustedListenableFutureTask<V> extends AbstractFuture.TrustedFuture<V>
     }
 
     @Override
-    void afterRanInterruptibly(V result, Throwable error) {
+    void afterRanInterruptibly(@NullableDecl V result, @NullableDecl Throwable error) {
       if (error == null) {
         TrustedListenableFutureTask.this.set(result);
       } else {

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
               <arg>-Xplugin:Traute</arg>
               <arg>-Atraute.failure.text.parameter=$${PARAMETER_NAME} was null</arg>
             </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>tech.harmonysoft</groupId>
+                <artifactId>traute-javac</artifactId>
+                <version>1.1.5</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
         <plugin>
@@ -293,13 +300,6 @@
             <artifactId>guava</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>tech.harmonysoft</groupId>
-        <artifactId>traute-javac</artifactId>
-        <version>1.1.5</version>
-        <!-- make the jar eligible for compilation only -->
-        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,10 @@
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
+            <compilerArgs>
+              <arg>-Xplugin:Traute</arg>
+              <arg>-Atraute.failure.text.parameter=$${PARAMETER_NAME} was null</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>
@@ -289,6 +293,13 @@
             <artifactId>guava</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>tech.harmonysoft</groupId>
+        <artifactId>traute-javac</artifactId>
+        <version>1.1.5</version>
+        <!-- make the jar eligible for compilation only -->
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This *PR* illustrates an approach where explicit *null*-checks are replaced by automatic checks.  

Consider a sample class - [Iterators](https://github.com/denis-zhdanov/guava/commit/71eee2dea89f6827f340e231bc715311120df6ca#diff-d2ea06a03a4988cf54d6d3d923deae88):  

*Original source code*  

```java
public static <T> Iterator<T> concat(Iterator<? extends T> a, Iterator<? extends T> b) {
  checkNotNull(a);
  checkNotNull(b);
  return concat(consumingForArray(a, b));
}
```  

*Suggested source code*  

```java
public static <T> Iterator<T> concat(Iterator<? extends T> a, Iterator<? extends T> b) {
  return concat(consumingForArray(a, b));
}
```  

Resulting bytecode looks like if it's compiled from the source below:  

```java
public static <T> Iterator<T> concat(Iterator<? extends T> a, Iterator<? extends T> b) {
  if (a == null) {
    throw new NullPointerException("a was null");
  }
  if (b == null) {
    throw new NullPointerException("b was null");
  }
  return concat(consumingForArray(new Iterator[] { a, b }));
}
```  

*Raw bytecode*  

```
javap -c ./guava/target/classes/com/google/common/collect/Iterators.class
...
  public static <T> java.util.Iterator<T> concat(java.util.Iterator<? extends T>, java.util.Iterator<? extends T>);
    Code:
       0: aload_0
       1: ifnonnull     14
       4: new           #5                  // class java/lang/NullPointerException
       7: dup
       8: ldc           #51                 // String a was null
      10: invokespecial #7                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      13: athrow
      14: aload_1
      15: ifnonnull     28
      18: new           #5                  // class java/lang/NullPointerException
      21: dup
      22: ldc           #52                 // String b was null
      24: invokespecial #7                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      27: athrow
      28: iconst_2
      29: anewarray     #53                 // class java/util/Iterator
      32: dup
      33: iconst_0
      34: aload_0
      35: aastore
      36: dup
      37: iconst_1
      38: aload_1
      39: aastore
      40: invokestatic  #54                 // Method consumingForArray:([Ljava/lang/Object;)Ljava/util/Iterator;
      43: invokestatic  #55                 // Method concat:(Ljava/util/Iterator;)Ljava/util/Iterator;
      46: areturn
```  

**Implementation**  

The checks are generated by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin - it finds [existing package-level *ParametersAreNonnullByDefault*](https://github.com/google/guava/blob/master/guava/src/com/google/common/collect/package-info.java#L215) annotation and adds checks for all method parameters not marked by *Nullable* annotation (*Checker*'s *NullableDecl* is [supported by default](http://traute.oss.harmonysoft.tech/core/javac/#73-nullable-annotations)).  

**Restrictions**  

*Traute* is a *javac* plugin and corresponding *API* is available since *java8*. Do you guys use something like `javac8 -source 1.7 -target 1.7` for generating *javac7* bytecode?  

**Proposal**  

I'd be glad to create a *PR*/modify current *PR* which replaces all explicit *null*-checks if the team likes the approach.