### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-testlib/src/com/google/common/testing/GcFinalization.java
+++ b/android/guava-testlib/src/com/google/common/testing/GcFinalization.java
@@ -66,7 +66,7 @@ import java.util.concurrent.TimeoutException;
  * <p>Here's an example that uses a user-defined finalization predicate:
  *
  * <pre>{@code
- * final WeakHashMap<Object, Object> map = new WeakHashMap<Object, Object>();
+ * final WeakHashMap<Object, Object> map = new WeakHashMap<>();
  * map.put(new Object(), Boolean.TRUE);
  * GcFinalization.awaitDone(new FinalizationPredicate() {
  *   public boolean isDone() {
@@ -82,7 +82,7 @@ import java.util.concurrent.TimeoutException;
  * // Helper function keeps victim stack-unreachable.
  * private WeakReference<Foo> fooWeakRef() {
  *   Foo x = ....;
- *   WeakReference<Foo> weakRef = new WeakReference<Foo>(x);
+ *   WeakReference<Foo> weakRef = new WeakReference<>(x);
  *   // ... use x ...
  *   x = null;  // Hint to the JIT that x is stack-unreachable
  *   return weakRef;

--- a/android/guava-tests/test/com/google/common/base/SuppliersTest.java
+++ b/android/guava-tests/test/com/google/common/base/SuppliersTest.java
@@ -17,6 +17,7 @@
 package com.google.common.base;
 
 import static com.google.common.testing.SerializableTester.reserialize;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -48,6 +49,11 @@ public class SuppliersTest extends TestCase {
     public Integer get() {
       calls++;
       return calls * 10;
+    }
+
+    @Override
+    public String toString() {
+      return "CountingSupplier";
     }
   }
 
@@ -123,9 +129,13 @@ public class SuppliersTest extends TestCase {
   public void testMemoizeNonSerializable() throws Exception {
     CountingSupplier countingSupplier = new CountingSupplier();
     Supplier<Integer> memoizedSupplier = Suppliers.memoize(countingSupplier);
+    assertThat(memoizedSupplier.toString()).isEqualTo("Suppliers.memoize(CountingSupplier)");
     checkMemoize(countingSupplier, memoizedSupplier);
     // Calls to the original memoized supplier shouldn't affect its copy.
     memoizedSupplier.get();
+    assertThat(memoizedSupplier.toString())
+        .isEqualTo("Suppliers.memoize(<supplier that returned 10>)");
+
     // Should get an exception when we try to serialize.
     try {
       reserialize(memoizedSupplier);
@@ -138,11 +148,13 @@ public class SuppliersTest extends TestCase {
   @GwtIncompatible // SerializableTester
   public void testMemoizeSerializable() throws Exception {
     SerializableCountingSupplier countingSupplier = new SerializableCountingSupplier();
-
     Supplier<Integer> memoizedSupplier = Suppliers.memoize(countingSupplier);
+    assertThat(memoizedSupplier.toString()).isEqualTo("Suppliers.memoize(CountingSupplier)");
     checkMemoize(countingSupplier, memoizedSupplier);
     // Calls to the original memoized supplier shouldn't affect its copy.
     memoizedSupplier.get();
+    assertThat(memoizedSupplier.toString())
+        .isEqualTo("Suppliers.memoize(<supplier that returned 10>)");
 
     Supplier<Integer> copy = reserialize(memoizedSupplier);
     memoizedSupplier.get();

--- a/android/guava/src/com/google/common/base/Suppliers.java
+++ b/android/guava/src/com/google/common/base/Suppliers.java
@@ -137,7 +137,9 @@ public final class Suppliers {
 
     @Override
     public String toString() {
-      return "Suppliers.memoize(" + delegate + ")";
+      return "Suppliers.memoize("
+          + (initialized ? "<supplier that returned " + value + ">" : delegate)
+          + ")";
     }
 
     private static final long serialVersionUID = 0;
@@ -175,7 +177,10 @@ public final class Suppliers {
 
     @Override
     public String toString() {
-      return "Suppliers.memoize(" + delegate + ")";
+      Supplier<T> delegate = this.delegate;
+      return "Suppliers.memoize("
+          + (delegate == null ? "<supplier that returned " + value + ">" : delegate)
+          + ")";
     }
   }
 

--- a/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -233,16 +233,17 @@ final class LittleEndianByteArray {
     try {
       /*
         UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause crashes
-        on 32-bit Android (ARMv7 with ART). Ideally, we shouldn't use Unsafe.getLong() at all, but
-        the performance benefit on x86_64 is too great to ignore, so as a compromise, we enable the
-        optimization only on platforms that we specifically know to work.
+        on Android when running in 32-bit mode. For maximum safety, we shouldn't use
+        Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so as
+        a compromise, we enable the optimization only on platforms that we specifically know to
+        work.
 
         In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(), which
         will have an efficient native implementation in JDK 9.
 
       */
       final String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch) || "aarch64".equals(arch)) {
+      if ("amd64".equals(arch)) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN

--- a/android/guava/src/com/google/common/net/InternetDomainName.java
+++ b/android/guava/src/com/google/common/net/InternetDomainName.java
@@ -86,8 +86,6 @@ public final class InternetDomainName {
    */
   private static final int NO_SUFFIX_FOUND = -1;
 
-  private static final String DOT_REGEX = "\\.";
-
   /**
    * Maximum parts (labels) in a domain name. This value arises from the 255-octet limit described
    * in <a href="http://www.ietf.org/rfc/rfc2181.txt">RFC 2181</a> part 11 with the fact that the
@@ -592,10 +590,10 @@ public final class InternetDomainName {
    */
   private static boolean matchesWildcardSuffixType(
       Optional<PublicSuffixType> desiredType, String domain) {
-    final String[] pieces = domain.split(DOT_REGEX, 2);
-    return pieces.length == 2
+    List<String> pieces = DOT_SPLITTER.limit(2).splitToList(domain);
+    return pieces.size() == 2
         && matchesType(
-            desiredType, Optional.fromNullable(PublicSuffixPatterns.UNDER.get(pieces[1])));
+            desiredType, Optional.fromNullable(PublicSuffixPatterns.UNDER.get(pieces.get(1))));
   }
 
   /**

--- a/guava-testlib/src/com/google/common/testing/GcFinalization.java
+++ b/guava-testlib/src/com/google/common/testing/GcFinalization.java
@@ -66,7 +66,7 @@ import java.util.concurrent.TimeoutException;
  * <p>Here's an example that uses a user-defined finalization predicate:
  *
  * <pre>{@code
- * final WeakHashMap<Object, Object> map = new WeakHashMap<Object, Object>();
+ * final WeakHashMap<Object, Object> map = new WeakHashMap<>();
  * map.put(new Object(), Boolean.TRUE);
  * GcFinalization.awaitDone(new FinalizationPredicate() {
  *   public boolean isDone() {
@@ -82,7 +82,7 @@ import java.util.concurrent.TimeoutException;
  * // Helper function keeps victim stack-unreachable.
  * private WeakReference<Foo> fooWeakRef() {
  *   Foo x = ....;
- *   WeakReference<Foo> weakRef = new WeakReference<Foo>(x);
+ *   WeakReference<Foo> weakRef = new WeakReference<>(x);
  *   // ... use x ...
  *   x = null;  // Hint to the JIT that x is stack-unreachable
  *   return weakRef;

--- a/guava-tests/test/com/google/common/base/SuppliersTest.java
+++ b/guava-tests/test/com/google/common/base/SuppliersTest.java
@@ -17,6 +17,7 @@
 package com.google.common.base;
 
 import static com.google.common.testing.SerializableTester.reserialize;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -48,6 +49,11 @@ public class SuppliersTest extends TestCase {
     public Integer get() {
       calls++;
       return calls * 10;
+    }
+
+    @Override
+    public String toString() {
+      return "CountingSupplier";
     }
   }
 
@@ -123,9 +129,13 @@ public class SuppliersTest extends TestCase {
   public void testMemoizeNonSerializable() throws Exception {
     CountingSupplier countingSupplier = new CountingSupplier();
     Supplier<Integer> memoizedSupplier = Suppliers.memoize(countingSupplier);
+    assertThat(memoizedSupplier.toString()).isEqualTo("Suppliers.memoize(CountingSupplier)");
     checkMemoize(countingSupplier, memoizedSupplier);
     // Calls to the original memoized supplier shouldn't affect its copy.
     memoizedSupplier.get();
+    assertThat(memoizedSupplier.toString())
+        .isEqualTo("Suppliers.memoize(<supplier that returned 10>)");
+
     // Should get an exception when we try to serialize.
     try {
       reserialize(memoizedSupplier);
@@ -138,11 +148,13 @@ public class SuppliersTest extends TestCase {
   @GwtIncompatible // SerializableTester
   public void testMemoizeSerializable() throws Exception {
     SerializableCountingSupplier countingSupplier = new SerializableCountingSupplier();
-
     Supplier<Integer> memoizedSupplier = Suppliers.memoize(countingSupplier);
+    assertThat(memoizedSupplier.toString()).isEqualTo("Suppliers.memoize(CountingSupplier)");
     checkMemoize(countingSupplier, memoizedSupplier);
     // Calls to the original memoized supplier shouldn't affect its copy.
     memoizedSupplier.get();
+    assertThat(memoizedSupplier.toString())
+        .isEqualTo("Suppliers.memoize(<supplier that returned 10>)");
 
     Supplier<Integer> copy = reserialize(memoizedSupplier);
     memoizedSupplier.get();

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -61,7 +61,6 @@ import com.google.common.testing.TestLogHandler;
 import java.io.Serializable;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -695,22 +694,6 @@ public class LocalCacheTest extends TestCase {
     assertFalse(map.values() instanceof Set);
     assertTrue(map.values().removeAll(ImmutableSet.of("bar")));
     assertEquals(1, map.size());
-  }
-
-  public void testComputeIfAbsent_RemovalListener() {
-    List<RemovalNotification<Object, Object>> notifications = new ArrayList<>();
-    RemovalListener<Object, Object> removalListener =
-        new RemovalListener<Object, Object>() {
-          @Override
-          public void onRemoval(RemovalNotification<Object, Object> notification) {
-            notifications.add(notification);
-          }
-        };
-    Cache<Object, Object> cache =
-        CacheBuilder.newBuilder().removalListener(removalListener).build();
-    cache.put("a", "b");
-    cache.asMap().computeIfAbsent("a", k -> "c");
-    assertTrue(notifications.toString(), notifications.isEmpty());
   }
 
   public void testCopyEntry_computing() {

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -137,7 +137,9 @@ public final class Suppliers {
 
     @Override
     public String toString() {
-      return "Suppliers.memoize(" + delegate + ")";
+      return "Suppliers.memoize("
+          + (initialized ? "<supplier that returned " + value + ">" : delegate)
+          + ")";
     }
 
     private static final long serialVersionUID = 0;
@@ -175,7 +177,10 @@ public final class Suppliers {
 
     @Override
     public String toString() {
-      return "Suppliers.memoize(" + delegate + ")";
+      Supplier<T> delegate = this.delegate;
+      return "Suppliers.memoize("
+          + (delegate == null ? "<supplier that returned " + value + ">" : delegate)
+          + ")";
     }
   }
 

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -2243,9 +2243,6 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
 
         newValue = loadingValueReference.compute(key, function);
         if (newValue != null) {
-          if (valueReference != null && newValue == valueReference.get()) {
-            return newValue;
-          }
           try {
             return getAndRecordStats(
                 key, hash, loadingValueReference, Futures.immediateFuture(newValue));

--- a/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -233,16 +233,17 @@ final class LittleEndianByteArray {
     try {
       /*
         UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause crashes
-        on 32-bit Android (ARMv7 with ART). Ideally, we shouldn't use Unsafe.getLong() at all, but
-        the performance benefit on x86_64 is too great to ignore, so as a compromise, we enable the
-        optimization only on platforms that we specifically know to work.
+        on Android when running in 32-bit mode. For maximum safety, we shouldn't use
+        Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so as
+        a compromise, we enable the optimization only on platforms that we specifically know to
+        work.
 
         In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(), which
         will have an efficient native implementation in JDK 9.
 
       */
       final String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch) || "aarch64".equals(arch)) {
+      if ("amd64".equals(arch)) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN

--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -86,8 +86,6 @@ public final class InternetDomainName {
    */
   private static final int NO_SUFFIX_FOUND = -1;
 
-  private static final String DOT_REGEX = "\\.";
-
   /**
    * Maximum parts (labels) in a domain name. This value arises from the 255-octet limit described
    * in <a href="http://www.ietf.org/rfc/rfc2181.txt">RFC 2181</a> part 11 with the fact that the
@@ -592,10 +590,10 @@ public final class InternetDomainName {
    */
   private static boolean matchesWildcardSuffixType(
       Optional<PublicSuffixType> desiredType, String domain) {
-    final String[] pieces = domain.split(DOT_REGEX, 2);
-    return pieces.length == 2
+    List<String> pieces = DOT_SPLITTER.limit(2).splitToList(domain);
+    return pieces.size() == 2
         && matchesType(
-            desiredType, Optional.fromNullable(PublicSuffixPatterns.UNDER.get(pieces[1])));
+            desiredType, Optional.fromNullable(PublicSuffixPatterns.UNDER.get(pieces.get(1))));
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix toString of NonSerializableMemoizingSupplier

Fixes #3107

9185822ee16cdd641657c0f8e7ead755c9e9a564

-------

<p> Use Splitter instead of String.split, in InternetDomainName.

e56f1aa3d21b04eed8f5481d4103c05af5c51ec7

-------

<p> Use Splitter for IPv6, too. This eliminates usage of java.util.regex from this file (which is used via String.split, otherwise).

65a2a7de4ef4eea913f769a5cbbce6e35e1fccce

-------

<p> Use Diamond.

27eb336c2a2d9068878edbf49edcca493cd69cd8

-------

<p> Automated rollback of a12ef6b46b26fe178021c099e3db6a8a99f5174e.

It looks like the original change can cause an infinite loop in LocalCache.LoadingValueReference.get().

c2266a6ff8c6f298673688d6779b8b7368fe9147

-------

<p> Don't enable use of Unsafe.getLong() on aarch64 devices.

Android devices may report to run aarch64 while running in 32-bit mode, and then
crash when loading 64-bit values at unaligned addresses.

263bbcf6cf0cfae6768ddf9e9f3d749da555e422