### PR TITLE
Add missing test case for Comparators.emptiesLast()

### DIFF
--- a/guava-tests/test/com/google/common/collect/ComparatorsTest.java
+++ b/guava-tests/test/com/google/common/collect/ComparatorsTest.java
@@ -102,4 +102,16 @@ public class ComparatorsTest extends TestCase {
     // No explicit type parameter required:
     comparator = Comparators.emptiesFirst(naturalOrder());
   }
+
+  public void testEmptiesLast() {
+    Optional<String> empty = Optional.empty();
+    Optional<String> abc = Optional.of("abc");
+    Optional<String> z = Optional.of("z");
+
+    Comparator<Optional<String>> comparator = Comparators.emptiesLast(comparing(String::length));
+    Helpers.testComparator(comparator, z, abc, empty);
+
+    // No explicit type parameter required:
+    comparator = Comparators.emptiesLast(naturalOrder());
+  }
 }


### PR DESCRIPTION
There were two new utility methods added in a1a83d407f3f19891b7032e151d945363c441780 however only one of them is covered by unit tests.
 - adding missing test case for Comparators.emptiesLast()