### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Guava: Google Core Libraries for Java
 
 [![Build Status](https://travis-ci.org/google/guava.svg?branch=master)](https://travis-ci.org/google/guava)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.google.guava/guava/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.google.guava/guava)
+[![Maven Central](https://img.shields.io/maven-central/v/com.google.guava/guava.svg)](https://mvnrepository.com/artifact/com.google.guava/guava/latest)
 
 Guava is a set of core libraries that includes new collection types (such as
 multimap and multiset), immutable collections, a graph library, functional

--- a/android/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
+++ b/android/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
@@ -23,6 +23,7 @@ import static com.google.common.cache.TestingRemovalListeners.nullRemovalListene
 import static com.google.common.cache.TestingRemovalListeners.queuingRemovalListener;
 import static com.google.common.cache.TestingWeighers.constantWeigher;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -41,7 +42,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import junit.framework.TestCase;
@@ -580,7 +580,7 @@ public class CacheBuilderTest extends TestCase {
         CacheBuilder.newBuilder()
             .recordStats()
             .concurrencyLevel(2)
-            .expireAfterWrite(100, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(100, MILLISECONDS)
             .removalListener(removalListener)
             .maximumSize(5000)
             .build(countingIdentityLoader);
@@ -604,7 +604,7 @@ public class CacheBuilderTest extends TestCase {
     }
 
     threadPool.shutdown();
-    threadPool.awaitTermination(300, TimeUnit.SECONDS);
+    threadPool.awaitTermination(300, SECONDS);
 
     // Since we're not doing any more cache operations, and the cache only expires/evicts when doing
     // other operations, the cache and the removal queue won't change from this point on.

--- a/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
+++ b/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
@@ -23,6 +23,7 @@ import static com.google.common.cache.TestingRemovalListeners.nullRemovalListene
 import static com.google.common.cache.TestingRemovalListeners.queuingRemovalListener;
 import static com.google.common.cache.TestingWeighers.constantWeigher;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -41,7 +42,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import junit.framework.TestCase;
@@ -268,10 +268,41 @@ public class CacheBuilderTest extends TestCase {
     }
   }
 
+  @GwtIncompatible // java.time.Duration
+  public void testLargeDurations() {
+    java.time.Duration threeHundredYears = java.time.Duration.ofDays(365 * 300);
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    try {
+      builder.expireAfterWrite(threeHundredYears);
+      fail();
+    } catch (ArithmeticException expected) {
+    }
+    try {
+      builder.expireAfterAccess(threeHundredYears);
+      fail();
+    } catch (ArithmeticException expected) {
+    }
+    try {
+      builder.refreshAfterWrite(threeHundredYears);
+      fail();
+    } catch (ArithmeticException expected) {
+    }
+  }
+
   public void testTimeToLive_negative() {
     CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
     try {
       builder.expireAfterWrite(-1, SECONDS);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @GwtIncompatible // java.time.Duration
+  public void testTimeToLive_negative_duration() {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    try {
+      builder.expireAfterWrite(java.time.Duration.ofSeconds(-1));
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -293,10 +324,32 @@ public class CacheBuilderTest extends TestCase {
     }
   }
 
+  @GwtIncompatible // java.time.Duration
+  public void testTimeToLive_setTwice_duration() {
+    CacheBuilder<Object, Object> builder =
+        CacheBuilder.newBuilder().expireAfterWrite(java.time.Duration.ofSeconds(3600));
+    try {
+      // even to the same value is not allowed
+      builder.expireAfterWrite(java.time.Duration.ofSeconds(3600));
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
   public void testTimeToIdle_negative() {
     CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
     try {
       builder.expireAfterAccess(-1, SECONDS);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @GwtIncompatible // java.time.Duration
+  public void testTimeToIdle_negative_duration() {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    try {
+      builder.expireAfterAccess(java.time.Duration.ofSeconds(-1));
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -313,6 +366,18 @@ public class CacheBuilderTest extends TestCase {
     try {
       // even to the same value is not allowed
       builder.expireAfterAccess(3600, SECONDS);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @GwtIncompatible // java.time.Duration
+  public void testTimeToIdle_setTwice_duration() {
+    CacheBuilder<Object, Object> builder =
+        CacheBuilder.newBuilder().expireAfterAccess(java.time.Duration.ofSeconds(3600));
+    try {
+      // even to the same value is not allowed
+      builder.expireAfterAccess(java.time.Duration.ofSeconds(3600));
       fail();
     } catch (IllegalStateException expected) {
     }
@@ -336,6 +401,16 @@ public class CacheBuilderTest extends TestCase {
     }
   }
 
+  @GwtIncompatible // java.time.Duration
+  public void testRefresh_zero_duration() {
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+    try {
+      builder.refreshAfterWrite(java.time.Duration.ZERO);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @GwtIncompatible // refreshAfterWrite
   public void testRefresh_setTwice() {
     CacheBuilder<Object, Object> builder =
@@ -343,6 +418,18 @@ public class CacheBuilderTest extends TestCase {
     try {
       // even to the same value is not allowed
       builder.refreshAfterWrite(3600, SECONDS);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @GwtIncompatible // java.time.Duration
+  public void testRefresh_setTwice_duration() {
+    CacheBuilder<Object, Object> builder =
+        CacheBuilder.newBuilder().refreshAfterWrite(java.time.Duration.ofSeconds(3600));
+    try {
+      // even to the same value is not allowed
+      builder.refreshAfterWrite(java.time.Duration.ofSeconds(3600));
       fail();
     } catch (IllegalStateException expected) {
     }
@@ -580,7 +667,7 @@ public class CacheBuilderTest extends TestCase {
         CacheBuilder.newBuilder()
             .recordStats()
             .concurrencyLevel(2)
-            .expireAfterWrite(100, TimeUnit.MILLISECONDS)
+            .expireAfterWrite(100, MILLISECONDS)
             .removalListener(removalListener)
             .maximumSize(5000)
             .build(countingIdentityLoader);
@@ -604,7 +691,7 @@ public class CacheBuilderTest extends TestCase {
     }
 
     threadPool.shutdown();
-    threadPool.awaitTermination(300, TimeUnit.SECONDS);
+    threadPool.awaitTermination(300, SECONDS);
 
     // Since we're not doing any more cache operations, and the cache only expires/evicts when doing
     // other operations, the cache and the removal queue won't change from this point on.

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -30,6 +30,7 @@ import com.google.common.cache.AbstractCache.SimpleStatsCounter;
 import com.google.common.cache.AbstractCache.StatsCounter;
 import com.google.common.cache.LocalCache.Strength;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.ConcurrentModificationException;
@@ -65,7 +66,7 @@ import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
  * <pre>{@code
  * LoadingCache<Key, Graph> graphs = CacheBuilder.newBuilder()
  *     .maximumSize(10000)
- *     .expireAfterWrite(10, TimeUnit.MINUTES)
+ *     .expireAfterWrite(Duration.ofMinutes(10))
  *     .removalListener(MY_LISTENER)
  *     .build(
  *         new CacheLoader<Key, Graph>() {
@@ -635,6 +636,32 @@ public final class CacheBuilder<K, V> {
    *
    * @param duration the length of time after an entry is created that it should be automatically
    *     removed
+   * @return this {@code CacheBuilder} instance (for chaining)
+   * @throws IllegalArgumentException if {@code duration} is negative
+   * @throws IllegalStateException if the time to live or time to idle was already set
+   * @throws ArithmeticException for durations greater than +/- approximately 292 years
+   * @since NEXT
+   */
+  @J2ObjCIncompatible
+  @GwtIncompatible // java.time.Duration
+  public CacheBuilder<K, V> expireAfterWrite(java.time.Duration duration) {
+    return expireAfterWrite(duration.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Specifies that each entry should be automatically removed from the cache once a fixed duration
+   * has elapsed after the entry's creation, or the most recent replacement of its value.
+   *
+   * <p>When {@code duration} is zero, this method hands off to {@link #maximumSize(long)
+   * maximumSize}{@code (0)}, ignoring any otherwise-specified maximum size or weight. This can be
+   * useful in testing, or to disable caching temporarily without a code change.
+   *
+   * <p>Expired entries may be counted in {@link Cache#size}, but will never be visible to read or
+   * write operations. Expired entries are cleaned up as part of the routine maintenance described
+   * in the class javadoc.
+   *
+   * @param duration the length of time after an entry is created that it should be automatically
+   *     removed
    * @param unit the unit that {@code duration} is expressed in
    * @return this {@code CacheBuilder} instance (for chaining)
    * @throws IllegalArgumentException if {@code duration} is negative
@@ -652,6 +679,35 @@ public final class CacheBuilder<K, V> {
 
   long getExpireAfterWriteNanos() {
     return (expireAfterWriteNanos == UNSET_INT) ? DEFAULT_EXPIRATION_NANOS : expireAfterWriteNanos;
+  }
+
+  /**
+   * Specifies that each entry should be automatically removed from the cache once a fixed duration
+   * has elapsed after the entry's creation, the most recent replacement of its value, or its last
+   * access. Access time is reset by all cache read and write operations (including {@code
+   * Cache.asMap().get(Object)} and {@code Cache.asMap().put(K, V)}), but not by operations on the
+   * collection-views of {@link Cache#asMap}.
+   *
+   * <p>When {@code duration} is zero, this method hands off to {@link #maximumSize(long)
+   * maximumSize}{@code (0)}, ignoring any otherwise-specified maximum size or weight. This can be
+   * useful in testing, or to disable caching temporarily without a code change.
+   *
+   * <p>Expired entries may be counted in {@link Cache#size}, but will never be visible to read or
+   * write operations. Expired entries are cleaned up as part of the routine maintenance described
+   * in the class javadoc.
+   *
+   * @param duration the length of time after an entry is last accessed that it should be
+   *     automatically removed
+   * @return this {@code CacheBuilder} instance (for chaining)
+   * @throws IllegalArgumentException if {@code duration} is negative
+   * @throws IllegalStateException if the time to idle or time to live was already set
+   * @throws ArithmeticException for durations greater than +/- approximately 292 years
+   * @since NEXT
+   */
+  @J2ObjCIncompatible
+  @GwtIncompatible // java.time.Duration
+  public CacheBuilder<K, V> expireAfterAccess(java.time.Duration duration) {
+    return expireAfterAccess(duration.toNanos(), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -690,6 +746,38 @@ public final class CacheBuilder<K, V> {
     return (expireAfterAccessNanos == UNSET_INT)
         ? DEFAULT_EXPIRATION_NANOS
         : expireAfterAccessNanos;
+  }
+
+  /**
+   * Specifies that active entries are eligible for automatic refresh once a fixed duration has
+   * elapsed after the entry's creation, or the most recent replacement of its value. The semantics
+   * of refreshes are specified in {@link LoadingCache#refresh}, and are performed by calling {@link
+   * CacheLoader#reload}.
+   *
+   * <p>As the default implementation of {@link CacheLoader#reload} is synchronous, it is
+   * recommended that users of this method override {@link CacheLoader#reload} with an asynchronous
+   * implementation; otherwise refreshes will be performed during unrelated cache read and write
+   * operations.
+   *
+   * <p>Currently automatic refreshes are performed when the first stale request for an entry
+   * occurs. The request triggering refresh will make a blocking call to {@link CacheLoader#reload}
+   * and immediately return the new value if the returned future is complete, and the old value
+   * otherwise.
+   *
+   * <p><b>Note:</b> <i>all exceptions thrown during refresh will be logged and then swallowed</i>.
+   *
+   * @param duration the length of time after an entry is created that it should be considered
+   *     stale, and thus eligible for refresh
+   * @return this {@code CacheBuilder} instance (for chaining)
+   * @throws IllegalArgumentException if {@code duration} is negative
+   * @throws IllegalStateException if the refresh interval was already set
+   * @throws ArithmeticException for durations greater than +/- approximately 292 years
+   * @since NEXT
+   */
+  @J2ObjCIncompatible
+  @GwtIncompatible // java.time.Duration
+  public CacheBuilder<K, V> refreshAfterWrite(java.time.Duration duration) {
+    return refreshAfterWrite(duration.toNanos(), TimeUnit.NANOSECONDS);
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add java.time.Duration overloads to CacheBuilder:
  cacheBuilder.expireAfterAccess(Duration)
  cacheBuilder.expireAfterWrite(Duration)
  cacheBuilder.refreshAfterWrite(Duration)

Fixes https://github.com/google/guava/issues/2999

RELNOTES=Add `java.time.Duration` overloads to `CacheBuilder`.

ffa5051884eacf180b5511ab270885960eb792d0

-------

<p> remove maven-badges.herokuapp.com from readme

Fixes #3090

de5a62a3d185b41875be8318e633698e85c045bf