### PR TITLE
Change .orderedBy() builders generic type to <? super>

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
@@ -861,4 +861,20 @@ public class ImmutableSortedMapTest extends TestCase {
     ImmutableSortedMap.Builder<SuperComparableExample, Object> reverse =
         ImmutableSortedMap.reverseOrder();
   }
+
+  private static final Comparator<Object> TO_STRING =
+      new Comparator<Object>() {
+        @Override
+        public int compare(Object o1, Object o2) {
+          return o1.toString().compareTo(o2.toString());
+        }
+      };
+
+  public void testBuilderGenerics_SuperComparator() {
+    ImmutableSortedMap.Builder<Integer, Object> builder =
+        ImmutableSortedMap.orderedBy(TO_STRING);
+
+    ImmutableSortedMap.Builder<Integer, Object> builder2 =
+        new ImmutableSortedMap.Builder<>(TO_STRING);
+  }
 }

--- a/android/guava-tests/test/com/google/common/collect/ImmutableSortedMultisetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableSortedMultisetTest.java
@@ -472,6 +472,21 @@ public class ImmutableSortedMultisetTest extends TestCase {
     }
   }
 
+  private static final Comparator<Object> TO_STRING =
+      new Comparator<Object>() {
+        @Override
+        public int compare(Object o1, Object o2) {
+          return o1.toString().compareTo(o2.toString());
+        }
+      };
+
+  public void testBuilderGenerics_SuperComparator() {
+    ImmutableSortedMultiset.Builder<Integer> builder =
+        ImmutableSortedMultiset.orderedBy(TO_STRING);
+
+    ImmutableSortedMultiset.Builder<Integer> builder2 =
+        new ImmutableSortedMultiset.Builder<>(TO_STRING);
+  }
   public void testNullPointers() {
     new NullPointerTester().testAllPublicStaticMethods(ImmutableSortedMultiset.class);
   }

--- a/android/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -821,6 +821,13 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     assertThat(set).containsExactly(101, 12, 3, 44).inOrder();
   }
 
+  public void testSupertypeComparatorToOrderedBy() {
+    ImmutableSortedSet.Builder<Integer> setBuilder =
+        ImmutableSortedSet.orderedBy(TO_STRING);
+    SortedSet<Integer> set = setBuilder.add(3, 12, 101, 44).build();
+    assertThat(set).containsExactly(101, 12, 3, 44).inOrder();
+  }
+
   public void testSupertypeComparatorSubtypeElements() {
     SortedSet<Number> set =
         new ImmutableSortedSet.Builder<Number>(TO_STRING).add(3, 12, 101, 44).build();

--- a/android/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
+++ b/android/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
@@ -815,6 +816,18 @@ public class MinMaxPriorityQueueTest extends TestCase {
       assertIntact(queue);
       assertThat(queue).containsExactlyElementsIn(elements);
     }
+  }
+
+  private static final Comparator<Object> TO_STRING =
+	      new Comparator<Object>() {
+	        @Override
+	        public int compare(Object o1, Object o2) {
+	          return o1.toString().compareTo(o2.toString());
+	        }
+	      };
+
+  public void testBuilderSupertypeComparator() {
+	  MinMaxPriorityQueue<Integer> queue = MinMaxPriorityQueue.orderedBy(TO_STRING).create();
   }
 
   /** Returns the seed used for the randomization. */

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -358,14 +358,11 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
   }
 
   /**
-   * Returns a builder that creates immutable sorted maps with an explicit comparator. If the
-   * comparator has a more general type than the map's keys, such as creating a {@code
-   * SortedMap<Integer, String>} with a {@code Comparator<Number>}, use the {@link Builder}
-   * constructor instead.
+   * Returns a builder that creates immutable sorted maps with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <K, V> Builder<K, V> orderedBy(Comparator<K> comparator) {
+  public static <K, V> Builder<K, V> orderedBy(Comparator<? super K> comparator) {
     return new Builder<>(comparator);
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -343,14 +343,11 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableSortedMultiset
   public abstract ImmutableSortedMultiset<E> tailMultiset(E lowerBound, BoundType boundType);
 
   /**
-   * Returns a builder that creates immutable sorted multisets with an explicit comparator. If the
-   * comparator has a more general type than the set being generated, such as creating a {@code
-   * SortedMultiset<Integer>} with a {@code Comparator<Number>}, use the {@link Builder} constructor
-   * instead.
+   * Returns a builder that creates immutable sorted multisets with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
+  public static <E> Builder<E> orderedBy(Comparator<? super E> comparator) {
     return new Builder<E>(comparator);
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -362,14 +362,11 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSortedSetFauxveride
   }
 
   /**
-   * Returns a builder that creates immutable sorted sets with an explicit comparator. If the
-   * comparator has a more general type than the set being generated, such as creating a {@code
-   * SortedSet<Integer>} with a {@code Comparator<Number>}, use the {@link Builder} constructor
-   * instead.
+   * Returns a builder that creates immutable sorted sets with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
+  public static <E> Builder<E> orderedBy(Comparator<? super E> comparator) {
     return new Builder<E>(comparator);
   }
 

--- a/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
@@ -915,4 +915,20 @@ public class ImmutableSortedMapTest extends TestCase {
     ImmutableSortedMap.Builder<SuperComparableExample, Object> reverse =
         ImmutableSortedMap.reverseOrder();
   }
+
+  private static final Comparator<Object> TO_STRING =
+      new Comparator<Object>() {
+        @Override
+        public int compare(Object o1, Object o2) {
+          return o1.toString().compareTo(o2.toString());
+        }
+      };
+
+  public void testBuilderGenerics_SuperComparator() {
+    ImmutableSortedMap.Builder<Integer, Object> builder =
+        ImmutableSortedMap.orderedBy(TO_STRING);
+
+    ImmutableSortedMap.Builder<Integer, Object> builder2 =
+        new ImmutableSortedMap.Builder<>(TO_STRING);
+  }
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableSortedMultisetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedMultisetTest.java
@@ -453,6 +453,22 @@ public class ImmutableSortedMultisetTest extends TestCase {
     }
   }
 
+  private static final Comparator<Object> TO_STRING =
+      new Comparator<Object>() {
+        @Override
+        public int compare(Object o1, Object o2) {
+          return o1.toString().compareTo(o2.toString());
+        }
+      };
+
+  public void testBuilderGenerics_SuperComparator() {
+    ImmutableSortedMultiset.Builder<Integer> builder =
+        ImmutableSortedMultiset.orderedBy(TO_STRING);
+
+    ImmutableSortedMultiset.Builder<Integer> builder2 =
+        new ImmutableSortedMultiset.Builder<>(TO_STRING);
+  }
+
   public void testToImmutableSortedMultiset() {
     BiPredicate<ImmutableSortedMultiset<String>, ImmutableSortedMultiset<String>> equivalence =
         (ms1, ms2) ->

--- a/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -895,6 +895,13 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     assertThat(set).containsExactly(101, 12, 3, 44).inOrder();
   }
 
+  public void testSupertypeComparatorToOrderedBy() {
+    ImmutableSortedSet.Builder<Integer> setBuilder =
+        ImmutableSortedSet.orderedBy(TO_STRING);
+    SortedSet<Integer> set = setBuilder.add(3, 12, 101, 44).build();
+    assertThat(set).containsExactly(101, 12, 3, 44).inOrder();
+  }
+
   public void testSupertypeComparatorSubtypeElements() {
     SortedSet<Number> set =
         new ImmutableSortedSet.Builder<Number>(TO_STRING).add(3, 12, 101, 44).build();

--- a/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
+++ b/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
@@ -815,6 +816,18 @@ public class MinMaxPriorityQueueTest extends TestCase {
       assertIntact(queue);
       assertThat(queue).containsExactlyElementsIn(elements);
     }
+  }
+
+  private static final Comparator<Object> TO_STRING =
+	      new Comparator<Object>() {
+	        @Override
+	        public int compare(Object o1, Object o2) {
+	          return o1.toString().compareTo(o2.toString());
+	        }
+	      };
+
+  public void testBuilderSupertypeComparator() {
+	  MinMaxPriorityQueue<Integer> queue = MinMaxPriorityQueue.orderedBy(TO_STRING).create();
   }
 
   /** Returns the seed used for the randomization. */

--- a/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -411,14 +411,11 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
   }
 
   /**
-   * Returns a builder that creates immutable sorted maps with an explicit comparator. If the
-   * comparator has a more general type than the map's keys, such as creating a {@code
-   * SortedMap<Integer, String>} with a {@code Comparator<Number>}, use the {@link Builder}
-   * constructor instead.
+   * Returns a builder that creates immutable sorted maps with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <K, V> Builder<K, V> orderedBy(Comparator<K> comparator) {
+  public static <K, V> Builder<K, V> orderedBy(Comparator<? super K> comparator) {
     return new Builder<>(comparator);
   }
 

--- a/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -391,14 +391,11 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableSortedMultiset
   public abstract ImmutableSortedMultiset<E> tailMultiset(E lowerBound, BoundType boundType);
 
   /**
-   * Returns a builder that creates immutable sorted multisets with an explicit comparator. If the
-   * comparator has a more general type than the set being generated, such as creating a {@code
-   * SortedMultiset<Integer>} with a {@code Comparator<Number>}, use the {@link Builder} constructor
-   * instead.
+   * Returns a builder that creates immutable sorted multisets with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
+  public static <E> Builder<E> orderedBy(Comparator<? super E> comparator) {
     return new Builder<E>(comparator);
   }
 

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -380,14 +380,11 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSortedSetFauxveride
   }
 
   /**
-   * Returns a builder that creates immutable sorted sets with an explicit comparator. If the
-   * comparator has a more general type than the set being generated, such as creating a {@code
-   * SortedSet<Integer>} with a {@code Comparator<Number>}, use the {@link Builder} constructor
-   * instead.
+   * Returns a builder that creates immutable sorted sets with an explicit comparator.
    *
    * @throws NullPointerException if {@code comparator} is null
    */
-  public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
+  public static <E> Builder<E> orderedBy(Comparator<? super E> comparator) {
     return new Builder<E>(comparator);
   }
 


### PR DESCRIPTION
Using `.orderedBy(...)` over `new Builder<>(...)` is much more compact.

It compiles on both Java 7, 8 and 9.  It is source-compatible change, but I am not sure, whether it is fully binary-compatible or not.