### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/android/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,28 +430,63 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
+  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
+
+  public void testToByteArray() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_emptyStream() throws IOException {
+    InputStream in = newTestStream(0);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(new byte[0], b);
+  }
+
+  public void testToByteArray_largeStream() throws IOException {
+    // well, large enough to require multiple buffers
+    byte[] expected = newPreFilledByteArray(10000000);
+    InputStream in = new ByteArrayInputStream(expected);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(expected, b);
+  }
+
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    // this results in toByteArrayInternal being called when the stream is actually exhausted
+    byte[] b = ByteStreams.toByteArray(in, 99);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in, 98);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testExhaust() throws IOException {

--- a/android/guava/src/com/google/common/io/ByteStreams.java
+++ b/android/guava/src/com/google/common/io/ByteStreams.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.math.IntMath;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +37,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -151,6 +154,61 @@ public final class ByteStreams {
     return total;
   }
 
+  /** Max array length on JVM. */
+  private static final int MAX_ARRAY_LEN = Integer.MAX_VALUE - 8;
+
+  /** Large enough to never need to expand, given the geometric progression of buffer sizes. */
+  private static final int TO_BYTE_ARRAY_DEQUE_SIZE = 20;
+
+  /**
+   * Returns a byte array containing the bytes from the buffers already in {@code bufs} (which have
+   * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
+   * input stream.
+   */
+  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
+      throws IOException {
+    // Starting with an 8k buffer, double the size of each sucessive buffer. Buffers are retained
+    // in a deque so that there's no copying between buffers while reading and so all of the bytes
+    // in each new allocated buffer are available for reading from the stream.
+    for (int bufSize = BUFFER_SIZE;
+         totalLen < MAX_ARRAY_LEN;
+         bufSize = IntMath.saturatedMultiply(bufSize, 2)) {
+      byte[] buf = new byte[Math.min(bufSize, MAX_ARRAY_LEN - totalLen)];
+      bufs.add(buf);
+      int off = 0;
+      while (off < buf.length) {
+        // always OK to fill buf; its size plus the rest of bufs is never more than MAX_ARRAY_LEN
+        int r = in.read(buf, off, buf.length - off);
+        if (r == -1) {
+          return combineBuffers(bufs, totalLen);
+        }
+        off += r;
+        totalLen += r;
+      }
+    }
+
+    // read MAX_ARRAY_LEN bytes without seeing end of stream
+    if (in.read() == -1) {
+      // oh, there's the end of the stream
+      return combineBuffers(bufs, MAX_ARRAY_LEN);
+    } else {
+      throw new OutOfMemoryError("input is too large to fit in a byte array");
+    }
+  }
+
+  private static byte[] combineBuffers(Deque<byte[]> bufs, int totalLen) {
+    byte[] result = new byte[totalLen];
+    int remaining = totalLen;
+    while (remaining > 0) {
+      byte[] buf = bufs.removeFirst();
+      int bytesToCopy = Math.min(remaining, buf.length);
+      int resultOffset = totalLen - remaining;
+      System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
+      remaining -= bytesToCopy;
+    }
+    return result;
+  }
+
   /**
    * Reads all bytes from an input stream into a byte array. Does not close the stream.
    *
@@ -159,9 +217,8 @@ public final class ByteStreams {
    * @throws IOException if an I/O error occurs
    */
   public static byte[] toByteArray(InputStream in) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(BUFFER_SIZE, in.available()));
-    copy(in, out);
-    return out.toByteArray();
+    checkNotNull(in);
+    return toByteArrayInternal(in, new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE), 0);
   }
 
   /**
@@ -171,7 +228,7 @@ public final class ByteStreams {
    */
   static byte[] toByteArray(InputStream in, long expectedSize) throws IOException {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be non-negative", expectedSize);
-    if (expectedSize > Integer.MAX_VALUE) {
+    if (expectedSize > MAX_ARRAY_LEN) {
       throw new OutOfMemoryError(expectedSize + " bytes is too large to fit in a byte array");
     }
 
@@ -196,28 +253,10 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    FastByteArrayOutputStream out = new FastByteArrayOutputStream(BUFFER_SIZE);
-    copy(in, out);
-
-    byte[] result = Arrays.copyOf(bytes, bytes.length + 1 + out.size());
-    result[bytes.length] = (byte) b;
-    out.writeTo(result, bytes.length + 1);
-    return result;
-  }
-
-  /** BAOS that provides limited access to its internal byte array. */
-  private static final class FastByteArrayOutputStream extends ByteArrayOutputStream {
-    FastByteArrayOutputStream(int initialSize) {
-      super(initialSize);
-    }
-
-    /**
-     * Writes the contents of the internal buffer to the given array starting at the given offset.
-     * Assumes the array has space to hold count bytes.
-     */
-    void writeTo(byte[] b, int off) {
-      System.arraycopy(buf, 0, b, off, count);
-    }
+    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
+    bufs.add(bytes);
+    bufs.add(new byte[] { (byte) b });
+    return toByteArrayInternal(in, bufs, bytes.length + 1);
   }
 
   /**

--- a/guava-tests/test/com/google/common/io/ByteStreamsTest.java
+++ b/guava-tests/test/com/google/common/io/ByteStreamsTest.java
@@ -430,28 +430,63 @@ public class ByteStreamsTest extends IoTestCase {
     assertEquals(new byte[] {0x12, 0x34, 0x56, 0x78}, baos.toByteArray());
   }
 
+  private static final byte[] PRE_FILLED_100 = newPreFilledByteArray(100);
+
+  public void testToByteArray() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_emptyStream() throws IOException {
+    InputStream in = newTestStream(0);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(new byte[0], b);
+  }
+
+  public void testToByteArray_largeStream() throws IOException {
+    // well, large enough to require multiple buffers
+    byte[] expected = newPreFilledByteArray(10000000);
+    InputStream in = new ByteArrayInputStream(expected);
+    byte[] b = ByteStreams.toByteArray(in);
+    assertEquals(expected, b);
+  }
+
   public void testToByteArray_withSize_givenCorrectSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 100);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenSmallerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 80);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenLargerSize() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 120);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testToByteArray_withSize_givenSizeZero() throws IOException {
-    InputStream in = newTestStream(100);
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
     byte[] b = ByteStreams.toByteArray(in, 0);
-    assertEquals(100, b.length);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_withSize_givenSizeOneSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    // this results in toByteArrayInternal being called when the stream is actually exhausted
+    byte[] b = ByteStreams.toByteArray(in, 99);
+    assertEquals(PRE_FILLED_100, b);
+  }
+
+  public void testToByteArray_withSize_givenSizeTwoSmallerThanActual() throws IOException {
+    InputStream in = new ByteArrayInputStream(PRE_FILLED_100);
+    byte[] b = ByteStreams.toByteArray(in, 98);
+    assertEquals(PRE_FILLED_100, b);
   }
 
   public void testExhaust() throws IOException {

--- a/guava/src/com/google/common/collect/HashBiMap.java
+++ b/guava/src/com/google/common/collect/HashBiMap.java
@@ -287,7 +287,6 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
       insert(newEntry, oldEntryForKey);
       oldEntryForKey.prevInKeyInsertionOrder = null;
       oldEntryForKey.nextInKeyInsertionOrder = null;
-      rehashIfNecessary();
       return oldEntryForKey.value;
     } else {
       insert(newEntry, null);

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.math.IntMath;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -36,7 +37,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -151,6 +154,61 @@ public final class ByteStreams {
     return total;
   }
 
+  /** Max array length on JVM. */
+  private static final int MAX_ARRAY_LEN = Integer.MAX_VALUE - 8;
+
+  /** Large enough to never need to expand, given the geometric progression of buffer sizes. */
+  private static final int TO_BYTE_ARRAY_DEQUE_SIZE = 20;
+
+  /**
+   * Returns a byte array containing the bytes from the buffers already in {@code bufs} (which have
+   * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
+   * input stream.
+   */
+  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
+      throws IOException {
+    // Starting with an 8k buffer, double the size of each sucessive buffer. Buffers are retained
+    // in a deque so that there's no copying between buffers while reading and so all of the bytes
+    // in each new allocated buffer are available for reading from the stream.
+    for (int bufSize = BUFFER_SIZE;
+         totalLen < MAX_ARRAY_LEN;
+         bufSize = IntMath.saturatedMultiply(bufSize, 2)) {
+      byte[] buf = new byte[Math.min(bufSize, MAX_ARRAY_LEN - totalLen)];
+      bufs.add(buf);
+      int off = 0;
+      while (off < buf.length) {
+        // always OK to fill buf; its size plus the rest of bufs is never more than MAX_ARRAY_LEN
+        int r = in.read(buf, off, buf.length - off);
+        if (r == -1) {
+          return combineBuffers(bufs, totalLen);
+        }
+        off += r;
+        totalLen += r;
+      }
+    }
+
+    // read MAX_ARRAY_LEN bytes without seeing end of stream
+    if (in.read() == -1) {
+      // oh, there's the end of the stream
+      return combineBuffers(bufs, MAX_ARRAY_LEN);
+    } else {
+      throw new OutOfMemoryError("input is too large to fit in a byte array");
+    }
+  }
+
+  private static byte[] combineBuffers(Deque<byte[]> bufs, int totalLen) {
+    byte[] result = new byte[totalLen];
+    int remaining = totalLen;
+    while (remaining > 0) {
+      byte[] buf = bufs.removeFirst();
+      int bytesToCopy = Math.min(remaining, buf.length);
+      int resultOffset = totalLen - remaining;
+      System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
+      remaining -= bytesToCopy;
+    }
+    return result;
+  }
+
   /**
    * Reads all bytes from an input stream into a byte array. Does not close the stream.
    *
@@ -159,9 +217,8 @@ public final class ByteStreams {
    * @throws IOException if an I/O error occurs
    */
   public static byte[] toByteArray(InputStream in) throws IOException {
-    ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(BUFFER_SIZE, in.available()));
-    copy(in, out);
-    return out.toByteArray();
+    checkNotNull(in);
+    return toByteArrayInternal(in, new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE), 0);
   }
 
   /**
@@ -171,7 +228,7 @@ public final class ByteStreams {
    */
   static byte[] toByteArray(InputStream in, long expectedSize) throws IOException {
     checkArgument(expectedSize >= 0, "expectedSize (%s) must be non-negative", expectedSize);
-    if (expectedSize > Integer.MAX_VALUE) {
+    if (expectedSize > MAX_ARRAY_LEN) {
       throw new OutOfMemoryError(expectedSize + " bytes is too large to fit in a byte array");
     }
 
@@ -196,28 +253,10 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    FastByteArrayOutputStream out = new FastByteArrayOutputStream(BUFFER_SIZE);
-    copy(in, out);
-
-    byte[] result = Arrays.copyOf(bytes, bytes.length + 1 + out.size());
-    result[bytes.length] = (byte) b;
-    out.writeTo(result, bytes.length + 1);
-    return result;
-  }
-
-  /** BAOS that provides limited access to its internal byte array. */
-  private static final class FastByteArrayOutputStream extends ByteArrayOutputStream {
-    FastByteArrayOutputStream(int initialSize) {
-      super(initialSize);
-    }
-
-    /**
-     * Writes the contents of the internal buffer to the given array starting at the given offset.
-     * Assumes the array has space to hold count bytes.
-     */
-    void writeTo(byte[] b, int off) {
-      System.arraycopy(buf, 0, b, off, count);
-    }
+    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
+    bufs.add(bytes);
+    bufs.add(new byte[] { (byte) b });
+    return toByteArrayInternal(in, bufs, bytes.length + 1);
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> HashBiMap: unnecessary call to rehashIfNecessary

Closes https://github.com/google/guava/pull/3076

532ab835043d451e6884f463e2b97c4416e55cc6

-------

<p> Stop using ByteArrayOutputStream in ByteStreams.toByteArray methods.

They were using ByteStreams.copy to copy the source to the BAOS. This meant reading from the source into a buffer, then copying from that buffer to a different buffer in the BAOS. Additionally, the way BAOS operates is not great: whenever it needs more space, it creates a new array twice as large as the previous, copies all bytes from the previous array to the new one, and discards the previous array.

Instead, read directly from the source into a sequence of buffers. When a buffer fills up, don't discard it, but instead create a new, twice as large, buffer and start reading into it.

(Roll-forward of previously rolled back e50ce7e7ed79fbce1901081838c8e0f9269d4128 now that the tests failing because they were mocking InputStream are fixed.)

e1b6d117a5b1d688d7e7348c3ce36324f6283c7b