### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,28 +430,55 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
+  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
+
+  public void testToByteArray() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_emptyStream() throws IOException {
+    InputStream in = newTestStream(0);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(b, new byte[0]);
+  }
+
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    // this results in toByteArrayInternal being called when the stream is actually exhausted
+    byte[] b = ByteStreams.toByteArray(in, 99);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in, 98);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testExhaust() throws IOException {

--- a/android/guava-tests/test/com/google/common/io/FilesTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesTest.java
@@ -27,10 +27,8 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
@@ -91,66 +89,6 @@ public class FilesTest extends IoTestCase {
     assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), Files.toByteArray(asciiFile)));
     assertTrue(Arrays.equals(I18N.getBytes(Charsets.UTF_8), Files.toByteArray(i18nFile)));
     assertTrue(Arrays.equals(I18N.getBytes(Charsets.UTF_8), Files.asByteSource(i18nFile).read()));
-  }
-
-  public void testReadFile_withCorrectSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, asciiFile.length());
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withSmallerSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 10);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withLargerSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 500);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withSizeZero() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 0);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
   }
 
   /** A {@link File} that provides a specialized value for {@link File#length()}. */

--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -39,7 +39,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -152,7 +151,7 @@ public final class Files {
       Closer closer = Closer.create();
       try {
         FileInputStream in = closer.register(openStream());
-        return readFile(in, in.getChannel().size());
+        return ByteStreams.toByteArray(in, in.getChannel().size());
       } catch (Throwable e) {
         throw closer.rethrow(e);
       } finally {
@@ -164,29 +163,6 @@ public final class Files {
     public String toString() {
       return "Files.asByteSource(" + file + ")";
     }
-  }
-
-  /**
-   * Reads a file of the given expected size from the given input stream, if it will fit into a byte
-   * array. This method handles the case where the file size changes between when the size is read
-   * and when the contents are read from the stream.
-   */
-  static byte[] readFile(InputStream in, long expectedSize) throws IOException {
-    if (expectedSize > Integer.MAX_VALUE) {
-      throw new OutOfMemoryError(
-          "file is too large to fit in a byte array: " + expectedSize + " bytes");
-    }
-
-    // some special files may return size 0 but have content, so read
-    // the file normally in that case guessing at the buffer size to use.  Note, there is no point
-    // in calling the 'toByteArray' overload that doesn't take a size because that calls
-    // InputStream.available(), but our caller has already done that.  So instead just guess that
-    // the file is 4K bytes long and rely on the fallback in toByteArray to expand the buffer if
-    // needed.
-    // This also works around an app-engine bug where FileInputStream.available() consistently
-    // throws an IOException for certain files, even though FileInputStream.getChannel().size() does
-    // not!
-    return ByteStreams.toByteArray(in, expectedSize == 0 ? 4096 : (int) expectedSize);
   }
 
   /**

--- a/android/guava/src/com/google/common/reflect/TypeToken.java
+++ b/android/guava/src/com/google/common/reflect/TypeToken.java
@@ -1439,4 +1439,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
       }
     }
   }
+
+  // This happens to be the hash of the class as of now. So setting it makes a backward compatible
+  // change. Going forward, if any incompatible change is added, we can change the UID back to 1.
+  private static final long serialVersionUID = 3637540370352322684L;
 }

--- a/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,28 +430,55 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
+  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
+
+  public void testToByteArray() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_emptyStream() throws IOException {
+    InputStream in = newTestStream(0);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(b, new byte[0]);
+  }
+
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(100, b.length);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    // this results in toByteArrayInternal being called when the stream is actually exhausted
+    byte[] b = ByteStreams.toByteArray(in, 99);
+    assertEquals(b, PRE_FILLED_100);
+  }
+
+  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in, 98);
+    assertEquals(b, PRE_FILLED_100);
   }
 
   public void testExhaust() throws IOException {

--- a/guava-tests/test/com/google/common/io/FilesTest.java
+++ b/guava-tests/test/com/google/common/io/FilesTest.java
@@ -27,10 +27,8 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
@@ -91,66 +89,6 @@ public class FilesTest extends IoTestCase {
     assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), Files.toByteArray(asciiFile)));
     assertTrue(Arrays.equals(I18N.getBytes(Charsets.UTF_8), Files.toByteArray(i18nFile)));
     assertTrue(Arrays.equals(I18N.getBytes(Charsets.UTF_8), Files.asByteSource(i18nFile).read()));
-  }
-
-  public void testReadFile_withCorrectSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, asciiFile.length());
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withSmallerSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 10);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withLargerSize() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 500);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-  }
-
-  public void testReadFile_withSizeZero() throws IOException {
-    File asciiFile = getTestFile("ascii.txt");
-
-    Closer closer = Closer.create();
-    try {
-      InputStream in = closer.register(new FileInputStream(asciiFile));
-      byte[] bytes = Files.readFile(in, 0);
-      assertTrue(Arrays.equals(ASCII.getBytes(Charsets.US_ASCII), bytes));
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
   }
 
   /** A {@link File} that provides a specialized value for {@link File#length()}. */

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -39,7 +39,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -152,7 +151,7 @@ public final class Files {
       Closer closer = Closer.create();
       try {
         FileInputStream in = closer.register(openStream());
-        return readFile(in, in.getChannel().size());
+        return ByteStreams.toByteArray(in, in.getChannel().size());
       } catch (Throwable e) {
         throw closer.rethrow(e);
       } finally {
@@ -164,29 +163,6 @@ public final class Files {
     public String toString() {
       return "Files.asByteSource(" + file + ")";
     }
-  }
-
-  /**
-   * Reads a file of the given expected size from the given input stream, if it will fit into a byte
-   * array. This method handles the case where the file size changes between when the size is read
-   * and when the contents are read from the stream.
-   */
-  static byte[] readFile(InputStream in, long expectedSize) throws IOException {
-    if (expectedSize > Integer.MAX_VALUE) {
-      throw new OutOfMemoryError(
-          "file is too large to fit in a byte array: " + expectedSize + " bytes");
-    }
-
-    // some special files may return size 0 but have content, so read
-    // the file normally in that case guessing at the buffer size to use.  Note, there is no point
-    // in calling the 'toByteArray' overload that doesn't take a size because that calls
-    // InputStream.available(), but our caller has already done that.  So instead just guess that
-    // the file is 4K bytes long and rely on the fallback in toByteArray to expand the buffer if
-    // needed.
-    // This also works around an app-engine bug where FileInputStream.available() consistently
-    // throws an IOException for certain files, even though FileInputStream.getChannel().size() does
-    // not!
-    return ByteStreams.toByteArray(in, expectedSize == 0 ? 4096 : (int) expectedSize);
   }
 
   /**

--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -159,8 +159,7 @@ public final class MoreFiles {
     @Override
     public byte[] read() throws IOException {
       try (SeekableByteChannel channel = Files.newByteChannel(path, options)) {
-        return com.google.common.io.Files.readFile(
-            Channels.newInputStream(channel), channel.size());
+        return ByteStreams.toByteArray(Channels.newInputStream(channel), channel.size());
       }
     }
 

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -1439,4 +1439,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
       }
     }
   }
+
+  // This happens to be the hash of the class as of now. So setting it makes a backward compatible
+  // change. Going forward, if any incompatible change is added, we can change the UID back to 1.
+  private static final long serialVersionUID = 3637540370352322684L;
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make ByteSource.read() use sizeIfKnown(), if available, to help avoid extra byte array allocations/copies.

Also don't use 32 as the initial ByteArrayOutputStream size in either version of ByteStreams.toByteArray(); just seems way too small. Use the default size for buffers instead, at a minimum.

Also change ConcatenatedByteSource.sizeIfKnown() to return absent if its Iterable of sources is not a Collection; this is to prevent sizeIfKnown() trying to loop over an infinite Iterable, which previous caused an infinite loop. That is also fixed in this CL; ConcatenatedByteSource.size() and sizeIfKnown() now stop and return Long.MAX_VALUE if the result would exceed that rather than going negative and continuing. But looping over an infinite Iterable in sizeIfKnown() seems potentially slow even if it will eventually stop, and as such against the spirit of sizeIfKnown(), which should be fast.

27d33d4fd1bbbf6f5aacd8835633943da33300a3

-------

<p> Stop using ByteArrayOutputStream in ByteStreams.toByteArray methods.

They were using ByteStreams.copy to copy the source to the BAOS. This meant reading from the source into a buffer, then copying from that buffer to a different buffer in the BAOS. Additionally, the way BAOS operates is not great: whenever it needs more space, it creates a new array twice as large as the previous, copies all bytes from the previous array to the new one, and discards the previous array.

Instead, read directly from the source into a sequence of buffers. When a buffer fills up, don't discard it, but instead create a new, twice as large, buffer and start reading into it.

47530cebb974612862c1e0f12e304ae1773ca9ce

-------

<p> Set serialVersionUID in TypeToken.java

RELNOTES=Add a `serialVersionUID` to `TypeToken`

dc8ef1a7ac05b17d3be6e2918809ada5e68b31bc