### PR TITLE
Moe Sync

### DIFF
--- a/guava-gwt/src-super/java/util/super/java/util/concurrent/Future.java
+++ b/guava-gwt/src-super/java/util/super/java/util/concurrent/Future.java
@@ -18,7 +18,7 @@ package java.util.concurrent;
 
 /**
  * Emulation of Future. Since GWT environment is single threaded, attempting to block on the future
- * by calling {@link #get()} or {@link #get(long, TimeUnit)} when the it is not yet done is
+ * by calling {@link #get()} or {@link #get(long, TimeUnit)} when the future is not yet done is
  * considered illegal because it would lead to a deadlock. Future implementations must throw {@link
  * IllegalStateException} to avoid a deadlock.
  *

--- a/guava-tests/test/com/google/common/io/MoreFilesFileTraverserTest.java
+++ b/guava-tests/test/com/google/common/io/MoreFilesFileTraverserTest.java
@@ -19,8 +19,11 @@ package com.google.common.io;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Iterables;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import junit.framework.TestCase;
 
@@ -36,12 +39,13 @@ public class MoreFilesFileTraverserTest extends TestCase {
 
   @Override
   public void setUp() throws IOException {
-    rootDir = Files.createTempDir().toPath();
+    rootDir = Jimfs.newFileSystem(Configuration.unix()).getPath("/tmp");
+    Files.createDirectory(rootDir);
   }
 
   @Override
   public void tearDown() throws IOException {
-    MoreFiles.deleteRecursively(rootDir);
+    rootDir.getFileSystem().close();
   }
 
   public void testFileTraverser_emptyDirectory() throws Exception {
@@ -104,16 +108,16 @@ public class MoreFilesFileTraverserTest extends TestCase {
   }
 
   @CanIgnoreReturnValue
-  private Path newDir(String name) {
+  private Path newDir(String name) throws IOException {
     Path dir = rootDir.resolve(name);
-    dir.toFile().mkdir();
+    Files.createDirectory(dir);
     return dir;
   }
 
   @CanIgnoreReturnValue
   private Path newFile(String name) throws IOException {
     Path file = rootDir.resolve(name);
-    file.toFile().createNewFile();
+    MoreFiles.touch(file);
     return file;
   }
 }

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -660,6 +660,9 @@ public final class CacheBuilder<K, V> {
    * write operations. Expired entries are cleaned up as part of the routine maintenance described
    * in the class javadoc.
    *
+   * <p>If you can represent the duration as a {@link java.time.Duration} (which should be preferred
+   * when feasible), use {@link #expireAfterWrite(Duration)} instead.
+   *
    * @param duration the length of time after an entry is created that it should be automatically
    *     removed
    * @param unit the unit that {@code duration} is expressed in
@@ -724,6 +727,9 @@ public final class CacheBuilder<K, V> {
    * <p>Expired entries may be counted in {@link Cache#size}, but will never be visible to read or
    * write operations. Expired entries are cleaned up as part of the routine maintenance described
    * in the class javadoc.
+   *
+   * <p>If you can represent the duration as a {@link java.time.Duration} (which should be preferred
+   * when feasible), use {@link #expireAfterAccess(Duration)} instead.
    *
    * @param duration the length of time after an entry is last accessed that it should be
    *     automatically removed
@@ -797,6 +803,9 @@ public final class CacheBuilder<K, V> {
    * otherwise.
    *
    * <p><b>Note:</b> <i>all exceptions thrown during refresh will be logged and then swallowed</i>.
+   *
+   * <p>If you can represent the duration as a {@link java.time.Duration} (which should be preferred
+   * when feasible), use {@link #refreshAfterWrite(Duration)} instead.
    *
    * @param duration the length of time after an entry is created that it should be considered
    *     stale, and thus eligible for refresh


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Slightly discourage the use of the <long, TimeUnit> overloads on CacheBuilder.

babed10eeb8bc5571bdebecec94d48eb3b4748e8

-------

<p> Fix tests that failed if we couldn't recursively delete securely by using Jimfs and just getting rid of the whole file system each time.

Fixes https://github.com/google/guava/issues/3100

1974d26799780c448ef72c09eee2201dc7812fbb

-------

<p> Fix typo in Future javadoc.

7416b725e7a657cd215783651984217aad0840cc