### PR TITLE
collect: add Sets#newSingleElementSet

### DIFF
--- a/guava-tests/test/com/google/common/collect/SetsTest.java
+++ b/guava-tests/test/com/google/common/collect/SetsTest.java
@@ -1327,4 +1327,9 @@ public class SetsTest extends TestCase {
     assertEquals(ImmutableSortedSet.of(8, 10), Sets.subSet(set, Range.atMost(8)));
     assertEquals(ImmutableSortedSet.of(2, 4, 6, 8, 10), Sets.subSet(set, Range.<Integer>all()));
   }
+
+ public void testNewSingleElementSet() {
+   Set<Integer> set = Sets.newSingleElementSet(1);
+   verifySetContents(set, Arrays.asList(1));
+ }
 }

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -494,6 +494,13 @@ public final class Sets {
   }
 
   /**
+   * Creates an <i>immutable</i> {@code Set} containg only a single element.
+   */
+  public static <E> Set<E> newSingleElementSet(E element) {
+    return new SingleElementSet<>(checkNotNull(element));
+  }
+
+  /**
    * Creates an {@code EnumSet} consisting of all enum values that are not in the specified
    * collection. If the collection is an {@link EnumSet}, this method has the same behavior as
    * {@link EnumSet#complementOf}. Otherwise, the specified collection must contain at least one
@@ -2124,5 +2131,40 @@ public final class Sets {
       return set.headSet(range.upperEndpoint(), range.upperBoundType() == BoundType.CLOSED);
     }
     return checkNotNull(set);
+  }
+
+  private static final class SingleElementSet<E> extends AbstractSet<E> {
+
+    private final E element;
+
+    public SingleElementSet(E element) {
+      this.element = element;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return new Iterator<E>() {
+        private boolean eod;
+
+        @Override
+        public boolean hasNext() {
+          return !eod;
+        }
+
+        @Override
+        public E next() {
+          if (hasNext()) {
+            eod = true;
+            return element;
+          }
+          throw new NoSuchElementException();
+        }
+      };
+    }
+
+    @Override
+    public int size() {
+      return 1;
+    }
   }
 }


### PR DESCRIPTION
In many situations APIs force to use Set, where only a single element is
required. Such use cases can be covered by Sets#newHashSet(element).
However, if we know in advance that this is an immutable Set with a
single element a more efficient implementation can be used.

Add a new Sets#newSingleElementSet method to create a lightweight Set
to store a single element.