### PR TITLE
Restrict length of varargs array in immutable collection factory methods

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -16,6 +16,7 @@
 
 package com.google.common.collect;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
@@ -190,12 +191,18 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
   /**
    * Returns an immutable list containing the given elements, in order.
    *
+   * <p>The array {@code others} must not be longer than {@code Integer.MAX_VALUE - 12}.
+   *
    * @throws NullPointerException if any element is null
    * @since 3.0 (source-compatible since 2.0)
    */
   @SafeVarargs // For Eclipse. For internal javac we have disabled this pointless type of warning.
   public static <E> ImmutableList<E> of(
       E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10, E e11, E e12, E... others) {
+    checkArgument(
+        others.length <= Integer.MAX_VALUE - 12,
+        "others.length (%s) must be <= Integer.MAX_VALUE - 12",
+        others.length);
     Object[] array = new Object[12 + others.length];
     array[0] = e1;
     array[1] = e2;

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -201,8 +201,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
       E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10, E e11, E e12, E... others) {
     checkArgument(
         others.length <= Integer.MAX_VALUE - 12,
-        "others.length (%s) must be <= Integer.MAX_VALUE - 12",
-        others.length);
+        "the total number of elements must fit in an int");
     Object[] array = new Object[12 + others.length];
     array[0] = e1;
     array[1] = e2;

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -125,10 +125,16 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    * first specified. That is, if multiple elements are {@linkplain Object#equals equal}, all except
    * the first are ignored.
    *
+   * <p>The array {@code others} must not be longer than {@code Integer.MAX_VALUE - 6}.
+   *
    * @since 3.0 (source-compatible since 2.0)
    */
   @SafeVarargs // For Eclipse. For internal javac we have disabled this pointless type of warning.
   public static <E> ImmutableSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E... others) {
+    checkArgument(
+        others.length <= Integer.MAX_VALUE - 6,
+        "others.length (%s) must be <= Integer.MAX_VALUE - 6",
+        others.length);
     final int paramCount = 6;
     Object[] elements = new Object[paramCount + others.length];
     elements[0] = e1;

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -133,8 +133,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
   public static <E> ImmutableSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E... others) {
     checkArgument(
         others.length <= Integer.MAX_VALUE - 6,
-        "others.length (%s) must be <= Integer.MAX_VALUE - 6",
-        others.length);
+        "the total number of elements must fit in an int");
     final int paramCount = 6;
     Object[] elements = new Object[paramCount + others.length];
     elements[0] = e1;

--- a/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
@@ -139,8 +139,7 @@ public final class ImmutableDoubleArray implements Serializable {
   public static ImmutableDoubleArray of(double first, double... rest) {
     checkArgument(
         rest.length <= Integer.MAX_VALUE - 1,
-        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
-        rest.length);
+        "the total number of elements must fit in an int");
     double[] array = new double[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);

--- a/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
@@ -129,10 +129,18 @@ public final class ImmutableDoubleArray implements Serializable {
 
   // TODO(kevinb): go up to 11?
 
-  /** Returns an immutable array containing the given values, in order. */
+  /**
+   * Returns an immutable array containing the given values, in order.
+   *
+   * <p>The array {@code rest} must not be longer than {@code Integer.MAX_VALUE - 1}.
+   */
   // Use (first, rest) so that `of(someDoubleArray)` won't compile (they should use copyOf), which
   // is okay since we have to copy the just-created array anyway.
   public static ImmutableDoubleArray of(double first, double... rest) {
+    checkArgument(
+        rest.length <= Integer.MAX_VALUE - 1,
+        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
+        rest.length);
     double[] array = new double[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);

--- a/guava/src/com/google/common/primitives/ImmutableIntArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableIntArray.java
@@ -138,8 +138,7 @@ public final class ImmutableIntArray implements Serializable {
   public static ImmutableIntArray of(int first, int... rest) {
     checkArgument(
         rest.length <= Integer.MAX_VALUE - 1,
-        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
-        rest.length);
+        "the total number of elements must fit in an int");
     int[] array = new int[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);

--- a/guava/src/com/google/common/primitives/ImmutableIntArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableIntArray.java
@@ -128,10 +128,18 @@ public final class ImmutableIntArray implements Serializable {
 
   // TODO(kevinb): go up to 11?
 
-  /** Returns an immutable array containing the given values, in order. */
+  /**
+   * Returns an immutable array containing the given values, in order.
+   *
+   * <p>The array {@code rest} must not be longer than {@code Integer.MAX_VALUE - 1}.
+   */
   // Use (first, rest) so that `of(someIntArray)` won't compile (they should use copyOf), which is
   // okay since we have to copy the just-created array anyway.
   public static ImmutableIntArray of(int first, int... rest) {
+    checkArgument(
+        rest.length <= Integer.MAX_VALUE - 1,
+        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
+        rest.length);
     int[] array = new int[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);

--- a/guava/src/com/google/common/primitives/ImmutableLongArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableLongArray.java
@@ -128,10 +128,18 @@ public final class ImmutableLongArray implements Serializable {
 
   // TODO(kevinb): go up to 11?
 
-  /** Returns an immutable array containing the given values, in order. */
+  /**
+   * Returns an immutable array containing the given values, in order.
+   *
+   * <p>The array {@code rest} must not be longer than {@code Integer.MAX_VALUE - 1}.
+   */
   // Use (first, rest) so that `of(someLongArray)` won't compile (they should use copyOf), which is
   // okay since we have to copy the just-created array anyway.
   public static ImmutableLongArray of(long first, long... rest) {
+    checkArgument(
+        rest.length <= Integer.MAX_VALUE - 1,
+        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
+        rest.length);
     long[] array = new long[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);

--- a/guava/src/com/google/common/primitives/ImmutableLongArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableLongArray.java
@@ -138,8 +138,7 @@ public final class ImmutableLongArray implements Serializable {
   public static ImmutableLongArray of(long first, long... rest) {
     checkArgument(
         rest.length <= Integer.MAX_VALUE - 1,
-        "rest.length (%s) must be <= Integer.MAX_VALUE - 1",
-        rest.length);
+        "the total number of elements must fit in an int");
     long[] array = new long[rest.length + 1];
     array[0] = first;
     System.arraycopy(rest, 0, array, 1, rest.length);


### PR DESCRIPTION
This PR documents the restriction that immutable collection factory methods with varargs pose on the length of the last argument, and adds a check for this precondition to prevent `NegativeArraySizeException` from being thrown.

Fixes #3026.
