### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
+++ b/android/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
@@ -123,7 +123,7 @@ public class TypeTokenResolutionTest extends TestCase {
     @SuppressWarnings("rawtypes") // trying to test raw type
     Parameterized<?, ?, ?> parameterized =
         new Parameterized<TypeTokenResolutionTest, Bar, String>() {};
-    TypeResolver typeResolver = TypeResolver.accordingTo(parameterized.getClass());
+    TypeResolver typeResolver = TypeResolver.covariantly(parameterized.getClass());
     ParameterizedType resolved =
         (ParameterizedType) typeResolver.resolveType(parameterized.parameterizedType());
     assertEquals(TypeTokenResolutionTest.class, resolved.getOwnerType());

--- a/android/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
+++ b/android/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
@@ -87,6 +87,15 @@ public class TypeTokenSubtypeTest extends TestCase {
             .isSubtypeOf(superclass));
   }
 
+  public void testGetSubtypeOf_impossibleWildcard() {
+    TypeToken<List<? extends Number>> numberList = new TypeToken<List<? extends Number>>() {};
+    abstract class StringList implements List<String> {}
+    try {
+      numberList.getSubtype(StringList.class);
+      fail();
+    } catch (IllegalArgumentException expected) {}
+  }
+
   private static class OwnerTypeSubtypingTests extends SubtypeTester {
     @TestSubtype
     public Mall<Outdoor>.Shop<Electronics> innerTypeIsSubtype(

--- a/android/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
+++ b/android/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.reflect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
@@ -30,6 +32,19 @@ public class TypeTokenSubtypeTest extends TestCase {
 
   public void testWildcardSubtypes() throws Exception {
     new WildcardSubtypingTests().testAllDeclarations();
+  }
+
+  /**
+   * This test reproduces the bug in canonicalizeWildcardType() when the type variable is
+   * recursively bounded.
+   */
+  public void testRecursiveWildcardSubtypeBug() throws Exception {
+    try {
+      new RecursiveTypeBoundBugExample<>().testAllDeclarations();
+      fail();
+    } catch (Exception e) {
+      assertThat(e).hasCauseThat().isInstanceOf(AssertionError.class);
+    }
   }
 
   public void testSubtypeOfInnerClass_nonStaticAnonymousClass() {
@@ -201,7 +216,174 @@ public class TypeTokenSubtypeTest extends TestCase {
     }
   }
 
+  private static class RecursiveTypeBoundBugExample<T extends RecursiveTypeBoundBugExample<T>>
+      extends SubtypeTester {
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<RecursiveTypeBoundBugExample<?>> ifYouUseTheTypeVariableOnTheClassAndItIsRecursive(
+        List<RecursiveTypeBoundBugExample<? extends RecursiveTypeBoundBugExample<T>>> arg) {
+      return notSubtype(arg);  // isSubtype() currently incorectly considers it a subtype.
+    }
+  }
+
   private static class WildcardSubtypingTests extends SubtypeTester {
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<?> noBounds(List<?> list) {
+      return isSubtype(list);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<List<?>> listOfListOfWildcard(List<List<?>> listOfList) {
+      return isSubtype(listOfList);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<? extends List<?>> listOfWildcardListOfWildcard(
+        List<? extends List<?>> listOfList) {
+      return isSubtype(listOfList);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<? extends Enum<?>> implicitlyBoundedEnumIsSubtypeOfExplicitlyBoundedEnum(
+        Enum<?> e) {
+      return isSubtype(e);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<?> implicitlyBoundedEnum(Enum<?> e) {
+      return isSubtype(e);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<?> explicitlyBoundedEnumIsSubtypeOfImplicitlyBoundedEnum(
+        Enum<? extends Enum<?>> obj) {
+      return isSubtype(obj);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> listOfEnums(List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public UseList<? extends List<Enum<? extends Enum<?>>>>
+    wildcardBoundUsesImplicitlyRecursiveBoundedWildcard(
+        UseList<? extends List<Enum<?>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public UseList<? extends List<Enum<? extends Enum<?>>>>
+    wildcardBoundHasImplicitBoundAtsInvariantPosition(
+        UseList<? extends List<Enum<?>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> listOfEnumsWithExplicitBoundIsSubtypeOfIterableOfEnumWithImplicitBound(
+        List<Enum<? extends Enum<?>>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> nestedExplicitEnumBoundIsSubtypeOfImplicitEnumBound(
+        List<Enum<? extends Enum<? extends Enum<?>>>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<? extends Enum<? extends Enum<?>>>>
+    implicitEnumBoundIsSubtypeOfNestedExplicitEnumBound(List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<? extends Enum<?>>>
+    listOfEnumsWithImplicitBoundIsSubtypeOfIterableOfEnumWithExplicitBound(
+        List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<Enum<? extends Enum<?>>> listOfSubEnumsIsNotSubtypeOfListOfEnums(
+        List<MyEnum> listOfEnums) {
+      return notSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<MyTypeBoundUsesImplicitBound<? extends Enum<?>>> typeVariableBoundOmitsItsOwnBound(
+        List<MyTypeBoundUsesImplicitBound<?>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<MyTypeBoundUsesImplicitBound<? extends MyEnum>>
+    wildcardUpperBoundIsNotSubtypeOfTypeVariableBound(
+        List<MyTypeBoundUsesImplicitBound<?>> arg) {
+      return notSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<UseList<? extends List<?>>>>>
+    wildcardBoundUsesParameterizedTypeWithImplicitBound(
+        List<List<? extends Iterable<UseList<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<Enum<? extends Enum<?>>>>>
+    wildcardBoundUsesRecursiveParameterizedTypeWithImplicitBound(
+        List<List<? extends Iterable<Enum<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<MyTypeBoundUsesImplicitBound<? extends Enum<?>>>>>
+    wildcardBoundUsesParameterizedTypeDefinedWithImplicitBound(
+        List<List<? extends Iterable<MyTypeBoundUsesImplicitBound<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsSubtypeOfWildcardOfExplicitlyBounded(
+        List<UseIterable<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseSerializableIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsSubtypeOfWildcardOfExplicitlyPartialBounded(
+        List<UseSerializableIterable<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseList<? extends Iterable<?>>> useListOfIterableWildcard(
+        List<UseList<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<?>>
+    listOfExplicitBoundedIsSubtypeOfListOfImplicitlyBounded(
+        List<UseIterable<? extends Iterable<?>>> withExplicitBounds) {
+      return isSubtype(withExplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsNotSubtypeOfNonWildcardOfExplicitlyBounded(
+        List<? extends UseIterable<?>> withImplicitBounds) {
+      return notSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends List<?>>>
+    wildcardOfImplicitBoundedIsNotSubtypeOfWildcardWithNarrowerBounds(
+        List<UseIterable<?>> withImplicitBounds) {
+      return notSubtype(withImplicitBounds);
+    }
+
     @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
     public <T> Iterable<? extends T> supertypeWithWildcardUpperBound(List<T> list) {
       return isSubtype(list);
@@ -269,18 +451,6 @@ public class TypeTokenSubtypeTest extends TestCase {
     }
 
     @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
-    public Enum<? extends Enum<?>> implicitlyBoundedEnumIsSubtypeOfExplicitlyBoundedEnum(
-        Enum<?> obj) {
-      return isSubtype(obj);
-    }
-
-    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
-    public Enum<?> explicitlyBoundedEnumIsSubtypeOfImplicitlyBoundedEnum(
-        Enum<? extends Enum<?>> obj) {
-      return isSubtype(obj);
-    }
-
-    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
     public UseSerializableIterable<? extends Serializable>
         implicitTypeBoundIsSubtypeOfPartialExplicitTypeBound(UseSerializableIterable<?> obj) {
       return isSubtype(obj);
@@ -330,4 +500,10 @@ public class TypeTokenSubtypeTest extends TestCase {
   private interface UseIterable<T extends Iterable<?>> {}
 
   private interface UseSerializableIterable<T extends Serializable & Iterable<?>> {}
+
+  private interface UseList<T extends List<?>> {}
+
+  private enum MyEnum {}
+
+  private interface MyTypeBoundUsesImplicitBound<E extends Enum<?>> {}
 }

--- a/android/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
+++ b/android/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
@@ -1474,9 +1474,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_methodParameter_upperBound() throws Exception {
     TypeToken<Holder<?>> type = new TypeToken<Holder<?>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     assertEquals(List.class, parameterType.getRawType());
     assertFalse(
         parameterType.getType().toString(),
@@ -1493,9 +1494,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_wildcardWithImplicitBound() throws Exception {
     TypeToken<Holder<?>> type = new TypeToken<Holder<?>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     Type[] typeArgs = ((ParameterizedType) parameterType.getType()).getActualTypeArguments();
     assertThat(typeArgs).asList().hasSize(1);
     TypeVariable<?> captured = (TypeVariable<?>) typeArgs[0];
@@ -1505,9 +1507,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_wildcardWithExplicitBound() throws Exception {
     TypeToken<Holder<? extends Number>> type = new TypeToken<Holder<? extends Number>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     Type[] typeArgs = ((ParameterizedType) parameterType.getType()).getActualTypeArguments();
     assertThat(typeArgs).asList().hasSize(1);
     TypeVariable<?> captured = (TypeVariable<?>) typeArgs[0];

--- a/android/guava/src/com/google/common/graph/Traverser.java
+++ b/android/guava/src/com/google/common/graph/Traverser.java
@@ -18,10 +18,10 @@ package com.google.common.graph;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterators.singletonIterator;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.UnmodifiableIterator;
 import java.util.ArrayDeque;
@@ -30,9 +30,33 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
- * Provides methods for traversing a graph.
+ * An object that can traverse the nodes that are reachable from a specified (set of) start node(s)
+ * using a specified {@link SuccessorsFunction}.
+ *
+ * <p>There are two entry points for creating a {@code Traverser}: {@link
+ * #forTree(SuccessorsFunction)} and {@link #forGraph(SuccessorsFunction)}. You should choose one
+ * based on your answers to the following questions:
+ *
+ * <ol>
+ *   <li>Is there only one path to any node that's reachable from any start node? (If so, the
+ *       graph to be traversed is a tree or forest even if it is a subgraph of a graph which is
+ *       neither.)
+ *   <li>Are the node objects' implementations of {@code equals()}/{@code hashCode()} <a
+ *       href="https://github.com/google/guava/wiki/GraphsExplained#non-recursiveness">recursive</a>?
+ * </ol>
+ *
+ * <p>If your answers are:
+ *
+ * <ul>
+ *   <li>(1) "no" and (2) "no", use {@link #forGraph(SuccessorsFunction)}.
+ *   <li>(1) "yes" and (2) "yes", use {@link #forTree(SuccessorsFunction)}.
+ *   <li>(1) "yes" and (2) "no", you can use either, but {@code forTree()} will be more efficient.
+ *   <li>(1) "no" and (2) "yes", <b><i>neither will work</i></b>, but if you transform your node
+ *       objects into a non-recursive form, you can use {@code forGraph()}.
+ * </ul>
  *
  * @author Jens Nyman
  * @param <N> Node parameter type
@@ -44,15 +68,20 @@ public abstract class Traverser<N> {
   /**
    * Creates a new traverser for the given general {@code graph}.
    *
-   * <p>If {@code graph} is known to be tree-shaped, consider using {@link
-   * #forTree(SuccessorsFunction)} instead.
+   * <p>Traversers created using this method are guaranteed to visit each node reachable from the
+   * start node(s) at most once.
+   *
+   * <p>If you know that no node in {@code graph} is reachable by more than one path from the start
+   * node(s), consider using {@link #forTree(SuccessorsFunction)} instead.
    *
    * <p><b>Performance notes</b>
    *
    * <ul>
    *   <li>Traversals require <i>O(n)</i> time (where <i>n</i> is the number of nodes reachable from
    *       the start node), assuming that the node objects have <i>O(1)</i> {@code equals()} and
-   *       {@code hashCode()} implementations.
+   *       {@code hashCode()} implementations. (See the <a
+   *       href="https://github.com/google/guava/wiki/GraphsExplained#elements-must-be-useable-as-map-keys">
+   *       notes on element objects</a> for more information.)
    *   <li>While traversing, the traverser will use <i>O(n)</i> space (where <i>n</i> is the number
    *       of nodes that have thus far been visited), plus <i>O(H)</i> space (where <i>H</i> is the
    *       number of nodes that have been seen but not yet visited, that is, the "horizon").
@@ -67,17 +96,24 @@ public abstract class Traverser<N> {
 
   /**
    * Creates a new traverser for a directed acyclic graph that has at most one path from the start
-   * node to any node reachable from the start node, such as a tree.
+   * node(s) to any node reachable from the start node(s), and has no paths from any start node to
+   * any other start node, such as a tree or forest.
    *
-   * <p>Providing graphs that don't conform to the above description may lead to:
+   * <p>{@code forTree()} is especially useful (versus {@code forGraph()}) in cases where the data
+   * structure being traversed is, in addition to being a tree/forest, also defined <a
+   * href="https://github.com/google/guava/wiki/GraphsExplained#non-recursiveness">recursively</a>.
+   * This is because the {@code forTree()}-based implementations don't keep track of visited nodes,
+   * and therefore don't need to call `equals()` or `hashCode()` on the node objects; this saves
+   * both time and space versus traversing the same graph using {@code forGraph()}.
+   *
+   * <p>Providing a graph to be traversed for which there is more than one path from the start
+   * node(s) to any node may lead to:
    *
    * <ul>
    *   <li>Traversal not terminating (if the graph has cycles)
-   *   <li>Nodes being visited multiple times (if multiple paths exist from the start node to any
-   *       node reachable from it)
+   *   <li>Nodes being visited multiple times (if multiple paths exist from any start node to any
+   *       node reachable from any start node)
    * </ul>
-   *
-   * In these cases, use {@link #forGraph(SuccessorsFunction)} instead.
    *
    * <p><b>Performance notes</b>
    *
@@ -88,9 +124,11 @@ public abstract class Traverser<N> {
    *       of nodes that have been seen but not yet visited, that is, the "horizon").
    * </ul>
    *
-   * <p><b>Examples</b>
+   * <p><b>Examples</b> (all edges are directed facing downwards)
    *
-   * <p>This is a valid input graph (all edges are directed facing downwards):
+   * <p>The graph below would be valid input with start nodes of {@code a, f, c}. However, if {@code
+   * b} were <i>also</i> a start node, then there would be multiple paths to reach {@code e} and
+   * {@code h}.
    *
    * <pre>{@code
    *    a     b      c
@@ -102,7 +140,10 @@ public abstract class Traverser<N> {
    *       h
    * }</pre>
    *
-   * <p>This is <b>not</b> a valid input graph (all edges are directed facing downwards):
+   * <p>.
+   *
+   * <p>The graph below would be a valid input with start nodes of {@code a, f}. However, if {@code
+   * b} were a start node, there would be multiple paths to {@code f}.
    *
    * <pre>{@code
    *    a     b
@@ -113,9 +154,6 @@ public abstract class Traverser<N> {
    *         \ /
    *          f
    * }</pre>
-   *
-   * <p>because there are two paths from {@code b} to {@code f} ({@code b->d->f} and {@code
-   * b->e->f}).
    *
    * <p><b>Note on binary trees</b>
    *
@@ -174,6 +212,17 @@ public abstract class Traverser<N> {
   public abstract Iterable<N> breadthFirst(N startNode);
 
   /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a breadth-first traversal. This is equivalent to a breadth-first
+   * traversal of a graph with an additional root node whose successors are the listed {@code
+   * startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #breadthFirst(Object)
+   */
+  public abstract Iterable<N> breadthFirst(Iterable<? extends N> startNodes);
+
+  /**
    * Returns an unmodifiable {@code Iterable} over the nodes reachable from {@code startNode}, in
    * the order of a depth-first pre-order traversal. "Pre-order" implies that nodes appear in the
    * {@code Iterable} in the order in which they are first visited.
@@ -205,6 +254,17 @@ public abstract class Traverser<N> {
    * @throws IllegalArgumentException if {@code startNode} is not an element of the graph
    */
   public abstract Iterable<N> depthFirstPreOrder(N startNode);
+
+  /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a depth-first pre-order traversal. This is equivalent to a
+   * depth-first pre-order traversal of a graph with an additional root node whose successors are
+   * the listed {@code startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #depthFirstPreOrder(Object)
+   */
+  public abstract Iterable<N> depthFirstPreOrder(Iterable<? extends N> startNodes);
 
   /**
    * Returns an unmodifiable {@code Iterable} over the nodes reachable from {@code startNode}, in
@@ -239,6 +299,17 @@ public abstract class Traverser<N> {
    */
   public abstract Iterable<N> depthFirstPostOrder(N startNode);
 
+  /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a depth-first post-order traversal. This is equivalent to a
+   * depth-first post-order traversal of a graph with an additional root node whose successors are
+   * the listed {@code startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #depthFirstPostOrder(Object)
+   */
+  public abstract Iterable<N> depthFirstPostOrder(Iterable<? extends N> startNodes);
+
   // Avoid subclasses outside of this class
   private Traverser() {}
 
@@ -252,11 +323,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> breadthFirst(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return breadthFirst(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> breadthFirst(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new BreadthFirstIterator(startNode);
+          return new BreadthFirstIterator(startNodes);
         }
       };
     }
@@ -264,11 +346,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPreOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return depthFirstPreOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPreOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstIterator(startNode, Order.PREORDER);
+          return new DepthFirstIterator(startNodes, Order.PREORDER);
         }
       };
     }
@@ -276,11 +369,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPostOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return depthFirstPostOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPostOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstIterator(startNode, Order.POSTORDER);
+          return new DepthFirstIterator(startNodes, Order.POSTORDER);
         }
       };
     }
@@ -296,9 +400,13 @@ public abstract class Traverser<N> {
       private final Queue<N> queue = new ArrayDeque<>();
       private final Set<N> visited = new HashSet<>();
 
-      BreadthFirstIterator(N root) {
-        queue.add(root);
-        visited.add(root);
+      BreadthFirstIterator(Iterable<? extends N> roots) {
+        for (N root : roots) {
+          // add all roots to the queue, skipping duplicates
+          if (visited.add(root)) {
+            queue.add(root);
+          }
+        }
       }
 
       @Override
@@ -323,10 +431,8 @@ public abstract class Traverser<N> {
       private final Set<N> visited = new HashSet<>();
       private final Order order;
 
-      DepthFirstIterator(N root, Order order) {
-        // our invariant is that in computeNext we call next on the iterator at the top first, so we
-        // need to start with one additional item on that iterator
-        stack.push(withSuccessors(root));
+      DepthFirstIterator(Iterable<? extends N> roots, Order order) {
+        stack.push(new NodeAndSuccessors(null, roots));
         this.order = order;
       }
 
@@ -336,22 +442,22 @@ public abstract class Traverser<N> {
           if (stack.isEmpty()) {
             return endOfData();
           }
-          NodeAndSuccessors node = stack.getFirst();
-          boolean firstVisit = visited.add(node.node);
-          boolean lastVisit = !node.successorIterator.hasNext();
+          NodeAndSuccessors nodeAndSuccessors = stack.getFirst();
+          boolean firstVisit = visited.add(nodeAndSuccessors.node);
+          boolean lastVisit = !nodeAndSuccessors.successorIterator.hasNext();
           boolean produceNode =
               (firstVisit && order == Order.PREORDER) || (lastVisit && order == Order.POSTORDER);
           if (lastVisit) {
             stack.pop();
           } else {
             // we need to push a neighbor, but only if we haven't already seen it
-            N successor = node.successorIterator.next();
+            N successor = nodeAndSuccessors.successorIterator.next();
             if (!visited.contains(successor)) {
               stack.push(withSuccessors(successor));
             }
           }
-          if (produceNode) {
-            return node.node;
+          if (produceNode && nodeAndSuccessors.node != null) {
+            return nodeAndSuccessors.node;
           }
         }
       }
@@ -362,10 +468,10 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its successors. */
       private final class NodeAndSuccessors {
-        final N node;
+        @NullableDecl final N node;
         final Iterator<? extends N> successorIterator;
 
-        NodeAndSuccessors(N node, Iterable<? extends N> successors) {
+        NodeAndSuccessors(@NullableDecl N node, Iterable<? extends N> successors) {
           this.node = node;
           this.successorIterator = successors.iterator();
         }
@@ -383,11 +489,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> breadthFirst(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return breadthFirst(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> breadthFirst(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInTree(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new BreadthFirstIterator(startNode);
+          return new BreadthFirstIterator(startNodes);
         }
       };
     }
@@ -395,11 +512,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPreOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return depthFirstPreOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPreOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N node : startNodes) {
+        checkThatNodeIsInTree(node);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstPreOrderIterator(startNode);
+          return new DepthFirstPreOrderIterator(startNodes);
         }
       };
     }
@@ -407,11 +535,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPostOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return depthFirstPostOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPostOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInTree(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstPostOrderIterator(startNode);
+          return new DepthFirstPostOrderIterator(startNodes);
         }
       };
     }
@@ -426,8 +565,10 @@ public abstract class Traverser<N> {
     private final class BreadthFirstIterator extends UnmodifiableIterator<N> {
       private final Queue<N> queue = new ArrayDeque<>();
 
-      BreadthFirstIterator(N root) {
-        queue.add(root);
+      BreadthFirstIterator(Iterable<? extends N> roots) {
+        for (N root : roots) {
+          queue.add(root);
+        }
       }
 
       @Override
@@ -446,8 +587,8 @@ public abstract class Traverser<N> {
     private final class DepthFirstPreOrderIterator extends UnmodifiableIterator<N> {
       private final Deque<Iterator<? extends N>> stack = new ArrayDeque<>();
 
-      DepthFirstPreOrderIterator(N root) {
-        stack.addLast(singletonIterator(checkNotNull(root)));
+      DepthFirstPreOrderIterator(Iterable<? extends N> roots) {
+        stack.addLast(roots.iterator());
       }
 
       @Override
@@ -473,8 +614,8 @@ public abstract class Traverser<N> {
     private final class DepthFirstPostOrderIterator extends AbstractIterator<N> {
       private final ArrayDeque<NodeAndChildren> stack = new ArrayDeque<>();
 
-      DepthFirstPostOrderIterator(N root) {
-        stack.addLast(withChildren(root));
+      DepthFirstPostOrderIterator(Iterable<? extends N> roots) {
+        stack.addLast(new NodeAndChildren(null, roots));
       }
 
       @Override
@@ -486,7 +627,9 @@ public abstract class Traverser<N> {
             stack.addLast(withChildren(child));
           } else {
             stack.removeLast();
-            return top.node;
+            if (top.node != null) {
+              return top.node;
+            }
           }
         }
         return endOfData();
@@ -498,10 +641,10 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its children. */
       private final class NodeAndChildren {
-        final N node;
+        @NullableDecl final N node;
         final Iterator<? extends N> childIterator;
 
-        NodeAndChildren(N node, Iterable<? extends N> children) {
+        NodeAndChildren(@NullableDecl N node, Iterable<? extends N> children) {
           this.node = node;
           this.childIterator = children.iterator();
         }

--- a/android/guava/src/com/google/common/reflect/TypeResolver.java
+++ b/android/guava/src/com/google/common/reflect/TypeResolver.java
@@ -64,8 +64,32 @@ public final class TypeResolver {
     this.typeTable = typeTable;
   }
 
-  static TypeResolver accordingTo(Type type) {
-    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(type));
+  /**
+   * Returns a resolver that resolves types "covariantly".
+   * <p>For example, when resolving {@code List<T>} in the context of {@code ArrayList<?>},
+   * {@code <T>} is covariantly resolved to {@code <?>} such that return type of {@code List::get}
+   * is {@code <?>}.
+   *
+   */
+  static TypeResolver covariantly(Type contextType) {
+    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(contextType));
+  }
+
+  /**
+   * Returns a resolver that resolves types "invariantly".
+   *
+   * <p>For example, when resolving {@code List<T>} in the context of {@code ArrayList<?>},
+   * {@code <T>} cannot be invariantly resolved to {@code <?>} because otherwise the parameter type
+   * of {@code List::set} will be {@code <?>} and it'll falsely say any object can be passed into
+   * {@code ArrayList<?>::set}.
+   *
+   * <p>Instead, {@code <?>} will be resolved to a capture in the form of a type variable
+   * {@code <capture-of-? extends Object>}, effectively preventing {@code set} from accepting any
+   * type.
+   */
+  static TypeResolver invariantly(Type contextType) {
+    Type invariantContext = WildcardCapturer.INSTANCE.capture(contextType);
+    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(invariantContext));
   }
 
   /**
@@ -99,7 +123,7 @@ public final class TypeResolver {
   }
 
   private static void populateTypeMappings(
-      final Map<TypeVariableKey, Type> mappings, Type from, final Type to) {
+      final Map<TypeVariableKey, Type> mappings, final Type from, final Type to) {
     if (from.equals(to)) {
       return;
     }
@@ -202,6 +226,13 @@ public final class TypeResolver {
       // if Class<?>, no resolution needed, we are done.
       return type;
     }
+  }
+
+  Type[] resolveTypesInPlace(Type[] types) {
+    for (int i = 0; i < types.length; i++) {
+      types[i] = resolveType(types[i]);
+    }
+    return types;
   }
 
   private Type[] resolveTypes(Type[] types) {
@@ -341,8 +372,6 @@ public final class TypeResolver {
 
   private static final class TypeMappingIntrospector extends TypeVisitor {
 
-    private static final WildcardCapturer wildcardCapturer = new WildcardCapturer();
-
     private final Map<TypeVariableKey, Type> mappings = Maps.newHashMap();
 
     /**
@@ -350,8 +379,9 @@ public final class TypeResolver {
      * superclass and the super interfaces of {@code contextClass}.
      */
     static ImmutableMap<TypeVariableKey, Type> getTypeMappings(Type contextType) {
+      checkNotNull(contextType);
       TypeMappingIntrospector introspector = new TypeMappingIntrospector();
-      introspector.visit(wildcardCapturer.capture(contextType));
+      introspector.visit(contextType);
       return ImmutableMap.copyOf(introspector.mappings);
     }
 
@@ -417,9 +447,11 @@ public final class TypeResolver {
   // Instead, it should create a capture of the wildcard so that set() rejects any List<T>.
   private static class WildcardCapturer {
 
+    static final WildcardCapturer INSTANCE = new WildcardCapturer();
+
     private final AtomicInteger id;
 
-    WildcardCapturer() {
+    private WildcardCapturer() {
       this(new AtomicInteger());
     }
 

--- a/android/guava/src/com/google/common/reflect/TypeToken.java
+++ b/android/guava/src/com/google/common/reflect/TypeToken.java
@@ -422,6 +422,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
     Type resolvedTypeArgs = resolveTypeArgsForSubclass(subclass);
     @SuppressWarnings("unchecked") // guarded by the isAssignableFrom() statement above
     TypeToken<? extends T> subtype = (TypeToken<? extends T>) of(resolvedTypeArgs);
+    checkArgument(
+        subtype.isSubtypeOf(this), "%s does not appear to be a subtype of %s", subtype, this);
     return subtype;
   }
 

--- a/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
@@ -123,7 +123,7 @@ public class TypeTokenResolutionTest extends TestCase {
     @SuppressWarnings("rawtypes") // trying to test raw type
     Parameterized<?, ?, ?> parameterized =
         new Parameterized<TypeTokenResolutionTest, Bar, String>() {};
-    TypeResolver typeResolver = TypeResolver.accordingTo(parameterized.getClass());
+    TypeResolver typeResolver = TypeResolver.covariantly(parameterized.getClass());
     ParameterizedType resolved =
         (ParameterizedType) typeResolver.resolveType(parameterized.parameterizedType());
     assertEquals(TypeTokenResolutionTest.class, resolved.getOwnerType());

--- a/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
@@ -87,6 +87,15 @@ public class TypeTokenSubtypeTest extends TestCase {
             .isSubtypeOf(superclass));
   }
 
+  public void testGetSubtypeOf_impossibleWildcard() {
+    TypeToken<List<? extends Number>> numberList = new TypeToken<List<? extends Number>>() {};
+    abstract class StringList implements List<String> {}
+    try {
+      numberList.getSubtype(StringList.class);
+      fail();
+    } catch (IllegalArgumentException expected) {}
+  }
+
   private static class OwnerTypeSubtypingTests extends SubtypeTester {
     @TestSubtype
     public Mall<Outdoor>.Shop<Electronics> innerTypeIsSubtype(

--- a/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.reflect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
@@ -30,6 +32,19 @@ public class TypeTokenSubtypeTest extends TestCase {
 
   public void testWildcardSubtypes() throws Exception {
     new WildcardSubtypingTests().testAllDeclarations();
+  }
+
+  /**
+   * This test reproduces the bug in canonicalizeWildcardType() when the type variable is
+   * recursively bounded.
+   */
+  public void testRecursiveWildcardSubtypeBug() throws Exception {
+    try {
+      new RecursiveTypeBoundBugExample<>().testAllDeclarations();
+      fail();
+    } catch (Exception e) {
+      assertThat(e).hasCauseThat().isInstanceOf(AssertionError.class);
+    }
   }
 
   public void testSubtypeOfInnerClass_nonStaticAnonymousClass() {
@@ -201,7 +216,174 @@ public class TypeTokenSubtypeTest extends TestCase {
     }
   }
 
+  private static class RecursiveTypeBoundBugExample<T extends RecursiveTypeBoundBugExample<T>>
+      extends SubtypeTester {
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<RecursiveTypeBoundBugExample<?>> ifYouUseTheTypeVariableOnTheClassAndItIsRecursive(
+        List<RecursiveTypeBoundBugExample<? extends RecursiveTypeBoundBugExample<T>>> arg) {
+      return notSubtype(arg);  // isSubtype() currently incorectly considers it a subtype.
+    }
+  }
+
   private static class WildcardSubtypingTests extends SubtypeTester {
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<?> noBounds(List<?> list) {
+      return isSubtype(list);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<List<?>> listOfListOfWildcard(List<List<?>> listOfList) {
+      return isSubtype(listOfList);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<? extends List<?>> listOfWildcardListOfWildcard(
+        List<? extends List<?>> listOfList) {
+      return isSubtype(listOfList);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<? extends Enum<?>> implicitlyBoundedEnumIsSubtypeOfExplicitlyBoundedEnum(
+        Enum<?> e) {
+      return isSubtype(e);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<?> implicitlyBoundedEnum(Enum<?> e) {
+      return isSubtype(e);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Enum<?> explicitlyBoundedEnumIsSubtypeOfImplicitlyBoundedEnum(
+        Enum<? extends Enum<?>> obj) {
+      return isSubtype(obj);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> listOfEnums(List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public UseList<? extends List<Enum<? extends Enum<?>>>>
+    wildcardBoundUsesImplicitlyRecursiveBoundedWildcard(
+        UseList<? extends List<Enum<?>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public UseList<? extends List<Enum<? extends Enum<?>>>>
+    wildcardBoundHasImplicitBoundAtsInvariantPosition(
+        UseList<? extends List<Enum<?>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> listOfEnumsWithExplicitBoundIsSubtypeOfIterableOfEnumWithImplicitBound(
+        List<Enum<? extends Enum<?>>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<?>> nestedExplicitEnumBoundIsSubtypeOfImplicitEnumBound(
+        List<Enum<? extends Enum<? extends Enum<?>>>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<? extends Enum<? extends Enum<?>>>>
+    implicitEnumBoundIsSubtypeOfNestedExplicitEnumBound(List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<Enum<? extends Enum<?>>>
+    listOfEnumsWithImplicitBoundIsSubtypeOfIterableOfEnumWithExplicitBound(
+        List<Enum<?>> listOfEnums) {
+      return isSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<Enum<? extends Enum<?>>> listOfSubEnumsIsNotSubtypeOfListOfEnums(
+        List<MyEnum> listOfEnums) {
+      return notSubtype(listOfEnums);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<MyTypeBoundUsesImplicitBound<? extends Enum<?>>> typeVariableBoundOmitsItsOwnBound(
+        List<MyTypeBoundUsesImplicitBound<?>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<MyTypeBoundUsesImplicitBound<? extends MyEnum>>
+    wildcardUpperBoundIsNotSubtypeOfTypeVariableBound(
+        List<MyTypeBoundUsesImplicitBound<?>> arg) {
+      return notSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<UseList<? extends List<?>>>>>
+    wildcardBoundUsesParameterizedTypeWithImplicitBound(
+        List<List<? extends Iterable<UseList<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<Enum<? extends Enum<?>>>>>
+    wildcardBoundUsesRecursiveParameterizedTypeWithImplicitBound(
+        List<List<? extends Iterable<Enum<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public List<List<? extends Iterable<MyTypeBoundUsesImplicitBound<? extends Enum<?>>>>>
+    wildcardBoundUsesParameterizedTypeDefinedWithImplicitBound(
+        List<List<? extends Iterable<MyTypeBoundUsesImplicitBound<?>>>> arg) {
+      return isSubtype(arg);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsSubtypeOfWildcardOfExplicitlyBounded(
+        List<UseIterable<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseSerializableIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsSubtypeOfWildcardOfExplicitlyPartialBounded(
+        List<UseSerializableIterable<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseList<? extends Iterable<?>>> useListOfIterableWildcard(
+        List<UseList<?>> withImplicitBounds) {
+      return isSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<?>>
+    listOfExplicitBoundedIsSubtypeOfListOfImplicitlyBounded(
+        List<UseIterable<? extends Iterable<?>>> withExplicitBounds) {
+      return isSubtype(withExplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends Iterable<?>>>
+    wildcardOfImplicitBoundedIsNotSubtypeOfNonWildcardOfExplicitlyBounded(
+        List<? extends UseIterable<?>> withImplicitBounds) {
+      return notSubtype(withImplicitBounds);
+    }
+
+    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
+    public Iterable<UseIterable<? extends List<?>>>
+    wildcardOfImplicitBoundedIsNotSubtypeOfWildcardWithNarrowerBounds(
+        List<UseIterable<?>> withImplicitBounds) {
+      return notSubtype(withImplicitBounds);
+    }
+
     @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
     public <T> Iterable<? extends T> supertypeWithWildcardUpperBound(List<T> list) {
       return isSubtype(list);
@@ -269,18 +451,6 @@ public class TypeTokenSubtypeTest extends TestCase {
     }
 
     @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
-    public Enum<? extends Enum<?>> implicitlyBoundedEnumIsSubtypeOfExplicitlyBoundedEnum(
-        Enum<?> obj) {
-      return isSubtype(obj);
-    }
-
-    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
-    public Enum<?> explicitlyBoundedEnumIsSubtypeOfImplicitlyBoundedEnum(
-        Enum<? extends Enum<?>> obj) {
-      return isSubtype(obj);
-    }
-
-    @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
     public UseSerializableIterable<? extends Serializable>
         implicitTypeBoundIsSubtypeOfPartialExplicitTypeBound(UseSerializableIterable<?> obj) {
       return isSubtype(obj);
@@ -330,4 +500,10 @@ public class TypeTokenSubtypeTest extends TestCase {
   private interface UseIterable<T extends Iterable<?>> {}
 
   private interface UseSerializableIterable<T extends Serializable & Iterable<?>> {}
+
+  private interface UseList<T extends List<?>> {}
+
+  private enum MyEnum {}
+
+  private interface MyTypeBoundUsesImplicitBound<E extends Enum<?>> {}
 }

--- a/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
@@ -1474,9 +1474,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_methodParameter_upperBound() throws Exception {
     TypeToken<Holder<?>> type = new TypeToken<Holder<?>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     assertEquals(List.class, parameterType.getRawType());
     assertFalse(
         parameterType.getType().toString(),
@@ -1493,9 +1494,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_wildcardWithImplicitBound() throws Exception {
     TypeToken<Holder<?>> type = new TypeToken<Holder<?>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     Type[] typeArgs = ((ParameterizedType) parameterType.getType()).getActualTypeArguments();
     assertThat(typeArgs).asList().hasSize(1);
     TypeVariable<?> captured = (TypeVariable<?>) typeArgs[0];
@@ -1505,9 +1507,10 @@ public class TypeTokenTest extends TestCase {
 
   public void testWildcardCaptured_wildcardWithExplicitBound() throws Exception {
     TypeToken<Holder<? extends Number>> type = new TypeToken<Holder<? extends Number>>() {};
-    TypeToken<?> parameterType =
-        type.resolveType(
-            Holder.class.getDeclaredMethod("setList", List.class).getGenericParameterTypes()[0]);
+    ImmutableList<Parameter> parameters =
+        type.method(Holder.class.getDeclaredMethod("setList", List.class)).getParameters();
+    assertThat(parameters).hasSize(1);
+    TypeToken<?> parameterType = parameters.get(0).getType();
     Type[] typeArgs = ((ParameterizedType) parameterType.getType()).getActualTypeArguments();
     assertThat(typeArgs).asList().hasSize(1);
     TypeVariable<?> captured = (TypeVariable<?>) typeArgs[0];

--- a/guava/src/com/google/common/graph/Traverser.java
+++ b/guava/src/com/google/common/graph/Traverser.java
@@ -18,10 +18,10 @@ package com.google.common.graph;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterators.singletonIterator;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.UnmodifiableIterator;
 import java.util.ArrayDeque;
@@ -30,9 +30,33 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
- * Provides methods for traversing a graph.
+ * An object that can traverse the nodes that are reachable from a specified (set of) start node(s)
+ * using a specified {@link SuccessorsFunction}.
+ *
+ * <p>There are two entry points for creating a {@code Traverser}: {@link
+ * #forTree(SuccessorsFunction)} and {@link #forGraph(SuccessorsFunction)}. You should choose one
+ * based on your answers to the following questions:
+ *
+ * <ol>
+ *   <li>Is there only one path to any node that's reachable from any start node? (If so, the
+ *       graph to be traversed is a tree or forest even if it is a subgraph of a graph which is
+ *       neither.)
+ *   <li>Are the node objects' implementations of {@code equals()}/{@code hashCode()} <a
+ *       href="https://github.com/google/guava/wiki/GraphsExplained#non-recursiveness">recursive</a>?
+ * </ol>
+ *
+ * <p>If your answers are:
+ *
+ * <ul>
+ *   <li>(1) "no" and (2) "no", use {@link #forGraph(SuccessorsFunction)}.
+ *   <li>(1) "yes" and (2) "yes", use {@link #forTree(SuccessorsFunction)}.
+ *   <li>(1) "yes" and (2) "no", you can use either, but {@code forTree()} will be more efficient.
+ *   <li>(1) "no" and (2) "yes", <b><i>neither will work</i></b>, but if you transform your node
+ *       objects into a non-recursive form, you can use {@code forGraph()}.
+ * </ul>
  *
  * @author Jens Nyman
  * @param <N> Node parameter type
@@ -44,15 +68,20 @@ public abstract class Traverser<N> {
   /**
    * Creates a new traverser for the given general {@code graph}.
    *
-   * <p>If {@code graph} is known to be tree-shaped, consider using {@link
-   * #forTree(SuccessorsFunction)} instead.
+   * <p>Traversers created using this method are guaranteed to visit each node reachable from the
+   * start node(s) at most once.
+   *
+   * <p>If you know that no node in {@code graph} is reachable by more than one path from the start
+   * node(s), consider using {@link #forTree(SuccessorsFunction)} instead.
    *
    * <p><b>Performance notes</b>
    *
    * <ul>
    *   <li>Traversals require <i>O(n)</i> time (where <i>n</i> is the number of nodes reachable from
    *       the start node), assuming that the node objects have <i>O(1)</i> {@code equals()} and
-   *       {@code hashCode()} implementations.
+   *       {@code hashCode()} implementations. (See the <a
+   *       href="https://github.com/google/guava/wiki/GraphsExplained#elements-must-be-useable-as-map-keys">
+   *       notes on element objects</a> for more information.)
    *   <li>While traversing, the traverser will use <i>O(n)</i> space (where <i>n</i> is the number
    *       of nodes that have thus far been visited), plus <i>O(H)</i> space (where <i>H</i> is the
    *       number of nodes that have been seen but not yet visited, that is, the "horizon").
@@ -67,17 +96,24 @@ public abstract class Traverser<N> {
 
   /**
    * Creates a new traverser for a directed acyclic graph that has at most one path from the start
-   * node to any node reachable from the start node, such as a tree.
+   * node(s) to any node reachable from the start node(s), and has no paths from any start node to
+   * any other start node, such as a tree or forest.
    *
-   * <p>Providing graphs that don't conform to the above description may lead to:
+   * <p>{@code forTree()} is especially useful (versus {@code forGraph()}) in cases where the data
+   * structure being traversed is, in addition to being a tree/forest, also defined <a
+   * href="https://github.com/google/guava/wiki/GraphsExplained#non-recursiveness">recursively</a>.
+   * This is because the {@code forTree()}-based implementations don't keep track of visited nodes,
+   * and therefore don't need to call `equals()` or `hashCode()` on the node objects; this saves
+   * both time and space versus traversing the same graph using {@code forGraph()}.
+   *
+   * <p>Providing a graph to be traversed for which there is more than one path from the start
+   * node(s) to any node may lead to:
    *
    * <ul>
    *   <li>Traversal not terminating (if the graph has cycles)
-   *   <li>Nodes being visited multiple times (if multiple paths exist from the start node to any
-   *       node reachable from it)
+   *   <li>Nodes being visited multiple times (if multiple paths exist from any start node to any
+   *       node reachable from any start node)
    * </ul>
-   *
-   * In these cases, use {@link #forGraph(SuccessorsFunction)} instead.
    *
    * <p><b>Performance notes</b>
    *
@@ -88,9 +124,11 @@ public abstract class Traverser<N> {
    *       of nodes that have been seen but not yet visited, that is, the "horizon").
    * </ul>
    *
-   * <p><b>Examples</b>
+   * <p><b>Examples</b> (all edges are directed facing downwards)
    *
-   * <p>This is a valid input graph (all edges are directed facing downwards):
+   * <p>The graph below would be valid input with start nodes of {@code a, f, c}. However, if {@code
+   * b} were <i>also</i> a start node, then there would be multiple paths to reach {@code e} and
+   * {@code h}.
    *
    * <pre>{@code
    *    a     b      c
@@ -102,7 +140,10 @@ public abstract class Traverser<N> {
    *       h
    * }</pre>
    *
-   * <p>This is <b>not</b> a valid input graph (all edges are directed facing downwards):
+   * <p>.
+   *
+   * <p>The graph below would be a valid input with start nodes of {@code a, f}. However, if {@code
+   * b} were a start node, there would be multiple paths to {@code f}.
    *
    * <pre>{@code
    *    a     b
@@ -113,9 +154,6 @@ public abstract class Traverser<N> {
    *         \ /
    *          f
    * }</pre>
-   *
-   * <p>because there are two paths from {@code b} to {@code f} ({@code b->d->f} and {@code
-   * b->e->f}).
    *
    * <p><b>Note on binary trees</b>
    *
@@ -174,6 +212,17 @@ public abstract class Traverser<N> {
   public abstract Iterable<N> breadthFirst(N startNode);
 
   /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a breadth-first traversal. This is equivalent to a breadth-first
+   * traversal of a graph with an additional root node whose successors are the listed {@code
+   * startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #breadthFirst(Object)
+   */
+  public abstract Iterable<N> breadthFirst(Iterable<? extends N> startNodes);
+
+  /**
    * Returns an unmodifiable {@code Iterable} over the nodes reachable from {@code startNode}, in
    * the order of a depth-first pre-order traversal. "Pre-order" implies that nodes appear in the
    * {@code Iterable} in the order in which they are first visited.
@@ -205,6 +254,17 @@ public abstract class Traverser<N> {
    * @throws IllegalArgumentException if {@code startNode} is not an element of the graph
    */
   public abstract Iterable<N> depthFirstPreOrder(N startNode);
+
+  /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a depth-first pre-order traversal. This is equivalent to a
+   * depth-first pre-order traversal of a graph with an additional root node whose successors are
+   * the listed {@code startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #depthFirstPreOrder(Object)
+   */
+  public abstract Iterable<N> depthFirstPreOrder(Iterable<? extends N> startNodes);
 
   /**
    * Returns an unmodifiable {@code Iterable} over the nodes reachable from {@code startNode}, in
@@ -239,6 +299,17 @@ public abstract class Traverser<N> {
    */
   public abstract Iterable<N> depthFirstPostOrder(N startNode);
 
+  /**
+   * Returns an unmodifiable {@code Iterable} over the nodes reachable from any of the {@code
+   * startNodes}, in the order of a depth-first post-order traversal. This is equivalent to a
+   * depth-first post-order traversal of a graph with an additional root node whose successors are
+   * the listed {@code startNodes}.
+   *
+   * @throws IllegalArgumentException if any of {@code startNodes} is not an element of the graph
+   * @see #depthFirstPostOrder(Object)
+   */
+  public abstract Iterable<N> depthFirstPostOrder(Iterable<? extends N> startNodes);
+
   // Avoid subclasses outside of this class
   private Traverser() {}
 
@@ -252,11 +323,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> breadthFirst(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return breadthFirst(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> breadthFirst(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new BreadthFirstIterator(startNode);
+          return new BreadthFirstIterator(startNodes);
         }
       };
     }
@@ -264,11 +346,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPreOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return depthFirstPreOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPreOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstIterator(startNode, Order.PREORDER);
+          return new DepthFirstIterator(startNodes, Order.PREORDER);
         }
       };
     }
@@ -276,11 +369,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPostOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInGraph(startNode);
+      return depthFirstPostOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPostOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInGraph(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstIterator(startNode, Order.POSTORDER);
+          return new DepthFirstIterator(startNodes, Order.POSTORDER);
         }
       };
     }
@@ -296,9 +400,13 @@ public abstract class Traverser<N> {
       private final Queue<N> queue = new ArrayDeque<>();
       private final Set<N> visited = new HashSet<>();
 
-      BreadthFirstIterator(N root) {
-        queue.add(root);
-        visited.add(root);
+      BreadthFirstIterator(Iterable<? extends N> roots) {
+        for (N root : roots) {
+          // add all roots to the queue, skipping duplicates
+          if (visited.add(root)) {
+            queue.add(root);
+          }
+        }
       }
 
       @Override
@@ -323,10 +431,8 @@ public abstract class Traverser<N> {
       private final Set<N> visited = new HashSet<>();
       private final Order order;
 
-      DepthFirstIterator(N root, Order order) {
-        // our invariant is that in computeNext we call next on the iterator at the top first, so we
-        // need to start with one additional item on that iterator
-        stack.push(withSuccessors(root));
+      DepthFirstIterator(Iterable<? extends N> roots, Order order) {
+        stack.push(new NodeAndSuccessors(null, roots));
         this.order = order;
       }
 
@@ -336,22 +442,22 @@ public abstract class Traverser<N> {
           if (stack.isEmpty()) {
             return endOfData();
           }
-          NodeAndSuccessors node = stack.getFirst();
-          boolean firstVisit = visited.add(node.node);
-          boolean lastVisit = !node.successorIterator.hasNext();
+          NodeAndSuccessors nodeAndSuccessors = stack.getFirst();
+          boolean firstVisit = visited.add(nodeAndSuccessors.node);
+          boolean lastVisit = !nodeAndSuccessors.successorIterator.hasNext();
           boolean produceNode =
               (firstVisit && order == Order.PREORDER) || (lastVisit && order == Order.POSTORDER);
           if (lastVisit) {
             stack.pop();
           } else {
             // we need to push a neighbor, but only if we haven't already seen it
-            N successor = node.successorIterator.next();
+            N successor = nodeAndSuccessors.successorIterator.next();
             if (!visited.contains(successor)) {
               stack.push(withSuccessors(successor));
             }
           }
-          if (produceNode) {
-            return node.node;
+          if (produceNode && nodeAndSuccessors.node != null) {
+            return nodeAndSuccessors.node;
           }
         }
       }
@@ -362,10 +468,10 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its successors. */
       private final class NodeAndSuccessors {
-        final N node;
+        @NullableDecl final N node;
         final Iterator<? extends N> successorIterator;
 
-        NodeAndSuccessors(N node, Iterable<? extends N> successors) {
+        NodeAndSuccessors(@NullableDecl N node, Iterable<? extends N> successors) {
           this.node = node;
           this.successorIterator = successors.iterator();
         }
@@ -383,11 +489,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> breadthFirst(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return breadthFirst(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> breadthFirst(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInTree(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new BreadthFirstIterator(startNode);
+          return new BreadthFirstIterator(startNodes);
         }
       };
     }
@@ -395,11 +512,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPreOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return depthFirstPreOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPreOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N node : startNodes) {
+        checkThatNodeIsInTree(node);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstPreOrderIterator(startNode);
+          return new DepthFirstPreOrderIterator(startNodes);
         }
       };
     }
@@ -407,11 +535,22 @@ public abstract class Traverser<N> {
     @Override
     public Iterable<N> depthFirstPostOrder(final N startNode) {
       checkNotNull(startNode);
-      checkThatNodeIsInTree(startNode);
+      return depthFirstPostOrder(ImmutableSet.of(startNode));
+    }
+
+    @Override
+    public Iterable<N> depthFirstPostOrder(final Iterable<? extends N> startNodes) {
+      checkNotNull(startNodes);
+      if (Iterables.isEmpty(startNodes)) {
+        return ImmutableSet.of();
+      }
+      for (N startNode : startNodes) {
+        checkThatNodeIsInTree(startNode);
+      }
       return new Iterable<N>() {
         @Override
         public Iterator<N> iterator() {
-          return new DepthFirstPostOrderIterator(startNode);
+          return new DepthFirstPostOrderIterator(startNodes);
         }
       };
     }
@@ -426,8 +565,10 @@ public abstract class Traverser<N> {
     private final class BreadthFirstIterator extends UnmodifiableIterator<N> {
       private final Queue<N> queue = new ArrayDeque<>();
 
-      BreadthFirstIterator(N root) {
-        queue.add(root);
+      BreadthFirstIterator(Iterable<? extends N> roots) {
+        for (N root : roots) {
+          queue.add(root);
+        }
       }
 
       @Override
@@ -446,8 +587,8 @@ public abstract class Traverser<N> {
     private final class DepthFirstPreOrderIterator extends UnmodifiableIterator<N> {
       private final Deque<Iterator<? extends N>> stack = new ArrayDeque<>();
 
-      DepthFirstPreOrderIterator(N root) {
-        stack.addLast(singletonIterator(checkNotNull(root)));
+      DepthFirstPreOrderIterator(Iterable<? extends N> roots) {
+        stack.addLast(roots.iterator());
       }
 
       @Override
@@ -473,8 +614,8 @@ public abstract class Traverser<N> {
     private final class DepthFirstPostOrderIterator extends AbstractIterator<N> {
       private final ArrayDeque<NodeAndChildren> stack = new ArrayDeque<>();
 
-      DepthFirstPostOrderIterator(N root) {
-        stack.addLast(withChildren(root));
+      DepthFirstPostOrderIterator(Iterable<? extends N> roots) {
+        stack.addLast(new NodeAndChildren(null, roots));
       }
 
       @Override
@@ -486,7 +627,9 @@ public abstract class Traverser<N> {
             stack.addLast(withChildren(child));
           } else {
             stack.removeLast();
-            return top.node;
+            if (top.node != null) {
+              return top.node;
+            }
           }
         }
         return endOfData();
@@ -498,10 +641,10 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its children. */
       private final class NodeAndChildren {
-        final N node;
+        @NullableDecl final N node;
         final Iterator<? extends N> childIterator;
 
-        NodeAndChildren(N node, Iterable<? extends N> children) {
+        NodeAndChildren(@NullableDecl N node, Iterable<? extends N> children) {
           this.node = node;
           this.childIterator = children.iterator();
         }

--- a/guava/src/com/google/common/reflect/TypeResolver.java
+++ b/guava/src/com/google/common/reflect/TypeResolver.java
@@ -64,8 +64,32 @@ public final class TypeResolver {
     this.typeTable = typeTable;
   }
 
-  static TypeResolver accordingTo(Type type) {
-    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(type));
+  /**
+   * Returns a resolver that resolves types "covariantly".
+   * <p>For example, when resolving {@code List<T>} in the context of {@code ArrayList<?>},
+   * {@code <T>} is covariantly resolved to {@code <?>} such that return type of {@code List::get}
+   * is {@code <?>}.
+   *
+   */
+  static TypeResolver covariantly(Type contextType) {
+    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(contextType));
+  }
+
+  /**
+   * Returns a resolver that resolves types "invariantly".
+   *
+   * <p>For example, when resolving {@code List<T>} in the context of {@code ArrayList<?>},
+   * {@code <T>} cannot be invariantly resolved to {@code <?>} because otherwise the parameter type
+   * of {@code List::set} will be {@code <?>} and it'll falsely say any object can be passed into
+   * {@code ArrayList<?>::set}.
+   *
+   * <p>Instead, {@code <?>} will be resolved to a capture in the form of a type variable
+   * {@code <capture-of-? extends Object>}, effectively preventing {@code set} from accepting any
+   * type.
+   */
+  static TypeResolver invariantly(Type contextType) {
+    Type invariantContext = WildcardCapturer.INSTANCE.capture(contextType);
+    return new TypeResolver().where(TypeMappingIntrospector.getTypeMappings(invariantContext));
   }
 
   /**
@@ -99,7 +123,7 @@ public final class TypeResolver {
   }
 
   private static void populateTypeMappings(
-      final Map<TypeVariableKey, Type> mappings, Type from, final Type to) {
+      final Map<TypeVariableKey, Type> mappings, final Type from, final Type to) {
     if (from.equals(to)) {
       return;
     }
@@ -202,6 +226,13 @@ public final class TypeResolver {
       // if Class<?>, no resolution needed, we are done.
       return type;
     }
+  }
+
+  Type[] resolveTypesInPlace(Type[] types) {
+    for (int i = 0; i < types.length; i++) {
+      types[i] = resolveType(types[i]);
+    }
+    return types;
   }
 
   private Type[] resolveTypes(Type[] types) {
@@ -341,8 +372,6 @@ public final class TypeResolver {
 
   private static final class TypeMappingIntrospector extends TypeVisitor {
 
-    private static final WildcardCapturer wildcardCapturer = new WildcardCapturer();
-
     private final Map<TypeVariableKey, Type> mappings = Maps.newHashMap();
 
     /**
@@ -350,8 +379,9 @@ public final class TypeResolver {
      * superclass and the super interfaces of {@code contextClass}.
      */
     static ImmutableMap<TypeVariableKey, Type> getTypeMappings(Type contextType) {
+      checkNotNull(contextType);
       TypeMappingIntrospector introspector = new TypeMappingIntrospector();
-      introspector.visit(wildcardCapturer.capture(contextType));
+      introspector.visit(contextType);
       return ImmutableMap.copyOf(introspector.mappings);
     }
 
@@ -417,9 +447,11 @@ public final class TypeResolver {
   // Instead, it should create a capture of the wildcard so that set() rejects any List<T>.
   private static class WildcardCapturer {
 
+    static final WildcardCapturer INSTANCE = new WildcardCapturer();
+
     private final AtomicInteger id;
 
-    WildcardCapturer() {
+    private WildcardCapturer() {
       this(new AtomicInteger());
     }
 

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -422,6 +422,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
     Type resolvedTypeArgs = resolveTypeArgsForSubclass(subclass);
     @SuppressWarnings("unchecked") // guarded by the isAssignableFrom() statement above
     TypeToken<? extends T> subtype = (TypeToken<? extends T>) of(resolvedTypeArgs);
+    checkArgument(
+        subtype.isSubtypeOf(this), "%s does not appear to be a subtype of %s", subtype, this);
     return subtype;
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Traverser.java: add support for multiple start nodes.

Update documentation (in this file and in graphs_explained.md) relating to behavior and definitions of equals() and hashCode().

RELNOTES=`common.graph.Traverser`: add support for traversing from multiple start nodes.

9dce1c3302ec118f73921c9319e7822114325a2d

-------

<p> Fix List<Foo<?>>.isSubtypeOf(List<Foo<?>>).

This used to return false because isSubtypeOf() does a wildcard capture of the Foo<?> type parameter, turning it into Foo<C>, and then List<Foo<C>> isn't a subtype of List<Foo<?>>.

Wildcard capture is needed for resolving types at invariant or contravariant elements (fields and parameters). But for resolving in covariant context, wildcard should remain as is.

I found this when trying to add isSubtypeOf() precondition check in getSubtype(), in response to https://github.com/google/guava/issues/3048.

RELNOTES=TypeToken.isSubtypeOf() bug fix.

9918890013cd07ff00074a28afefd3af2c00c515

-------

<p> Add isSubtypeOf() "pre"-condition check before getSubtype() returns.

We have to call it before return because before type variable substitution, isSubtypeOf() can't apply.

See https://github.com/google/guava/issues/3048

RELNOTES=Validate `TypeToken.getSubtype()`.

f6d1461e2579f05f1106892c817681a61fc401ae