### PR TITLE
Use @SafeVarargs annotation for Sets#cartesianProduct

### DIFF
--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -1380,6 +1380,7 @@ public final class Sets {
    *     provided set is null
    * @since 2.0
    */
+  @SafeVarargs
   public static <B> Set<List<B>> cartesianProduct(Set<? extends B>... sets) {
     return cartesianProduct(Arrays.asList(sets));
   }


### PR DESCRIPTION
We already had `@SafeVarargs` annotation for `Lists.cartesianProduct(List<? extends B>... lists`. but `Sets.cartesianProduct(Set<? extends B>... sets) ` was missing this annotation so i have added that annotation in order to fix issue.
Fixes #2724 