### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ correctly in other environments. For the Android flavor, our unit tests run on
 API level 15 (Ice Cream Sandwich).
 
 [current release]: https://github.com/google/guava/releases/tag/v24.1
-[guava-snapshot-api-docs]: http://google.github.io/guava/releases/snapshot-jre/api/docs/
-[guava-snapshot-api-diffs]: http://google.github.io/guava/releases/snapshot-jre/api/diffs/
+[guava-snapshot-api-docs]: https://google.github.io/guava/releases/snapshot-jre/api/docs/
+[guava-snapshot-api-diffs]: https://google.github.io/guava/releases/snapshot-jre/api/diffs/
 [Guava Explained]: https://github.com/google/guava/wiki/Home
 [Guava Beta Checker]: https://github.com/google/guava-beta-checker
 

--- a/android/guava-tests/test/com/google/common/base/SuppliersTest.java
+++ b/android/guava-tests/test/com/google/common/base/SuppliersTest.java
@@ -112,7 +112,8 @@ public class SuppliersTest extends TestCase {
     memoizeExceptionThrownTest(new SerializableThrowingSupplier());
   }
 
-  private void memoizeExceptionThrownTest(ThrowingSupplier memoizedSupplier) {
+  private void memoizeExceptionThrownTest(ThrowingSupplier throwingSupplier) {
+    Supplier<Integer> memoizedSupplier = Suppliers.memoize(throwingSupplier);
     // call get() twice to make sure that memoization doesn't interfere
     // with throwing the exception
     for (int i = 0; i < 2; i++) {

--- a/guava-tests/test/com/google/common/base/SuppliersTest.java
+++ b/guava-tests/test/com/google/common/base/SuppliersTest.java
@@ -112,7 +112,8 @@ public class SuppliersTest extends TestCase {
     memoizeExceptionThrownTest(new SerializableThrowingSupplier());
   }
 
-  private void memoizeExceptionThrownTest(ThrowingSupplier memoizedSupplier) {
+  private void memoizeExceptionThrownTest(ThrowingSupplier throwingSupplier) {
+    Supplier<Integer> memoizedSupplier = Suppliers.memoize(throwingSupplier);
     // call get() twice to make sure that memoization doesn't interfere
     // with throwing the exception
     for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make SuppliersTest.testMemoizeExceptionThrown() actually memoize the suppliers before testing them.

Fixes https://github.com/google/guava/issues/3122

7622bb803ff6c0ae1e3d1d1b2311c7ad1be9c6f3

-------

<p> Use https for API docs

938839f401cadd29fbd94b1e9afc82b663c5a641