### PR TITLE
Fix toString of NonSerializableMemoizingSupplier

### DIFF
--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -175,7 +175,7 @@ public final class Suppliers {
 
     @Override
     public String toString() {
-      return "Suppliers.memoize(" + delegate + ")";
+      return "Suppliers.memoize(" + (delegate == null ? "() -> " + value : delegate) + ")";
     }
   }
 


### PR DESCRIPTION
Delegate is set to null once the value has been computed, but is still referenced by the toString method. When it's null, use the value instead.