### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,55 +430,28 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
-  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
-
-  public void testToByteArray() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    byte[] b = ByteStreams.toByteArray(in);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_emptyStream() throws IOException {
-    InputStream in = newTestStream(0);
-    byte[] b = ByteStreams.toByteArray(in);
-    assertEquals(b, new byte[0]);
-  }
-
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    // this results in toByteArrayInternal being called when the stream is actually exhausted
-    byte[] b = ByteStreams.toByteArray(in, 99);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    byte[] b = ByteStreams.toByteArray(in, 98);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testExhaust() throws IOException {

--- a/android/guava/src/com/google/common/io/ByteStreams.java
+++ b/android/guava/src/com/google/common/io/ByteStreams.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.common.math.IntMath;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -37,10 +36,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
-import java.util.Iterator;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -155,79 +151,6 @@ public final class ByteStreams {
     return total;
   }
 
-  /** Max array length on JVM */
-  private static final int MAX_ARRAY_LEN = Integer.MAX_VALUE - 8;
-
-  /**
-   * Returns a byte array containing the bytes from the buffers already in {@code bufs} (which have
-   * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
-   * input stream.
-   */
-  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
-      throws IOException {
-    // ByteArrayOutputStream uses a single byte array as a buffer and copies it to a new, larger
-    // buffer each time it needs more space. By contrast, this method just allocates a new buffer
-    // each time it needs more space and then copies all the buffers to a single array at the end.
-    // Like ByteArrayOutputStream, the size of each successive buffer is larger than the previous
-    // one (doubling each time, in this case), to reduce the number of allocations and potentially
-    // the number of calls to read() needed.
-    if (totalLen == MAX_ARRAY_LEN) {
-      // true iff called from toByteArray(in, MAX_ARRAY_LEN - 1)
-      return toByteArrayAtMaxLength(in, bufs);
-    }
-    byte[] buf = new byte[Math.min(BUFFER_SIZE, MAX_ARRAY_LEN - totalLen)];
-    bufs.add(buf);
-    int off = 0;
-    int r;
-    // always OK to completely fill buf; its size plus the rest of bufs is never more than
-    // MAX_ARRAY_LEN
-    while ((r = in.read(buf, off, buf.length - off)) != -1) {
-      if ((totalLen += r) == MAX_ARRAY_LEN) {
-        return toByteArrayAtMaxLength(in, bufs);
-      }
-      if ((off += r) == buf.length) {
-        // need a new buffer if we're going to read any more
-        int nextBufLen = IntMath.saturatedMultiply(buf.length, 2);
-        buf = new byte[Math.min(nextBufLen, MAX_ARRAY_LEN - totalLen)];
-        bufs.add(buf);
-        off = 0;
-      }
-    }
-
-    return combineBuffers(bufs, totalLen);
-  }
-
-  private static byte[] combineBuffers(Iterable<byte[]> bufs, int totalLen) {
-    byte[] result = new byte[totalLen];
-    Iterator<byte[]> iter = bufs.iterator();
-    int remaining = totalLen;
-    while (remaining > 0) {
-      byte[] buf = iter.next(); // since uncopied bytes remain, it's guaranteed there is a next
-      int bytesToCopy = Math.min(remaining, buf.length);
-      int resultOffset = totalLen - remaining;
-      System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
-      remaining -= bytesToCopy;
-    }
-    return result;
-  }
-
-  /**
-   * Called when toByteArray has not finished reading and cannot read anymore bytes into a single
-   * array. Typically throws OOME but may, if the stream was somehow exactly the right length,
-   * return an array of max length.
-   */
-  private static byte[] toByteArrayAtMaxLength(InputStream in, Iterable<byte[]> bufs)
-      throws IOException {
-    if (in.read() == -1) {
-      return combineBuffers(bufs, MAX_ARRAY_LEN);
-    } else {
-      throw new OutOfMemoryError("input is too large to fit in a byte array");
-    }
-  }
-
-  /** Large enough to never need to expand, given the geometric progression of buffer sizes. */
-  private static final int TO_BYTE_ARRAY_DEQUE_SIZE = 22;
-
   /**
    * Reads all bytes from an input stream into a byte array. Does not close the stream.
    *
@@ -236,8 +159,9 @@ public final class ByteStreams {
    * @throws IOException if an I/O error occurs
    */
   public static byte[] toByteArray(InputStream in) throws IOException {
-    checkNotNull(in);
-    return toByteArrayInternal(in, new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE), 0);
+    ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(BUFFER_SIZE, in.available()));
+    copy(in, out);
+    return out.toByteArray();
   }
 
   /**
@@ -247,7 +171,7 @@ public final class ByteStreams {
    */
   static byte[] toByteArray(InputStream in, long expectedSize) throws IOException {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be non-negative", expectedSize);
-    if (expectedSize > MAX_ARRAY_LEN) {
+    if (expectedSize > Integer.MAX_VALUE) {
       throw new OutOfMemoryError(expectedSize + " bytes is too large to fit in a byte array");
     }
 
@@ -272,10 +196,28 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE);
-    bufs.add(bytes);
-    bufs.add(new byte[] { (byte) b });
-    return toByteArrayInternal(in, bufs, bytes.length + 1);
+    FastByteArrayOutputStream out = new FastByteArrayOutputStream(BUFFER_SIZE);
+    copy(in, out);
+
+    byte[] result = Arrays.copyOf(bytes, bytes.length + 1 + out.size());
+    result[bytes.length] = (byte) b;
+    out.writeTo(result, bytes.length + 1);
+    return result;
+  }
+
+  /** BAOS that provides limited access to its internal byte array. */
+  private static final class FastByteArrayOutputStream extends ByteArrayOutputStream {
+    FastByteArrayOutputStream(int initialSize) {
+      super(initialSize);
+    }
+
+    /**
+     * Writes the contents of the internal buffer to the given array starting at the given offset.
+     * Assumes the array has space to hold count bytes.
+     */
+    void writeTo(byte[] b, int off) {
+      System.arraycopy(buf, 0, b, off, count);
+    }
   }
 
   /**

--- a/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,55 +430,28 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
-  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
-
-  public void testToByteArray() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    byte[] b = ByteStreams.toByteArray(in);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_emptyStream() throws IOException {
-    InputStream in = newTestStream(0);
-    byte[] b = ByteStreams.toByteArray(in);
-    assertEquals(b, new byte[0]);
-  }
-
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    InputStream in = newTestStream(100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    // this results in toByteArrayInternal being called when the stream is actually exhausted
-    byte[] b = ByteStreams.toByteArray(in, 99);
-    assertEquals(b, PRE_FILLED_100);
-  }
-
-  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
-    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
-    byte[] b = ByteStreams.toByteArray(in, 98);
-    assertEquals(b, PRE_FILLED_100);
+    assertEquals(100, b.length);
   }
 
   public void testExhaust() throws IOException {

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.common.math.IntMath;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -37,10 +36,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
-import java.util.Iterator;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -155,79 +151,6 @@ public final class ByteStreams {
     return total;
   }
 
-  /** Max array length on JVM */
-  private static final int MAX_ARRAY_LEN = Integer.MAX_VALUE - 8;
-
-  /**
-   * Returns a byte array containing the bytes from the buffers already in {@code bufs} (which have
-   * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
-   * input stream.
-   */
-  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
-      throws IOException {
-    // ByteArrayOutputStream uses a single byte array as a buffer and copies it to a new, larger
-    // buffer each time it needs more space. By contrast, this method just allocates a new buffer
-    // each time it needs more space and then copies all the buffers to a single array at the end.
-    // Like ByteArrayOutputStream, the size of each successive buffer is larger than the previous
-    // one (doubling each time, in this case), to reduce the number of allocations and potentially
-    // the number of calls to read() needed.
-    if (totalLen == MAX_ARRAY_LEN) {
-      // true iff called from toByteArray(in, MAX_ARRAY_LEN - 1)
-      return toByteArrayAtMaxLength(in, bufs);
-    }
-    byte[] buf = new byte[Math.min(BUFFER_SIZE, MAX_ARRAY_LEN - totalLen)];
-    bufs.add(buf);
-    int off = 0;
-    int r;
-    // always OK to completely fill buf; its size plus the rest of bufs is never more than
-    // MAX_ARRAY_LEN
-    while ((r = in.read(buf, off, buf.length - off)) != -1) {
-      if ((totalLen += r) == MAX_ARRAY_LEN) {
-        return toByteArrayAtMaxLength(in, bufs);
-      }
-      if ((off += r) == buf.length) {
-        // need a new buffer if we're going to read any more
-        int nextBufLen = IntMath.saturatedMultiply(buf.length, 2);
-        buf = new byte[Math.min(nextBufLen, MAX_ARRAY_LEN - totalLen)];
-        bufs.add(buf);
-        off = 0;
-      }
-    }
-
-    return combineBuffers(bufs, totalLen);
-  }
-
-  private static byte[] combineBuffers(Iterable<byte[]> bufs, int totalLen) {
-    byte[] result = new byte[totalLen];
-    Iterator<byte[]> iter = bufs.iterator();
-    int remaining = totalLen;
-    while (remaining > 0) {
-      byte[] buf = iter.next(); // since uncopied bytes remain, it's guaranteed there is a next
-      int bytesToCopy = Math.min(remaining, buf.length);
-      int resultOffset = totalLen - remaining;
-      System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
-      remaining -= bytesToCopy;
-    }
-    return result;
-  }
-
-  /**
-   * Called when toByteArray has not finished reading and cannot read anymore bytes into a single
-   * array. Typically throws OOME but may, if the stream was somehow exactly the right length,
-   * return an array of max length.
-   */
-  private static byte[] toByteArrayAtMaxLength(InputStream in, Iterable<byte[]> bufs)
-      throws IOException {
-    if (in.read() == -1) {
-      return combineBuffers(bufs, MAX_ARRAY_LEN);
-    } else {
-      throw new OutOfMemoryError("input is too large to fit in a byte array");
-    }
-  }
-
-  /** Large enough to never need to expand, given the geometric progression of buffer sizes. */
-  private static final int TO_BYTE_ARRAY_DEQUE_SIZE = 22;
-
   /**
    * Reads all bytes from an input stream into a byte array. Does not close the stream.
    *
@@ -236,8 +159,9 @@ public final class ByteStreams {
    * @throws IOException if an I/O error occurs
    */
   public static byte[] toByteArray(InputStream in) throws IOException {
-    checkNotNull(in);
-    return toByteArrayInternal(in, new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE), 0);
+    ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(BUFFER_SIZE, in.available()));
+    copy(in, out);
+    return out.toByteArray();
   }
 
   /**
@@ -247,7 +171,7 @@ public final class ByteStreams {
    */
   static byte[] toByteArray(InputStream in, long expectedSize) throws IOException {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be non-negative", expectedSize);
-    if (expectedSize > MAX_ARRAY_LEN) {
+    if (expectedSize > Integer.MAX_VALUE) {
       throw new OutOfMemoryError(expectedSize + " bytes is too large to fit in a byte array");
     }
 
@@ -272,10 +196,28 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE);
-    bufs.add(bytes);
-    bufs.add(new byte[] { (byte) b });
-    return toByteArrayInternal(in, bufs, bytes.length + 1);
+    FastByteArrayOutputStream out = new FastByteArrayOutputStream(BUFFER_SIZE);
+    copy(in, out);
+
+    byte[] result = Arrays.copyOf(bytes, bytes.length + 1 + out.size());
+    result[bytes.length] = (byte) b;
+    out.writeTo(result, bytes.length + 1);
+    return result;
+  }
+
+  /** BAOS that provides limited access to its internal byte array. */
+  private static final class FastByteArrayOutputStream extends ByteArrayOutputStream {
+    FastByteArrayOutputStream(int initialSize) {
+      super(initialSize);
+    }
+
+    /**
+     * Writes the contents of the internal buffer to the given array starting at the given offset.
+     * Assumes the array has space to hold count bytes.
+     */
+    void writeTo(byte[] b, int off) {
+      System.arraycopy(buf, 0, b, off, count);
+    }
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Automated rollback of e50ce7e7ed79fbce1901081838c8e0f9269d4128

*** Reason for rollback ***

Causing OutOfMemoryError in some tests.

*** Original change description ***

Stop using ByteArrayOutputStream in ByteStreams.toByteArray methods.

They were using ByteStreams.copy to copy the source to the BAOS. This meant reading from the source into a buffer, then copying from that buffer to a different buffer in the BAOS. Additionally, the way BAOS operates is not great: whenever it needs more space, it creates a new array twice as large as the previous, copies all bytes from the previous array to the new one, and discards the previous array.

Instead, read directly from the source into a sequence of buffers. When a buffer fills up, don't discard it, but instead create a new, twice as large, buffer and start reading into it.

***

8e341060fcef24921ecc5a079c256b184ca164f2