### PR TITLE
Put type annotations on types, not declarations

### DIFF
--- a/guava/src/com/google/common/base/Absent.java
+++ b/guava/src/com/google/common/base/Absent.java
@@ -61,8 +61,7 @@ final class Absent<T> extends Optional<T> {
   }
 
   @Override
-  @Nullable
-  public T orNull() {
+  public @Nullable T orNull() {
     return null;
   }
 

--- a/guava/src/com/google/common/base/AbstractIterator.java
+++ b/guava/src/com/google/common/base/AbstractIterator.java
@@ -39,13 +39,12 @@ abstract class AbstractIterator<T> implements Iterator<T> {
     FAILED,
   }
 
-  @Nullable private T next;
+  private @Nullable T next;
 
   protected abstract T computeNext();
 
-  @Nullable
   @CanIgnoreReturnValue
-  protected final T endOfData() {
+  protected final @Nullable T endOfData() {
     state = State.DONE;
     return null;
   }

--- a/guava/src/com/google/common/base/Converter.java
+++ b/guava/src/com/google/common/base/Converter.java
@@ -164,9 +164,8 @@ public abstract class Converter<A, B> implements Function<A, B> {
    *
    * @return the converted value; is null <i>if and only if</i> {@code a} is null
    */
-  @Nullable
   @CanIgnoreReturnValue
-  public final B convert(@Nullable A a) {
+  public final @Nullable B convert(@Nullable A a) {
     return correctedDoForward(a);
   }
 
@@ -386,9 +385,8 @@ public abstract class Converter<A, B> implements Function<A, B> {
    */
   @Deprecated
   @Override
-  @Nullable
   @CanIgnoreReturnValue
-  public final B apply(@Nullable A a) {
+  public final @Nullable B apply(@Nullable A a) {
     return convert(a);
   }
 

--- a/guava/src/com/google/common/base/Defaults.java
+++ b/guava/src/com/google/common/base/Defaults.java
@@ -37,9 +37,8 @@ public final class Defaults {
    * false} for {@code boolean} and {@code '\0'} for {@code char}. For non-primitive types and
    * {@code void}, {@code null} is returned.
    */
-  @Nullable
   @SuppressWarnings("unchecked")
-  public static <T> T defaultValue(Class<T> type) {
+  public static <T> @Nullable T defaultValue(Class<T> type) {
     checkNotNull(type);
     if (type == boolean.class) {
       return (T) Boolean.FALSE;

--- a/guava/src/com/google/common/base/Equivalence.java
+++ b/guava/src/com/google/common/base/Equivalence.java
@@ -184,7 +184,7 @@ public abstract class Equivalence<T> implements BiPredicate<T, T> {
    */
   public static final class Wrapper<T> implements Serializable {
     private final Equivalence<? super T> equivalence;
-    @Nullable private final T reference;
+    private final @Nullable T reference;
 
     private Wrapper(Equivalence<? super T> equivalence, @Nullable T reference) {
       this.equivalence = checkNotNull(equivalence);
@@ -192,8 +192,7 @@ public abstract class Equivalence<T> implements BiPredicate<T, T> {
     }
 
     /** Returns the (possibly null) reference wrapped by this instance. */
-    @Nullable
-    public T get() {
+    public @Nullable T get() {
       return reference;
     }
 
@@ -272,7 +271,7 @@ public abstract class Equivalence<T> implements BiPredicate<T, T> {
   private static final class EquivalentToPredicate<T> implements Predicate<T>, Serializable {
 
     private final Equivalence<T> equivalence;
-    @Nullable private final T target;
+    private final @Nullable T target;
 
     EquivalentToPredicate(Equivalence<T> equivalence, @Nullable T target) {
       this.equivalence = checkNotNull(equivalence);

--- a/guava/src/com/google/common/base/FinalizableReferenceQueue.java
+++ b/guava/src/com/google/common/base/FinalizableReferenceQueue.java
@@ -241,9 +241,8 @@ public class FinalizableReferenceQueue implements Closeable {
     // finding Finalizer on the system class path even if it is there.
     @VisibleForTesting static boolean disabled;
 
-    @Nullable
     @Override
-    public Class<?> loadFinalizer() {
+    public @Nullable Class<?> loadFinalizer() {
       if (disabled) {
         return null;
       }
@@ -279,9 +278,8 @@ public class FinalizableReferenceQueue implements Closeable {
             + "loader. To support reclaiming this class loader, either resolve the underlying "
             + "issue, or move Guava to your system class path.";
 
-    @Nullable
     @Override
-    public Class<?> loadFinalizer() {
+    public @Nullable Class<?> loadFinalizer() {
       try {
         /*
          * We use URLClassLoader because it's the only concrete class loader implementation in the

--- a/guava/src/com/google/common/base/Functions.java
+++ b/guava/src/com/google/common/base/Functions.java
@@ -88,8 +88,7 @@ public final class Functions {
     INSTANCE;
 
     @Override
-    @Nullable
-    public Object apply(@Nullable Object o) {
+    public @Nullable Object apply(@Nullable Object o) {
       return o;
     }
 
@@ -171,7 +170,7 @@ public final class Functions {
 
   private static class ForMapWithDefault<K, V> implements Function<K, V>, Serializable {
     final Map<K, ? extends V> map;
-    @Nullable final V defaultValue;
+    final @Nullable V defaultValue;
 
     ForMapWithDefault(Map<K, ? extends V> map, @Nullable V defaultValue) {
       this.map = checkNotNull(map);
@@ -320,7 +319,7 @@ public final class Functions {
   }
 
   private static class ConstantFunction<E> implements Function<Object, E>, Serializable {
-    @Nullable private final E value;
+    private final @Nullable E value;
 
     public ConstantFunction(@Nullable E value) {
       this.value = value;

--- a/guava/src/com/google/common/base/Optional.java
+++ b/guava/src/com/google/common/base/Optional.java
@@ -120,8 +120,7 @@ public abstract class Optional<T> implements Serializable {
    *
    * @since 21.0
    */
-  @Nullable
-  public static <T> Optional<T> fromJavaUtil(java.util.@Nullable Optional<T> javaUtilOptional) {
+  public static <T> @Nullable Optional<T> fromJavaUtil(java.util.@Nullable Optional<T> javaUtilOptional) {
     return (javaUtilOptional == null) ? null : fromNullable(javaUtilOptional.orElse(null));
   }
 
@@ -246,8 +245,7 @@ public abstract class Optional<T> implements Serializable {
    * <p><b>Comparison to {@code java.util.Optional}:</b> this method is equivalent to Java 8's
    * {@code Optional.orElse(null)}.
    */
-  @Nullable
-  public abstract T orNull();
+  public abstract @Nullable T orNull();
 
   /**
    * Returns an immutable singleton {@link Set} whose only element is the contained instance if it

--- a/guava/src/com/google/common/base/StandardSystemProperty.java
+++ b/guava/src/com/google/common/base/StandardSystemProperty.java
@@ -125,8 +125,7 @@ public enum StandardSystemProperty {
    * Returns the current value for this system property by delegating to {@link
    * System#getProperty(String)}.
    */
-  @Nullable
-  public String value() {
+  public @Nullable String value() {
     return System.getProperty(key);
   }
 

--- a/guava/src/com/google/common/base/Strings.java
+++ b/guava/src/com/google/common/base/Strings.java
@@ -47,8 +47,7 @@ public final class Strings {
    * @param string the string to test and possibly return
    * @return {@code string} itself if it is nonempty; {@code null} if it is empty or null
    */
-  @Nullable
-  public static String emptyToNull(@Nullable String string) {
+  public static @Nullable String emptyToNull(@Nullable String string) {
     return Platform.emptyToNull(string);
   }
 

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -113,7 +113,7 @@ public final class Suppliers {
     transient volatile boolean initialized;
     // "value" does not need to be volatile; visibility piggy-backs
     // on volatile read of "initialized".
-    @Nullable transient T value;
+    transient @Nullable T value;
 
     MemoizingSupplier(Supplier<T> delegate) {
       this.delegate = Preconditions.checkNotNull(delegate);
@@ -214,7 +214,7 @@ public final class Suppliers {
   static class ExpiringMemoizingSupplier<T> implements Supplier<T>, Serializable {
     final Supplier<T> delegate;
     final long durationNanos;
-    @Nullable transient volatile T value;
+    transient volatile @Nullable T value;
     // The special value 0 means "not yet initialized".
     transient volatile long expirationNanos;
 
@@ -266,7 +266,7 @@ public final class Suppliers {
   }
 
   private static class SupplierOfInstance<T> implements Supplier<T>, Serializable {
-    @Nullable final T instance;
+    final @Nullable T instance;
 
     SupplierOfInstance(@Nullable T instance) {
       this.instance = instance;

--- a/guava/src/com/google/common/base/Throwables.java
+++ b/guava/src/com/google/common/base/Throwables.java
@@ -448,32 +448,28 @@ public final class Throwables {
 
   /** Access to some fancy internal JVM internals. */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static final Object jla = getJLA();
+  private static final @Nullable Object jla = getJLA();
 
   /**
    * The "getStackTraceElementMethod" method, only available on some JDKs so we use reflection to
    * find it when available. When this is null, use the slow way.
    */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static final Method getStackTraceElementMethod = (jla == null) ? null : getGetMethod();
+  private static final @Nullable Method getStackTraceElementMethod = (jla == null) ? null : getGetMethod();
 
   /**
    * The "getStackTraceDepth" method, only available on some JDKs so we use reflection to find it
    * when available. When this is null, use the slow way.
    */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static final Method getStackTraceDepthMethod = (jla == null) ? null : getSizeMethod();
+  private static final @Nullable Method getStackTraceDepthMethod = (jla == null) ? null : getSizeMethod();
 
   /**
    * Returns the JavaLangAccess class that is present in all Sun JDKs. It is not whitelisted for
    * AppEngine, and not present in non-Sun JDKs.
    */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static Object getJLA() {
+  private static @Nullable Object getJLA() {
     try {
       /*
        * We load sun.misc.* classes using reflection since Android doesn't support these classes and
@@ -498,8 +494,7 @@ public final class Throwables {
    * method cannot be found (it is only to be found in fairly recent JDKs).
    */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static Method getGetMethod() {
+  private static @Nullable Method getGetMethod() {
     return getJlaMethod("getStackTraceElement", Throwable.class, int.class);
   }
 
@@ -513,8 +508,7 @@ public final class Throwables {
    * UnsupportedOperationException</a>.
    */
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static Method getSizeMethod() {
+  private static @Nullable Method getSizeMethod() {
     try {
       Method getStackTraceDepth = getJlaMethod("getStackTraceDepth", Throwable.class);
       if (getStackTraceDepth == null) {
@@ -528,8 +522,7 @@ public final class Throwables {
   }
 
   @GwtIncompatible // java.lang.reflect
-  @Nullable
-  private static Method getJlaMethod(String name, Class<?>... parameterTypes) throws ThreadDeath {
+  private static @Nullable Method getJlaMethod(String name, Class<?>... parameterTypes) throws ThreadDeath {
     try {
       return Class.forName(JAVA_LANG_ACCESS_CLASSNAME, false, null).getMethod(name, parameterTypes);
     } catch (ThreadDeath death) {

--- a/guava/src/com/google/common/base/internal/Finalizer.java
+++ b/guava/src/com/google/common/base/internal/Finalizer.java
@@ -116,11 +116,9 @@ public class Finalizer implements Runnable {
   // By preference, we will use the Thread constructor that has an `inheritThreadLocals` parameter.
   // But before Java 9, our only way not to inherit ThreadLocals is to zap them after the thread
   // is created, by accessing a private field.
-  @Nullable
-  private static final Constructor<Thread> bigThreadConstructor = getBigThreadConstructor();
+  private static final @Nullable Constructor<Thread> bigThreadConstructor = getBigThreadConstructor();
 
-  @Nullable
-  private static final Field inheritableThreadLocals =
+  private static final @Nullable Field inheritableThreadLocals =
       (bigThreadConstructor == null) ? getInheritableThreadLocalsField() : null;
 
   /** Constructs a new finalizer thread. */
@@ -192,8 +190,7 @@ public class Finalizer implements Runnable {
   }
 
   /** Looks up FinalizableReference.finalizeReferent() method. */
-  @Nullable
-  private Method getFinalizeReferentMethod() {
+  private @Nullable Method getFinalizeReferentMethod() {
     Class<?> finalizableReferenceClass = finalizableReferenceClassReference.get();
     if (finalizableReferenceClass == null) {
       /*
@@ -211,8 +208,7 @@ public class Finalizer implements Runnable {
     }
   }
 
-  @Nullable
-  private static Field getInheritableThreadLocalsField() {
+  private static @Nullable Field getInheritableThreadLocalsField() {
     try {
       Field inheritableThreadLocals = Thread.class.getDeclaredField("inheritableThreadLocals");
       inheritableThreadLocals.setAccessible(true);
@@ -226,8 +222,7 @@ public class Finalizer implements Runnable {
     }
   }
 
-  @Nullable
-  private static Constructor<Thread> getBigThreadConstructor() {
+  private static @Nullable Constructor<Thread> getBigThreadConstructor() {
     try {
       return Thread.class.getConstructor(
           ThreadGroup.class, Runnable.class, String.class, long.class, boolean.class);

--- a/guava/src/com/google/common/cache/CacheBuilderSpec.java
+++ b/guava/src/com/google/common/cache/CacheBuilderSpec.java
@@ -278,8 +278,7 @@ public final class CacheBuilderSpec {
    * Converts an expiration duration/unit pair into a single Long for hashing and equality. Uses
    * nanos to match CacheBuilder implementation.
    */
-  @Nullable
-  private static Long durationInNanos(long duration, @Nullable TimeUnit unit) {
+  private static @Nullable Long durationInNanos(long duration, @Nullable TimeUnit unit) {
     return (unit == null) ? null : unit.toNanos(duration);
   }
 

--- a/guava/src/com/google/common/cache/ForwardingCache.java
+++ b/guava/src/com/google/common/cache/ForwardingCache.java
@@ -43,8 +43,7 @@ public abstract class ForwardingCache<K, V> extends ForwardingObject implements 
 
   /** @since 11.0 */
   @Override
-  @Nullable
-  public V getIfPresent(Object key) {
+  public @Nullable V getIfPresent(Object key) {
     return delegate().getIfPresent(key);
   }
 

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -230,7 +230,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
   final StatsCounter globalStatsCounter;
 
   /** The default cache loader to use on loading operations. */
-  @Nullable final CacheLoader<? super K, V> defaultLoader;
+  final @Nullable CacheLoader<? super K, V> defaultLoader;
 
   /**
    * Creates a new, empty map with the specified strategy, initial capacity and concurrency level.
@@ -953,7 +953,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     // The code below is exactly the same for each entry type.
 
     final int hash;
-    @Nullable final ReferenceEntry<K, V> next;
+    final @Nullable ReferenceEntry<K, V> next;
     volatile ValueReference<K, V> valueReference = unset();
 
     @Override
@@ -1240,7 +1240,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     // The code below is exactly the same for each entry type.
 
     final int hash;
-    @Nullable final ReferenceEntry<K, V> next;
+    final @Nullable ReferenceEntry<K, V> next;
     volatile ValueReference<K, V> valueReference = unset();
 
     @Override
@@ -1893,13 +1893,13 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
      * The key reference queue contains entries whose keys have been garbage collected, and which
      * need to be cleaned up internally.
      */
-    @Nullable final ReferenceQueue<K> keyReferenceQueue;
+    final @Nullable ReferenceQueue<K> keyReferenceQueue;
 
     /**
      * The value reference queue contains value references whose values have been garbage collected,
      * and which need to be cleaned up internally.
      */
-    @Nullable final ReferenceQueue<V> valueReferenceQueue;
+    final @Nullable ReferenceQueue<V> valueReferenceQueue;
 
     /**
      * The recency queue is used to record which entries were accessed for updating the access
@@ -3932,8 +3932,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
   }
 
   @Override
-  @Nullable
-  public V get(@Nullable Object key) {
+  public @Nullable V get(@Nullable Object key) {
     if (key == null) {
       return null;
     }
@@ -3946,8 +3945,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     return segmentFor(hash).get(key, hash, loader);
   }
 
-  @Nullable
-  public V getIfPresent(Object key) {
+  public @Nullable V getIfPresent(Object key) {
     int hash = hash(checkNotNull(key));
     V value = segmentFor(hash).get(key, hash);
     if (value == null) {
@@ -3960,8 +3958,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
 
   // Only becomes available in Java 8 when it's on the interface.
   // @Override
-  @Nullable
-  public V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
+  public @Nullable V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
     V result = get(key);
     return (result != null) ? result : defaultValue;
   }
@@ -4693,7 +4690,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     final Weigher<K, V> weigher;
     final int concurrencyLevel;
     final RemovalListener<? super K, ? super V> removalListener;
-    @Nullable final Ticker ticker;
+    final @Nullable Ticker ticker;
     final CacheLoader<? super K, V> loader;
 
     @MonotonicNonNullDecl transient Cache<K, V> delegate;
@@ -4857,8 +4854,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     // Cache methods
 
     @Override
-    @Nullable
-    public V getIfPresent(Object key) {
+    public @Nullable V getIfPresent(Object key) {
       return localCache.getIfPresent(key);
     }
 

--- a/guava/src/com/google/common/collect/AbstractIterator.java
+++ b/guava/src/com/google/common/collect/AbstractIterator.java
@@ -81,7 +81,7 @@ public abstract class AbstractIterator<T> extends UnmodifiableIterator<T> {
     FAILED,
   }
 
-  @Nullable private T next;
+  private @Nullable T next;
 
   /**
    * Returns the next element. <b>Note:</b> the implementation must call {@link #endOfData()} when

--- a/guava/src/com/google/common/collect/AbstractMapBasedMultimap.java
+++ b/guava/src/com/google/common/collect/AbstractMapBasedMultimap.java
@@ -324,10 +324,10 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
    */
   @WeakOuter
   class WrappedCollection extends AbstractCollection<V> {
-    @Nullable final K key;
+    final @Nullable K key;
     Collection<V> delegate;
-    @Nullable final WrappedCollection ancestor;
-    @Nullable final Collection<V> ancestorDelegate;
+    final @Nullable WrappedCollection ancestor;
+    final @Nullable Collection<V> ancestorDelegate;
 
     WrappedCollection(
         @Nullable K key, Collection<V> delegate, @Nullable WrappedCollection ancestor) {

--- a/guava/src/com/google/common/collect/AbstractNavigableMap.java
+++ b/guava/src/com/google/common/collect/AbstractNavigableMap.java
@@ -36,30 +36,25 @@ abstract class AbstractNavigableMap<K, V> extends IteratorBasedAbstractMap<K, V>
     implements NavigableMap<K, V> {
 
   @Override
-  @Nullable
-  public abstract V get(@Nullable Object key);
+  public abstract @Nullable V get(@Nullable Object key);
 
   @Override
-  @Nullable
-  public Entry<K, V> firstEntry() {
+  public @Nullable Entry<K, V> firstEntry() {
     return Iterators.getNext(entryIterator(), null);
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> lastEntry() {
+  public @Nullable Entry<K, V> lastEntry() {
     return Iterators.getNext(descendingEntryIterator(), null);
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> pollFirstEntry() {
+  public @Nullable Entry<K, V> pollFirstEntry() {
     return Iterators.pollNext(entryIterator());
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> pollLastEntry() {
+  public @Nullable Entry<K, V> pollLastEntry() {
     return Iterators.pollNext(descendingEntryIterator());
   }
 
@@ -84,26 +79,22 @@ abstract class AbstractNavigableMap<K, V> extends IteratorBasedAbstractMap<K, V>
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> lowerEntry(K key) {
+  public @Nullable Entry<K, V> lowerEntry(K key) {
     return headMap(key, false).lastEntry();
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> floorEntry(K key) {
+  public @Nullable Entry<K, V> floorEntry(K key) {
     return headMap(key, true).lastEntry();
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> ceilingEntry(K key) {
+  public @Nullable Entry<K, V> ceilingEntry(K key) {
     return tailMap(key, true).firstEntry();
   }
 
   @Override
-  @Nullable
-  public Entry<K, V> higherEntry(K key) {
+  public @Nullable Entry<K, V> higherEntry(K key) {
     return tailMap(key, false).firstEntry();
   }
 

--- a/guava/src/com/google/common/collect/AbstractSequentialIterator.java
+++ b/guava/src/com/google/common/collect/AbstractSequentialIterator.java
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @GwtCompatible
 public abstract class AbstractSequentialIterator<T> extends UnmodifiableIterator<T> {
-  @Nullable private T nextOrNull;
+  private @Nullable T nextOrNull;
 
   /**
    * Creates a new iterator with the given first element, or, if {@code firstOrNull} is null,

--- a/guava/src/com/google/common/collect/ArrayTable.java
+++ b/guava/src/com/google/common/collect/ArrayTable.java
@@ -190,11 +190,9 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
 
     abstract String getKeyRole();
 
-    @Nullable
-    abstract V getValue(int index);
+    abstract @Nullable V getValue(int index);
 
-    @Nullable
-    abstract V setValue(int index, V newValue);
+    abstract @Nullable V setValue(int index, V newValue);
 
     @Override
     public int size() {

--- a/guava/src/com/google/common/collect/CollectSpliterators.java
+++ b/guava/src/com/google/common/collect/CollectSpliterators.java
@@ -65,8 +65,7 @@ final class CollectSpliterators {
       }
 
       @Override
-      @Nullable
-      public Spliterator<T> trySplit() {
+      public @Nullable Spliterator<T> trySplit() {
         Spliterator.OfInt split = delegate.trySplit();
         return (split == null) ? null : new WithCharacteristics(split);
       }

--- a/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/guava/src/com/google/common/collect/CompactHashMap.java
@@ -236,8 +236,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
   @CanIgnoreReturnValue
   @Override
-  @Nullable
-  public V put(@Nullable K key, @Nullable V value) {
+  public @Nullable V put(@Nullable K key, @Nullable V value) {
     long[] entries = this.entries;
     Object[] keys = this.keys;
     Object[] values = this.values;
@@ -373,13 +372,11 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
   @CanIgnoreReturnValue
   @Override
-  @Nullable
-  public V remove(@Nullable Object key) {
+  public @Nullable V remove(@Nullable Object key) {
     return remove(key, smearedHash(key));
   }
 
-  @Nullable
-  private V remove(@Nullable Object key, int hash) {
+  private @Nullable V remove(@Nullable Object key, int hash) {
     int tableIndex = hash & hashTableMask();
     int next = table[tableIndex];
     if (next == UNSET) { // empty bucket
@@ -664,7 +661,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   final class MapEntry extends AbstractMapEntry<K, V> {
-    @Nullable private final K key;
+    private final @Nullable K key;
 
     private int lastKnownIndex;
 

--- a/guava/src/com/google/common/collect/ConcurrentHashMultiset.java
+++ b/guava/src/com/google/common/collect/ConcurrentHashMultiset.java
@@ -522,7 +522,7 @@ public final class ConcurrentHashMultiset<E> extends AbstractMultiset<E> impleme
         };
 
     return new ForwardingIterator<Entry<E>>() {
-      @Nullable private Entry<E> last;
+      private @Nullable Entry<E> last;
 
       @Override
       protected Iterator<Entry<E>> delegate() {

--- a/guava/src/com/google/common/collect/Cut.java
+++ b/guava/src/com/google/common/collect/Cut.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @GwtCompatible
 abstract class Cut<C extends Comparable> implements Comparable<Cut<C>>, Serializable {
-  @Nullable final C endpoint;
+  final @Nullable C endpoint;
 
   Cut(@Nullable C endpoint) {
     this.endpoint = endpoint;

--- a/guava/src/com/google/common/collect/DenseImmutableTable.java
+++ b/guava/src/com/google/common/collect/DenseImmutableTable.java
@@ -101,8 +101,7 @@ final class DenseImmutableTable<R, C, V> extends RegularImmutableTable<R, C, V> 
       return keyToIndex().keySet().asList().get(index);
     }
 
-    @Nullable
-    abstract V getValue(int keyIndex);
+    abstract @Nullable V getValue(int keyIndex);
 
     @Override
     ImmutableSet<K> createKeySet() {

--- a/guava/src/com/google/common/collect/GeneralRange.java
+++ b/guava/src/com/google/common/collect/GeneralRange.java
@@ -92,10 +92,10 @@ final class GeneralRange<T> implements Serializable {
 
   private final Comparator<? super T> comparator;
   private final boolean hasLowerBound;
-  @Nullable private final T lowerEndpoint;
+  private final @Nullable T lowerEndpoint;
   private final BoundType lowerBoundType;
   private final boolean hasUpperBound;
-  @Nullable private final T upperEndpoint;
+  private final @Nullable T upperEndpoint;
   private final BoundType upperBoundType;
 
   private GeneralRange(

--- a/guava/src/com/google/common/collect/HashBiMap.java
+++ b/guava/src/com/google/common/collect/HashBiMap.java
@@ -105,8 +105,8 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
 
   private transient BiEntry<K, V>[] hashTableKToV;
   private transient BiEntry<K, V>[] hashTableVToK;
-  @Nullable private transient BiEntry<K, V> firstInKeyInsertionOrder;
-  @Nullable private transient BiEntry<K, V> lastInKeyInsertionOrder;
+  private transient @Nullable BiEntry<K, V> firstInKeyInsertionOrder;
+  private transient @Nullable BiEntry<K, V> lastInKeyInsertionOrder;
   private transient int size;
   private transient int mask;
   private transient int modCount;
@@ -249,9 +249,8 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     return seekByValue(value, smearedHash(value)) != null;
   }
 
-  @Nullable
   @Override
-  public V get(@Nullable Object key) {
+  public @Nullable V get(@Nullable Object key) {
     return Maps.valueOrNull(seekByKey(key, smearedHash(key)));
   }
 
@@ -301,8 +300,7 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     return put(key, value, true);
   }
 
-  @Nullable
-  private K putInverse(@Nullable V value, @Nullable K key, boolean force) {
+  private @Nullable K putInverse(@Nullable V value, @Nullable K key, boolean force) {
     int valueHash = smearedHash(value);
     int keyHash = smearedHash(key);
 

--- a/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
@@ -169,8 +169,7 @@ public final class ImmutableClassToInstanceMap<B> extends ForwardingMap<Class<? 
 
   @Override
   @SuppressWarnings("unchecked") // value could not get in if not a T
-  @Nullable
-  public <T extends B> T getInstance(Class<T> type) {
+  public <T extends B> @Nullable T getInstance(Class<T> type) {
     return (T) delegate.get(checkNotNull(type));
   }
 

--- a/guava/src/com/google/common/collect/ImmutableEntry.java
+++ b/guava/src/com/google/common/collect/ImmutableEntry.java
@@ -23,23 +23,21 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /** @see com.google.common.collect.Maps#immutableEntry(Object, Object) */
 @GwtCompatible(serializable = true)
 class ImmutableEntry<K, V> extends AbstractMapEntry<K, V> implements Serializable {
-  @Nullable final K key;
-  @Nullable final V value;
+  final @Nullable K key;
+  final @Nullable V value;
 
   ImmutableEntry(@Nullable K key, @Nullable V value) {
     this.key = key;
     this.value = value;
   }
 
-  @Nullable
   @Override
-  public final K getKey() {
+  public final @Nullable K getKey() {
     return key;
   }
 
-  @Nullable
   @Override
-  public final V getValue() {
+  public final @Nullable V getValue() {
     return value;
   }
 

--- a/guava/src/com/google/common/collect/ImmutableMapEntry.java
+++ b/guava/src/com/google/common/collect/ImmutableMapEntry.java
@@ -80,8 +80,7 @@ class ImmutableMapEntry<K, V> extends ImmutableEntry<K, V> {
     }
 
     @Override
-    @Nullable
-    final ImmutableMapEntry<K, V> getNextInKeyBucket() {
+    final @Nullable ImmutableMapEntry<K, V> getNextInKeyBucket() {
       return nextInKeyBucket;
     }
 

--- a/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -169,8 +169,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
   }
 
   @Override
-  @Nullable
-  public V get(K key) {
+  public @Nullable V get(K key) {
     int index =
         SortedLists.binarySearch(
             ranges,
@@ -187,8 +186,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
   }
 
   @Override
-  @Nullable
-  public Entry<Range<K>, V> getEntry(K key) {
+  public @Nullable Entry<Range<K>, V> getEntry(K key) {
     int index =
         SortedLists.binarySearch(
             ranges,

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -302,7 +302,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
   @Override
   public abstract UnmodifiableIterator<E> iterator();
 
-  @LazyInit @Nullable @RetainedWith private transient ImmutableList<E> asList;
+  @LazyInit @RetainedWith private transient @Nullable ImmutableList<E> asList;
 
   @Override
   public ImmutableList<E> asList() {

--- a/guava/src/com/google/common/collect/Iterables.java
+++ b/guava/src/com/google/common/collect/Iterables.java
@@ -199,8 +199,7 @@ public final class Iterables {
   }
 
   /** Removes and returns the first matching element, or returns {@code null} if there is none. */
-  @Nullable
-  static <T> T removeFirstMatching(Iterable<T> removeFrom, Predicate<? super T> predicate) {
+  static <T> @Nullable T removeFirstMatching(Iterable<T> removeFrom, Predicate<? super T> predicate) {
     checkNotNull(predicate);
     Iterator<T> iterator = removeFrom.iterator();
     while (iterator.hasNext()) {
@@ -263,8 +262,7 @@ public final class Iterables {
    *
    * @throws IllegalArgumentException if the iterator contains multiple elements
    */
-  @Nullable
-  public static <T> T getOnlyElement(Iterable<? extends T> iterable, @Nullable T defaultValue) {
+  public static <T> @Nullable T getOnlyElement(Iterable<? extends T> iterable, @Nullable T defaultValue) {
     return Iterators.getOnlyElement(iterable.iterator(), defaultValue);
   }
 
@@ -641,8 +639,7 @@ public final class Iterables {
    *
    * @since 7.0
    */
-  @Nullable
-  public static <T> T find(
+  public static <T> @Nullable T find(
       Iterable<? extends T> iterable, Predicate<? super T> predicate, @Nullable T defaultValue) {
     return Iterators.find(iterable.iterator(), predicate, defaultValue);
   }
@@ -745,8 +742,7 @@ public final class Iterables {
    * @throws IndexOutOfBoundsException if {@code position} is negative
    * @since 4.0
    */
-  @Nullable
-  public static <T> T get(Iterable<? extends T> iterable, int position, @Nullable T defaultValue) {
+  public static <T> @Nullable T get(Iterable<? extends T> iterable, int position, @Nullable T defaultValue) {
     checkNotNull(iterable);
     Iterators.checkNonnegative(position);
     if (iterable instanceof List) {
@@ -776,8 +772,7 @@ public final class Iterables {
    * @return the first element of {@code iterable} or the default value
    * @since 7.0
    */
-  @Nullable
-  public static <T> T getFirst(Iterable<? extends T> iterable, @Nullable T defaultValue) {
+  public static <T> @Nullable T getFirst(Iterable<? extends T> iterable, @Nullable T defaultValue) {
     return Iterators.getNext(iterable.iterator(), defaultValue);
   }
 
@@ -814,8 +809,7 @@ public final class Iterables {
    * @return the last element of {@code iterable} or the default value
    * @since 3.0
    */
-  @Nullable
-  public static <T> T getLast(Iterable<? extends T> iterable, @Nullable T defaultValue) {
+  public static <T> @Nullable T getLast(Iterable<? extends T> iterable, @Nullable T defaultValue) {
     if (iterable instanceof Collection) {
       Collection<? extends T> c = Collections2.cast(iterable);
       if (c.isEmpty()) {

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -324,8 +324,7 @@ public final class Iterators {
    *     iterator is unspecified.
    */
   @CanIgnoreReturnValue // TODO(kak): Consider removing this?
-  @Nullable
-  public static <T> T getOnlyElement(Iterator<? extends T> iterator, @Nullable T defaultValue) {
+  public static <T> @Nullable T getOnlyElement(Iterator<? extends T> iterator, @Nullable T defaultValue) {
     return iterator.hasNext() ? getOnlyElement(iterator) : defaultValue;
   }
 
@@ -707,8 +706,7 @@ public final class Iterators {
    *
    * @since 7.0
    */
-  @Nullable
-  public static <T> T find(
+  public static <T> @Nullable T find(
       Iterator<? extends T> iterator, Predicate<? super T> predicate, @Nullable T defaultValue) {
     checkNotNull(iterator);
     checkNotNull(predicate);
@@ -823,8 +821,7 @@ public final class Iterators {
    * @throws IndexOutOfBoundsException if {@code position} is negative
    * @since 4.0
    */
-  @Nullable
-  public static <T> T get(Iterator<? extends T> iterator, int position, @Nullable T defaultValue) {
+  public static <T> @Nullable T get(Iterator<? extends T> iterator, int position, @Nullable T defaultValue) {
     checkNonnegative(position);
     advance(iterator, position);
     return getNext(iterator, defaultValue);
@@ -844,8 +841,7 @@ public final class Iterators {
    * @return the next element of {@code iterator} or the default value
    * @since 7.0
    */
-  @Nullable
-  public static <T> T getNext(Iterator<? extends T> iterator, @Nullable T defaultValue) {
+  public static <T> @Nullable T getNext(Iterator<? extends T> iterator, @Nullable T defaultValue) {
     return iterator.hasNext() ? iterator.next() : defaultValue;
   }
 
@@ -872,8 +868,7 @@ public final class Iterators {
    * @return the last element of {@code iterator}
    * @since 3.0
    */
-  @Nullable
-  public static <T> T getLast(Iterator<? extends T> iterator, @Nullable T defaultValue) {
+  public static <T> @Nullable T getLast(Iterator<? extends T> iterator, @Nullable T defaultValue) {
     return iterator.hasNext() ? getLast(iterator) : defaultValue;
   }
 
@@ -970,8 +965,7 @@ public final class Iterators {
    * Deletes and returns the next value from the iterator, or returns {@code null} if there is no
    * such value.
    */
-  @Nullable
-  static <T> T pollNext(Iterator<T> iterator) {
+  static <T> @Nullable T pollNext(Iterator<T> iterator) {
     if (iterator.hasNext()) {
       T result = iterator.next();
       iterator.remove();
@@ -1051,7 +1045,7 @@ public final class Iterators {
    *
    * <p>The {@link Iterable} equivalent of this method is {@link Collections#singleton}.
    */
-  public static <T> UnmodifiableIterator<T> singletonIterator(@Nullable final T value) {
+  public static <T> UnmodifiableIterator<T> singletonIterator(final @Nullable T value) {
     return new UnmodifiableIterator<T>() {
       boolean done;
 
@@ -1119,7 +1113,7 @@ public final class Iterators {
 
     private final Iterator<? extends E> iterator;
     private boolean hasPeeked;
-    @Nullable private E peekedElement;
+    private @Nullable E peekedElement;
 
     public PeekingImpl(Iterator<? extends E> iterator) {
       this.iterator = checkNotNull(iterator);
@@ -1288,7 +1282,7 @@ public final class Iterators {
 
   private static class ConcatenatedIterator<T> implements Iterator<T> {
     /* The last iterator to return an element.  Calls to remove() go to this iterator. */
-    @Nullable private Iterator<? extends T> toRemove;
+    private @Nullable Iterator<? extends T> toRemove;
 
     /* The iterator currently returning elements. */
     private Iterator<? extends T> iterator;
@@ -1303,7 +1297,7 @@ public final class Iterators {
     private Iterator<? extends Iterator<? extends T>> topMetaIterator;
 
     // Only becomes nonnull if we encounter nested concatenations.
-    @Nullable private Deque<Iterator<? extends Iterator<? extends T>>> metaIterators;
+    private @Nullable Deque<Iterator<? extends Iterator<? extends T>>> metaIterators;
 
     ConcatenatedIterator(Iterator<? extends Iterator<? extends T>> metaIterator) {
       iterator = emptyIterator();
@@ -1311,8 +1305,7 @@ public final class Iterators {
     }
 
     // Returns a nonempty meta-iterator or, if all meta-iterators are empty, null.
-    @Nullable
-    private Iterator<? extends Iterator<? extends T>> getTopMetaIterator() {
+    private @Nullable Iterator<? extends Iterator<? extends T>> getTopMetaIterator() {
       while (topMetaIterator == null || !topMetaIterator.hasNext()) {
         if (metaIterators != null && !metaIterators.isEmpty()) {
           topMetaIterator = metaIterators.removeFirst();

--- a/guava/src/com/google/common/collect/LinkedListMultimap.java
+++ b/guava/src/com/google/common/collect/LinkedListMultimap.java
@@ -106,7 +106,7 @@ public class LinkedListMultimap<K, V> extends AbstractMultimap<K, V>
    */
 
   private static final class Node<K, V> extends AbstractMapEntry<K, V> {
-    @Nullable final K key;
+    final @Nullable K key;
     @Nullable V value;
     @Nullable Node<K, V> next; // the next node (with any key)
     @Nullable Node<K, V> previous; // the previous node (with any key)
@@ -150,8 +150,8 @@ public class LinkedListMultimap<K, V> extends AbstractMultimap<K, V>
     }
   }
 
-  @Nullable private transient Node<K, V> head; // the head for all keys
-  @Nullable private transient Node<K, V> tail; // the tail for all keys
+  private transient @Nullable Node<K, V> head; // the head for all keys
+  private transient @Nullable Node<K, V> tail; // the tail for all keys
   private transient Map<K, KeyList<K, V>> keyToKeyList;
   private transient int size;
 
@@ -454,7 +454,7 @@ public class LinkedListMultimap<K, V> extends AbstractMultimap<K, V>
 
   /** A {@code ListIterator} over values for a specified key. */
   private class ValueForKeyIterator implements ListIterator<V> {
-    @Nullable final Object key;
+    final @Nullable Object key;
     int nextIndex;
     @Nullable Node<K, V> next;
     @Nullable Node<K, V> current;

--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -314,7 +314,7 @@ public final class Lists {
   /** @see Lists#asList(Object, Object[]) */
   private static class OnePlusArrayList<E> extends AbstractList<E>
       implements Serializable, RandomAccess {
-    @Nullable final E first;
+    final @Nullable E first;
     final E[] rest;
 
     OnePlusArrayList(@Nullable E first, E[] rest) {
@@ -340,8 +340,8 @@ public final class Lists {
   /** @see Lists#asList(Object, Object, Object[]) */
   private static class TwoPlusArrayList<E> extends AbstractList<E>
       implements Serializable, RandomAccess {
-    @Nullable final E first;
-    @Nullable final E second;
+    final @Nullable E first;
+    final @Nullable E second;
     final E[] rest;
 
     TwoPlusArrayList(@Nullable E first, @Nullable E second, E[] rest) {

--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -340,7 +340,7 @@ class MapMakerInternalMap<
       implements InternalEntry<K, V, E> {
     final K key;
     final int hash;
-    @Nullable final E next;
+    final @Nullable E next;
 
     AbstractStrongKeyEntry(K key, int hash, @Nullable E next) {
       this.key = key;
@@ -390,15 +390,14 @@ class MapMakerInternalMap<
   static final class StrongKeyStrongValueEntry<K, V>
       extends AbstractStrongKeyEntry<K, V, StrongKeyStrongValueEntry<K, V>>
       implements StrongValueEntry<K, V, StrongKeyStrongValueEntry<K, V>> {
-    @Nullable private volatile V value = null;
+    private volatile @Nullable V value = null;
 
     StrongKeyStrongValueEntry(K key, int hash, @Nullable StrongKeyStrongValueEntry<K, V> next) {
       super(key, hash, next);
     }
 
     @Override
-    @Nullable
-    public V getValue() {
+    public @Nullable V getValue() {
       return value;
     }
 
@@ -647,7 +646,7 @@ class MapMakerInternalMap<
   abstract static class AbstractWeakKeyEntry<K, V, E extends InternalEntry<K, V, E>>
       extends WeakReference<K> implements InternalEntry<K, V, E> {
     final int hash;
-    @Nullable final E next;
+    final @Nullable E next;
 
     AbstractWeakKeyEntry(ReferenceQueue<K> queue, K key, int hash, @Nullable E next) {
       super(key, queue);
@@ -755,7 +754,7 @@ class MapMakerInternalMap<
   static final class WeakKeyStrongValueEntry<K, V>
       extends AbstractWeakKeyEntry<K, V, WeakKeyStrongValueEntry<K, V>>
       implements StrongValueEntry<K, V, WeakKeyStrongValueEntry<K, V>> {
-    @Nullable private volatile V value = null;
+    private volatile @Nullable V value = null;
 
     WeakKeyStrongValueEntry(
         ReferenceQueue<K> queue, K key, int hash, @Nullable WeakKeyStrongValueEntry<K, V> next) {
@@ -763,8 +762,7 @@ class MapMakerInternalMap<
     }
 
     @Override
-    @Nullable
-    public V getValue() {
+    public @Nullable V getValue() {
       return value;
     }
 

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -92,15 +92,13 @@ public final class Maps {
   private enum EntryFunction implements Function<Entry<?, ?>, Object> {
     KEY {
       @Override
-      @Nullable
-      public Object apply(Entry<?, ?> entry) {
+      public @Nullable Object apply(Entry<?, ?> entry) {
         return entry.getKey();
       }
     },
     VALUE {
       @Override
-      @Nullable
-      public Object apply(Entry<?, ?> entry) {
+      public @Nullable Object apply(Entry<?, ?> entry) {
         return entry.getValue();
       }
     };
@@ -695,8 +693,8 @@ public final class Maps {
   }
 
   static class ValueDifferenceImpl<V> implements MapDifference.ValueDifference<V> {
-    @Nullable private final V left;
-    @Nullable private final V right;
+    private final @Nullable V left;
+    private final @Nullable V right;
 
     static <V> ValueDifference<V> create(@Nullable V left, @Nullable V right) {
       return new ValueDifferenceImpl<V>(left, right);
@@ -1051,14 +1049,12 @@ public final class Maps {
     }
 
     @Override
-    @Nullable
-    public V get(@Nullable Object key) {
+    public @Nullable V get(@Nullable Object key) {
       return getOrDefault(key, null);
     }
 
     @Override
-    @Nullable
-    public V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
+    public @Nullable V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
       if (Collections2.safeContains(set, key)) {
         @SuppressWarnings("unchecked") // unsafe, but Javadoc warns about it
         K k = (K) key;
@@ -2030,16 +2026,14 @@ public final class Maps {
     }
 
     @Override
-    @Nullable
-    public V2 get(@Nullable Object key) {
+    public @Nullable V2 get(@Nullable Object key) {
       return getOrDefault(key, null);
     }
 
     // safe as long as the user followed the <b>Warning</b> in the javadoc
     @SuppressWarnings("unchecked")
     @Override
-    @Nullable
-    public V2 getOrDefault(@Nullable Object key, @Nullable V2 defaultValue) {
+    public @Nullable V2 getOrDefault(@Nullable Object key, @Nullable V2 defaultValue) {
       V1 value = fromMap.get(key);
       return (value != null || fromMap.containsKey(key))
           ? transformer.transformEntry((K) key, value)
@@ -2249,8 +2243,7 @@ public final class Maps {
       return transformEntries(fromMap().tailMap(fromKey, inclusive), transformer);
     }
 
-    @Nullable
-    private Entry<K, V2> transformEntry(@Nullable Entry<K, V1> entry) {
+    private @Nullable Entry<K, V2> transformEntry(@Nullable Entry<K, V1> entry) {
       return (entry == null) ? null : Maps.transformEntry(transformer, entry);
     }
 
@@ -3128,8 +3121,7 @@ public final class Maps {
     }
 
     @Override
-    @Nullable
-    public V get(@Nullable Object key) {
+    public @Nullable V get(@Nullable Object key) {
       return filteredDelegate.get(key);
     }
 
@@ -3284,8 +3276,7 @@ public final class Maps {
     }
   }
 
-  @Nullable
-  private static <K, V> Entry<K, V> unmodifiableOrNull(@Nullable Entry<K, ? extends V> entry) {
+  private static <K, V> @Nullable Entry<K, V> unmodifiableOrNull(@Nullable Entry<K, ? extends V> entry) {
     return (entry == null) ? null : Maps.unmodifiableEntry(entry);
   }
 
@@ -3744,13 +3735,11 @@ public final class Maps {
     }
   }
 
-  @Nullable
-  static <K> K keyOrNull(@Nullable Entry<K, ?> entry) {
+  static <K> @Nullable K keyOrNull(@Nullable Entry<K, ?> entry) {
     return (entry == null) ? null : entry.getKey();
   }
 
-  @Nullable
-  static <V> V valueOrNull(@Nullable Entry<?, V> entry) {
+  static <V> @Nullable V valueOrNull(@Nullable Entry<?, V> entry) {
     return (entry == null) ? null : entry.getValue();
   }
 

--- a/guava/src/com/google/common/collect/MinMaxPriorityQueue.java
+++ b/guava/src/com/google/common/collect/MinMaxPriorityQueue.java
@@ -754,7 +754,7 @@ public final class MinMaxPriorityQueue<E> extends AbstractQueue<E> {
     // either of them, up to the same multiplicity as the queue.
     @MonotonicNonNullDecl private Queue<E> forgetMeNot;
     @MonotonicNonNullDecl private List<E> skipMe;
-    @Nullable private E lastFromForgetMeNot;
+    private @Nullable E lastFromForgetMeNot;
     private boolean canRemove;
 
     @Override

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -246,7 +246,7 @@ public final class Multisets {
   }
 
   static class ImmutableEntry<E> extends AbstractEntry<E> implements Serializable {
-    @Nullable private final E element;
+    private final @Nullable E element;
     private final int count;
 
     ImmutableEntry(@Nullable E element, int count) {
@@ -256,8 +256,7 @@ public final class Multisets {
     }
 
     @Override
-    @Nullable
-    public final E getElement() {
+    public final @Nullable E getElement() {
       return element;
     }
 

--- a/guava/src/com/google/common/collect/RegularImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableBiMap.java
@@ -135,8 +135,7 @@ class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
   }
 
   @Override
-  @Nullable
-  public V get(@Nullable Object key) {
+  public @Nullable V get(@Nullable Object key) {
     return (keyTable == null) ? null : RegularImmutableMap.get(key, keyTable, mask);
   }
 

--- a/guava/src/com/google/common/collect/RegularImmutableMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableMap.java
@@ -155,8 +155,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     return get(key, table, mask);
   }
 
-  @Nullable
-  static <V> V get(@Nullable Object key, ImmutableMapEntry<?, V> @Nullable [] keyTable, int mask) {
+  static <V> @Nullable V get(@Nullable Object key, ImmutableMapEntry<?, V> @Nullable [] keyTable, int mask) {
     if (key == null || keyTable == null) {
       return null;
     }

--- a/guava/src/com/google/common/collect/RegularImmutableTable.java
+++ b/guava/src/com/google/common/collect/RegularImmutableTable.java
@@ -96,8 +96,8 @@ abstract class RegularImmutableTable<R, C, V> extends ImmutableTable<R, C, V> {
 
   static <R, C, V> RegularImmutableTable<R, C, V> forCells(
       List<Cell<R, C, V>> cells,
-      @Nullable final Comparator<? super R> rowComparator,
-      @Nullable final Comparator<? super C> columnComparator) {
+      final @Nullable Comparator<? super R> rowComparator,
+      final @Nullable Comparator<? super C> columnComparator) {
     checkNotNull(cells);
     if (rowComparator != null || columnComparator != null) {
       /*

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -1208,14 +1208,12 @@ public final class Sets {
     }
 
     @Override
-    @Nullable
-    public E lower(E e) {
+    public @Nullable E lower(E e) {
       return Iterators.find(unfiltered().headSet(e, false).descendingIterator(), predicate, null);
     }
 
     @Override
-    @Nullable
-    public E floor(E e) {
+    public @Nullable E floor(E e) {
       return Iterators.find(unfiltered().headSet(e, true).descendingIterator(), predicate, null);
     }
 

--- a/guava/src/com/google/common/collect/Tables.java
+++ b/guava/src/com/google/common/collect/Tables.java
@@ -151,9 +151,9 @@ public final class Tables {
   }
 
   static final class ImmutableCell<R, C, V> extends AbstractCell<R, C, V> implements Serializable {
-    @Nullable private final R rowKey;
-    @Nullable private final C columnKey;
-    @Nullable private final V value;
+    private final @Nullable R rowKey;
+    private final @Nullable C columnKey;
+    private final @Nullable V value;
 
     ImmutableCell(@Nullable R rowKey, @Nullable C columnKey, @Nullable V value) {
       this.rowKey = rowKey;

--- a/guava/src/com/google/common/collect/TopKSelector.java
+++ b/guava/src/com/google/common/collect/TopKSelector.java
@@ -110,7 +110,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * The largest of the lowest k elements we've seen so far relative to this comparator. If
    * bufferSize ≥ k, then we can ignore any elements greater than this value.
    */
-  @Nullable private T threshold;
+  private @Nullable T threshold;
 
   private TopKSelector(Comparator<? super T> comparator, int k) {
     this.comparator = checkNotNull(comparator, "comparator");

--- a/guava/src/com/google/common/collect/TreeBasedTable.java
+++ b/guava/src/com/google/common/collect/TreeBasedTable.java
@@ -169,8 +169,8 @@ public class TreeBasedTable<R, C, V> extends StandardRowSortedTable<R, C, V> {
   }
 
   private class TreeRow extends Row implements SortedMap<C, V> {
-    @Nullable final C lowerBound;
-    @Nullable final C upperBound;
+    final @Nullable C lowerBound;
+    final @Nullable C upperBound;
 
     TreeRow(R rowKey) {
       this(rowKey, null, null);
@@ -243,7 +243,7 @@ public class TreeBasedTable<R, C, V> extends StandardRowSortedTable<R, C, V> {
       return backingRowMap().lastKey();
     }
 
-    @Nullable transient SortedMap<C, V> wholeRow;
+    transient @Nullable SortedMap<C, V> wholeRow;
 
     /*
      * If the row was previously empty, we check if there's a new row here every

--- a/guava/src/com/google/common/collect/TreeMultiset.java
+++ b/guava/src/com/google/common/collect/TreeMultiset.java
@@ -380,8 +380,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
   }
 
   /** Returns the first node in the tree that is in range. */
-  @Nullable
-  private AvlNode<E> firstNode() {
+  private @Nullable AvlNode<E> firstNode() {
     AvlNode<E> root = rootReference.get();
     if (root == null) {
       return null;
@@ -403,8 +402,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
     return (node == header || !range.contains(node.getElement())) ? null : node;
   }
 
-  @Nullable
-  private AvlNode<E> lastNode() {
+  private @Nullable AvlNode<E> lastNode() {
     AvlNode<E> root = rootReference.get();
     if (root == null) {
       return null;
@@ -547,10 +545,9 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
   }
 
   private static final class Reference<T> {
-    @Nullable private T value;
+    private @Nullable T value;
 
-    @Nullable
-    public T get() {
+    public @Nullable T get() {
       return value;
     }
 
@@ -567,7 +564,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
   }
 
   private static final class AvlNode<E> {
-    @Nullable private final E elem;
+    private final @Nullable E elem;
 
     // elemCount is 0 iff this node has been deleted.
     private int elemCount;
@@ -575,10 +572,10 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
     private int distinctElements;
     private long totalCount;
     private int height;
-    @Nullable private AvlNode<E> left;
-    @Nullable private AvlNode<E> right;
-    @Nullable private AvlNode<E> pred;
-    @Nullable private AvlNode<E> succ;
+    private @Nullable AvlNode<E> left;
+    private @Nullable AvlNode<E> right;
+    private @Nullable AvlNode<E> pred;
+    private @Nullable AvlNode<E> succ;
 
     AvlNode(@Nullable E elem, int elemCount) {
       checkArgument(elemCount > 0);
@@ -946,8 +943,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
       return (node == null) ? 0 : node.height;
     }
 
-    @Nullable
-    private AvlNode<E> ceiling(Comparator<? super E> comparator, E e) {
+    private @Nullable AvlNode<E> ceiling(Comparator<? super E> comparator, E e) {
       int cmp = comparator.compare(e, elem);
       if (cmp < 0) {
         return (left == null) ? this : MoreObjects.firstNonNull(left.ceiling(comparator, e), this);
@@ -958,8 +954,7 @@ public final class TreeMultiset<E> extends AbstractSortedMultiset<E> implements 
       }
     }
 
-    @Nullable
-    private AvlNode<E> floor(Comparator<? super E> comparator, E e) {
+    private @Nullable AvlNode<E> floor(Comparator<? super E> comparator, E e) {
       int cmp = comparator.compare(e, elem);
       if (cmp > 0) {
         return (right == null) ? this : MoreObjects.firstNonNull(right.floor(comparator, e), this);

--- a/guava/src/com/google/common/collect/TreeRangeMap.java
+++ b/guava/src/com/google/common/collect/TreeRangeMap.java
@@ -100,15 +100,13 @@ public final class TreeRangeMap<K extends Comparable, V> implements RangeMap<K, 
   }
 
   @Override
-  @Nullable
-  public V get(K key) {
+  public @Nullable V get(K key) {
     Entry<Range<K>, V> entry = getEntry(key);
     return (entry == null) ? null : entry.getValue();
   }
 
   @Override
-  @Nullable
-  public Entry<Range<K>, V> getEntry(K key) {
+  public @Nullable Entry<Range<K>, V> getEntry(K key) {
     Entry<Cut<K>, RangeMapEntry<K, V>> mapEntry =
         entriesByLowerBound.floorEntry(Cut.belowValue(key));
     if (mapEntry != null && mapEntry.getValue().contains(key)) {
@@ -305,14 +303,12 @@ public final class TreeRangeMap<K extends Comparable, V> implements RangeMap<K, 
   private static final RangeMap EMPTY_SUB_RANGE_MAP =
       new RangeMap() {
         @Override
-        @Nullable
-        public Object get(Comparable key) {
+        public @Nullable Object get(Comparable key) {
           return null;
         }
 
         @Override
-        @Nullable
-        public Entry<Range, Object> getEntry(Comparable key) {
+        public @Nullable Entry<Range, Object> getEntry(Comparable key) {
           return null;
         }
 
@@ -377,14 +373,12 @@ public final class TreeRangeMap<K extends Comparable, V> implements RangeMap<K, 
     }
 
     @Override
-    @Nullable
-    public V get(K key) {
+    public @Nullable V get(K key) {
       return subRange.contains(key) ? TreeRangeMap.this.get(key) : null;
     }
 
     @Override
-    @Nullable
-    public Entry<Range<K>, V> getEntry(K key) {
+    public @Nullable Entry<Range<K>, V> getEntry(K key) {
       if (subRange.contains(key)) {
         Entry<Range<K>, V> entry = TreeRangeMap.this.getEntry(key);
         if (entry != null) {

--- a/guava/src/com/google/common/collect/TreeRangeSet.java
+++ b/guava/src/com/google/common/collect/TreeRangeSet.java
@@ -119,8 +119,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
   }
 
   @Override
-  @Nullable
-  public Range<C> rangeContaining(C value) {
+  public @Nullable Range<C> rangeContaining(C value) {
     checkNotNull(value);
     Entry<Cut<C>, Range<C>> floorEntry = rangesByLowerBound.floorEntry(Cut.belowValue(value));
     if (floorEntry != null && floorEntry.getValue().contains(value)) {
@@ -153,8 +152,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
     return floorEntry != null && floorEntry.getValue().encloses(range);
   }
 
-  @Nullable
-  private Range<C> rangeEnclosing(Range<C> range) {
+  private @Nullable Range<C> rangeEnclosing(Range<C> range) {
     checkNotNull(range);
     Entry<Cut<C>, Range<C>> floorEntry = rangesByLowerBound.floorEntry(range.lowerBound);
     return (floorEntry != null && floorEntry.getValue().encloses(range))
@@ -625,8 +623,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
     }
 
     @Override
-    @Nullable
-    public Range<C> get(Object key) {
+    public @Nullable Range<C> get(Object key) {
       if (key instanceof Cut) {
         try {
           @SuppressWarnings("unchecked")
@@ -743,8 +740,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
     }
 
     @Override
-    @Nullable
-    public Range<C> get(@Nullable Object key) {
+    public @Nullable Range<C> get(@Nullable Object key) {
       if (key instanceof Cut) {
         try {
           @SuppressWarnings("unchecked") // we catch CCE's
@@ -881,8 +877,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
     }
 
     @Override
-    @Nullable
-    public Range<C> rangeContaining(C value) {
+    public @Nullable Range<C> rangeContaining(C value) {
       if (!restriction.contains(value)) {
         return null;
       }

--- a/guava/src/com/google/common/graph/AbstractNetwork.java
+++ b/guava/src/com/google/common/graph/AbstractNetwork.java
@@ -192,8 +192,7 @@ public abstract class AbstractNetwork<N, E> implements Network<N, E> {
   }
 
   @Override
-  @Nullable
-  public E edgeConnectingOrNull(N nodeU, N nodeV) {
+  public @Nullable E edgeConnectingOrNull(N nodeU, N nodeV) {
     return edgeConnecting(nodeU, nodeV).orElse(null);
   }
 

--- a/guava/src/com/google/common/graph/ConfigurableValueGraph.java
+++ b/guava/src/com/google/common/graph/ConfigurableValueGraph.java
@@ -123,8 +123,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
-  @Nullable
-  public V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
+  public @Nullable V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
     checkNotNull(nodeU);
     checkNotNull(nodeV);
     GraphConnections<N, V> connectionsU = nodeConnections.get(nodeU);

--- a/guava/src/com/google/common/graph/DirectedMultiNetworkConnections.java
+++ b/guava/src/com/google/common/graph/DirectedMultiNetworkConnections.java
@@ -139,8 +139,7 @@ final class DirectedMultiNetworkConnections<N, E> extends AbstractDirectedNetwor
     }
   }
 
-  @Nullable
-  private static <T> T getReference(@Nullable Reference<T> reference) {
+  private static <T> @Nullable T getReference(@Nullable Reference<T> reference) {
     return (reference == null) ? null : reference.get();
   }
 }

--- a/guava/src/com/google/common/graph/EdgesConnecting.java
+++ b/guava/src/com/google/common/graph/EdgesConnecting.java
@@ -63,8 +63,7 @@ final class EdgesConnecting<E> extends AbstractSet<E> {
     return (connectingEdge != null && connectingEdge.equals(edge));
   }
 
-  @Nullable
-  private E getConnectingEdge() {
+  private @Nullable E getConnectingEdge() {
     return nodeToOutEdge.get(targetNode);
   }
 }

--- a/guava/src/com/google/common/graph/ElementOrder.java
+++ b/guava/src/com/google/common/graph/ElementOrder.java
@@ -50,8 +50,7 @@ public final class ElementOrder<T> {
   private final Type type;
 
   @SuppressWarnings("Immutable") // Hopefully the comparator provided is immutable!
-  @Nullable
-  private final Comparator<T> comparator;
+  private final @Nullable Comparator<T> comparator;
 
   /**
    * The type of ordering that this object specifies.

--- a/guava/src/com/google/common/graph/ForwardingValueGraph.java
+++ b/guava/src/com/google/common/graph/ForwardingValueGraph.java
@@ -101,8 +101,7 @@ abstract class ForwardingValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
-  @Nullable
-  public V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
+  public @Nullable V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
     return delegate().edgeValueOrDefault(nodeU, nodeV, defaultValue);
   }
 }

--- a/guava/src/com/google/common/graph/Graphs.java
+++ b/guava/src/com/google/common/graph/Graphs.java
@@ -344,8 +344,7 @@ public final class Graphs {
     }
 
     @Override
-    @Nullable
-    public V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
+    public @Nullable V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
       return delegate().edgeValueOrDefault(nodeV, nodeU, defaultValue); // transpose
     }
   }

--- a/guava/src/com/google/common/graph/MapIteratorCache.java
+++ b/guava/src/com/google/common/graph/MapIteratorCache.java
@@ -47,7 +47,7 @@ class MapIteratorCache<K, V> {
   // Per JDK: "the behavior of a map entry is undefined if the backing map has been modified after
   // the entry was returned by the iterator, except through the setValue operation on the map entry"
   // As such, this field must be cleared before every map mutation.
-  @Nullable private transient Entry<K, V> entrySetCache;
+  private transient @Nullable Entry<K, V> entrySetCache;
 
   MapIteratorCache(Map<K, V> backingMap) {
     this.backingMap = checkNotNull(backingMap);

--- a/guava/src/com/google/common/graph/MapRetrievalCache.java
+++ b/guava/src/com/google/common/graph/MapRetrievalCache.java
@@ -26,8 +26,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author James Sexton
  */
 class MapRetrievalCache<K, V> extends MapIteratorCache<K, V> {
-  @Nullable private transient CacheEntry<K, V> cacheEntry1;
-  @Nullable private transient CacheEntry<K, V> cacheEntry2;
+  private transient @Nullable CacheEntry<K, V> cacheEntry1;
+  private transient @Nullable CacheEntry<K, V> cacheEntry2;
 
   MapRetrievalCache(Map<K, V> backingMap) {
     super(backingMap);

--- a/guava/src/com/google/common/graph/Traverser.java
+++ b/guava/src/com/google/common/graph/Traverser.java
@@ -471,7 +471,7 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its successors. */
       private final class NodeAndSuccessors {
-        @Nullable final N node;
+        final @Nullable N node;
         final Iterator<? extends N> successorIterator;
 
         NodeAndSuccessors(@Nullable N node, Iterable<? extends N> successors) {
@@ -644,7 +644,7 @@ public abstract class Traverser<N> {
 
       /** A simple tuple of a node and a partially iterated {@link Iterator} of its children. */
       private final class NodeAndChildren {
-        @Nullable final N node;
+        final @Nullable N node;
         final Iterator<? extends N> childIterator;
 
         NodeAndChildren(@Nullable N node, Iterable<? extends N> children) {

--- a/guava/src/com/google/common/graph/UndirectedMultiNetworkConnections.java
+++ b/guava/src/com/google/common/graph/UndirectedMultiNetworkConnections.java
@@ -115,8 +115,7 @@ final class UndirectedMultiNetworkConnections<N, E>
     }
   }
 
-  @Nullable
-  private static <T> T getReference(@Nullable Reference<T> reference) {
+  private static <T> @Nullable T getReference(@Nullable Reference<T> reference) {
     return (reference == null) ? null : reference.get();
   }
 }

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -567,7 +567,7 @@ public abstract class BaseEncoding {
     // TODO(lowasser): provide a useful toString
     final Alphabet alphabet;
 
-    @Nullable final Character paddingChar;
+    final @Nullable Character paddingChar;
 
     StandardBaseEncoding(String name, String alphabetChars, @Nullable Character paddingChar) {
       this(new Alphabet(name, alphabetChars.toCharArray()), paddingChar);

--- a/guava/src/com/google/common/io/CharSource.java
+++ b/guava/src/com/google/common/io/CharSource.java
@@ -295,8 +295,7 @@ public abstract class CharSource {
    *
    * @throws IOException if an I/O error occurs while reading from this source
    */
-  @Nullable
-  public String readFirstLine() throws IOException {
+  public @Nullable String readFirstLine() throws IOException {
     Closer closer = Closer.create();
     try {
       BufferedReader reader = closer.register(openBufferedStream());

--- a/guava/src/com/google/common/io/FileBackedOutputStream.java
+++ b/guava/src/com/google/common/io/FileBackedOutputStream.java
@@ -46,7 +46,7 @@ public final class FileBackedOutputStream extends OutputStream {
 
   private OutputStream out;
   private MemoryOutput memory;
-  @Nullable private File file;
+  private @Nullable File file;
 
   /** ByteArrayOutputStream that exposes its internals. */
   private static class MemoryOutput extends ByteArrayOutputStream {

--- a/guava/src/com/google/common/io/LineReader.java
+++ b/guava/src/com/google/common/io/LineReader.java
@@ -39,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @GwtIncompatible
 public final class LineReader {
   private final Readable readable;
-  @Nullable private final Reader reader;
+  private final @Nullable Reader reader;
   private final CharBuffer cbuf = createBuffer();
   private final char[] buf = cbuf.array();
 

--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -611,8 +611,7 @@ public final class MoreFiles {
    * Secure recursive delete using {@code SecureDirectoryStream}. Returns a collection of exceptions
    * that occurred or null if no exceptions were thrown.
    */
-  @Nullable
-  private static Collection<IOException> deleteRecursivelySecure(
+  private static @Nullable Collection<IOException> deleteRecursivelySecure(
       SecureDirectoryStream<Path> dir, Path path) {
     Collection<IOException> exceptions = null;
     try {
@@ -640,8 +639,7 @@ public final class MoreFiles {
    * Secure method for deleting the contents of a directory using {@code SecureDirectoryStream}.
    * Returns a collection of exceptions that occurred or null if no exceptions were thrown.
    */
-  @Nullable
-  private static Collection<IOException> deleteDirectoryContentsSecure(
+  private static @Nullable Collection<IOException> deleteDirectoryContentsSecure(
       SecureDirectoryStream<Path> dir) {
     Collection<IOException> exceptions = null;
     try {
@@ -659,8 +657,7 @@ public final class MoreFiles {
    * Insecure recursive delete for file systems that don't support {@code SecureDirectoryStream}.
    * Returns a collection of exceptions that occurred or null if no exceptions were thrown.
    */
-  @Nullable
-  private static Collection<IOException> deleteRecursivelyInsecure(Path path) {
+  private static @Nullable Collection<IOException> deleteRecursivelyInsecure(Path path) {
     Collection<IOException> exceptions = null;
     try {
       if (Files.isDirectory(path, NOFOLLOW_LINKS)) {
@@ -686,8 +683,7 @@ public final class MoreFiles {
    * support {@code SecureDirectoryStream}. Returns a collection of exceptions that occurred or null
    * if no exceptions were thrown.
    */
-  @Nullable
-  private static Collection<IOException> deleteDirectoryContentsInsecure(
+  private static @Nullable Collection<IOException> deleteDirectoryContentsInsecure(
       DirectoryStream<Path> dir) {
     Collection<IOException> exceptions = null;
     try {
@@ -706,8 +702,7 @@ public final class MoreFiles {
    * path, this is simple. Otherwise, we need to do some trickier things. Returns null if the path
    * is a root or is the empty path.
    */
-  @Nullable
-  private static Path getParentPath(Path path) {
+  private static @Nullable Path getParentPath(Path path) {
     Path parent = path.getParent();
 
     // Paths that have a parent:
@@ -766,8 +761,7 @@ public final class MoreFiles {
    * null, the other collection is returned. Otherwise, the elements of {@code other} are added to
    * {@code exceptions} and {@code exceptions} is returned.
    */
-  @Nullable
-  private static Collection<IOException> concat(
+  private static @Nullable Collection<IOException> concat(
       @Nullable Collection<IOException> exceptions, @Nullable Collection<IOException> other) {
     if (exceptions == null) {
       return other;

--- a/guava/src/com/google/common/io/MultiInputStream.java
+++ b/guava/src/com/google/common/io/MultiInputStream.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class MultiInputStream extends InputStream {
 
   private Iterator<? extends ByteSource> it;
-  @Nullable private InputStream in;
+  private @Nullable InputStream in;
 
   /**
    * Creates a new instance.

--- a/guava/src/com/google/common/io/MultiReader.java
+++ b/guava/src/com/google/common/io/MultiReader.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @GwtIncompatible
 class MultiReader extends Reader {
   private final Iterator<? extends CharSource> it;
-  @Nullable private Reader current;
+  private @Nullable Reader current;
 
   MultiReader(Iterator<? extends CharSource> readers) throws IOException {
     this.it = readers;

--- a/guava/src/com/google/common/primitives/Doubles.java
+++ b/guava/src/com/google/common/primitives/Doubles.java
@@ -682,9 +682,8 @@ public final class Doubles {
    * @since 14.0
    */
   @Beta
-  @Nullable
   @GwtIncompatible // regular expressions
-  public static Double tryParse(String string) {
+  public static @Nullable Double tryParse(String string) {
     if (FLOATING_POINT_PATTERN.matcher(string).matches()) {
       // TODO(lowasser): could be potentially optimized, but only with
       // extensive testing

--- a/guava/src/com/google/common/primitives/Floats.java
+++ b/guava/src/com/google/common/primitives/Floats.java
@@ -649,9 +649,8 @@ public final class Floats {
    * @since 14.0
    */
   @Beta
-  @Nullable
   @GwtIncompatible // regular expressions
-  public static Float tryParse(String string) {
+  public static @Nullable Float tryParse(String string) {
     if (Doubles.FLOATING_POINT_PATTERN.matcher(string).matches()) {
       // TODO(lowasser): could be potentially optimized, but only with
       // extensive testing

--- a/guava/src/com/google/common/primitives/Ints.java
+++ b/guava/src/com/google/common/primitives/Ints.java
@@ -707,8 +707,7 @@ public final class Ints {
    * @since 11.0
    */
   @Beta
-  @Nullable
-  public static Integer tryParse(String string) {
+  public static @Nullable Integer tryParse(String string) {
     return tryParse(string, 10);
   }
 
@@ -732,8 +731,7 @@ public final class Ints {
    * @since 19.0
    */
   @Beta
-  @Nullable
-  public static Integer tryParse(String string, int radix) {
+  public static @Nullable Integer tryParse(String string, int radix) {
     Long result = Longs.tryParse(string, radix);
     if (result == null || result.longValue() != result.intValue()) {
       return null;

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -362,8 +362,7 @@ public final class Longs {
    * @since 14.0
    */
   @Beta
-  @Nullable
-  public static Long tryParse(String string) {
+  public static @Nullable Long tryParse(String string) {
     return tryParse(string, 10);
   }
 
@@ -387,8 +386,7 @@ public final class Longs {
    * @since 19.0
    */
   @Beta
-  @Nullable
-  public static Long tryParse(String string, int radix) {
+  public static @Nullable Long tryParse(String string, int radix) {
     if (checkNotNull(string).isEmpty()) {
       return null;
     }

--- a/guava/src/com/google/common/reflect/MutableTypeToInstanceMap.java
+++ b/guava/src/com/google/common/reflect/MutableTypeToInstanceMap.java
@@ -41,29 +41,25 @@ public final class MutableTypeToInstanceMap<B> extends ForwardingMap<TypeToken<?
 
   private final Map<TypeToken<? extends B>, B> backingMap = Maps.newHashMap();
 
-  @Nullable
   @Override
-  public <T extends B> T getInstance(Class<T> type) {
+  public <T extends B> @Nullable T getInstance(Class<T> type) {
     return trustedGet(TypeToken.of(type));
   }
 
-  @Nullable
   @Override
-  public <T extends B> T getInstance(TypeToken<T> type) {
+  public <T extends B> @Nullable T getInstance(TypeToken<T> type) {
     return trustedGet(type.rejectTypeVariables());
   }
 
-  @Nullable
   @Override
   @CanIgnoreReturnValue
-  public <T extends B> T putInstance(Class<T> type, @Nullable T value) {
+  public <T extends B> @Nullable T putInstance(Class<T> type, @Nullable T value) {
     return trustedPut(TypeToken.of(type), value);
   }
 
-  @Nullable
   @Override
   @CanIgnoreReturnValue
-  public <T extends B> T putInstance(TypeToken<T> type, @Nullable T value) {
+  public <T extends B> @Nullable T putInstance(TypeToken<T> type, @Nullable T value) {
     return trustedPut(type.rejectTypeVariables(), value);
   }
 
@@ -103,14 +99,12 @@ public final class MutableTypeToInstanceMap<B> extends ForwardingMap<TypeToken<?
   }
 
   @SuppressWarnings("unchecked") // value could not get in if not a T
-  @Nullable
-  private <T extends B> T trustedPut(TypeToken<T> type, @Nullable T value) {
+  private <T extends B> @Nullable T trustedPut(TypeToken<T> type, @Nullable T value) {
     return (T) backingMap.put(type, value);
   }
 
   @SuppressWarnings("unchecked") // value could not get in if not a T
-  @Nullable
-  private <T extends B> T trustedGet(TypeToken<T> type) {
+  private <T extends B> @Nullable T trustedGet(TypeToken<T> type) {
     return (T) backingMap.get(type);
   }
 

--- a/guava/src/com/google/common/reflect/Parameter.java
+++ b/guava/src/com/google/common/reflect/Parameter.java
@@ -68,8 +68,7 @@ public final class Parameter implements AnnotatedElement {
   }
 
   @Override
-  @Nullable
-  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+  public <A extends Annotation> @Nullable A getAnnotation(Class<A> annotationType) {
     checkNotNull(annotationType);
     for (Annotation annotation : annotations) {
       if (annotationType.isInstance(annotation)) {
@@ -99,8 +98,7 @@ public final class Parameter implements AnnotatedElement {
 
   /** @since 18.0 */
   // @Override on JDK8
-  @Nullable
-  public <A extends Annotation> A getDeclaredAnnotation(Class<A> annotationType) {
+  public <A extends Annotation> @Nullable A getDeclaredAnnotation(Class<A> annotationType) {
     checkNotNull(annotationType);
     return FluentIterable.from(annotations).filter(annotationType).first().orNull();
   }

--- a/guava/src/com/google/common/reflect/TypeToInstanceMap.java
+++ b/guava/src/com/google/common/reflect/TypeToInstanceMap.java
@@ -49,16 +49,14 @@ public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
    * <p>{@code getInstance(Foo.class)} is equivalent to {@code
    * getInstance(TypeToken.of(Foo.class))}.
    */
-  @Nullable
-  <T extends B> T getInstance(Class<T> type);
+  <T extends B> @Nullable T getInstance(Class<T> type);
 
   /**
    * Returns the value the specified type is mapped to, or {@code null} if no entry for this type is
    * present. This will only return a value that was bound to this specific type, not a value that
    * may have been bound to a subtype.
    */
-  @Nullable
-  <T extends B> T getInstance(TypeToken<T> type);
+  <T extends B> @Nullable T getInstance(TypeToken<T> type);
 
   /**
    * Maps the specified class to the specified value. Does <i>not</i> associate this value with any
@@ -70,9 +68,8 @@ public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
    * @return the value previously associated with this class (possibly {@code null}), or {@code
    *     null} if there was no previous entry.
    */
-  @Nullable
   @CanIgnoreReturnValue
-  <T extends B> T putInstance(Class<T> type, @Nullable T value);
+  <T extends B> @Nullable T putInstance(Class<T> type, @Nullable T value);
 
   /**
    * Maps the specified type to the specified value. Does <i>not</i> associate this value with any
@@ -81,7 +78,6 @@ public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
    * @return the value previously associated with this type (possibly {@code null}), or {@code null}
    *     if there was no previous entry.
    */
-  @Nullable
   @CanIgnoreReturnValue
-  <T extends B> T putInstance(TypeToken<T> type, @Nullable T value);
+  <T extends B> @Nullable T putInstance(TypeToken<T> type, @Nullable T value);
 }

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -289,8 +289,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
    * if the bound is a class or extends from a class. This means that the returned type could be a
    * type variable too.
    */
-  @Nullable
-  final TypeToken<? super T> getGenericSuperclass() {
+  final @Nullable TypeToken<? super T> getGenericSuperclass() {
     if (runtimeType instanceof TypeVariable) {
       // First bound is always the super class, if one exists.
       return boundAsSuperclass(((TypeVariable<?>) runtimeType).getBounds()[0]);
@@ -308,8 +307,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
     return superToken;
   }
 
-  @Nullable
-  private TypeToken<? super T> boundAsSuperclass(Type bound) {
+  private @Nullable TypeToken<? super T> boundAsSuperclass(Type bound) {
     TypeToken<?> token = of(bound);
     if (token.getRawType().isInterface()) {
       return null;
@@ -561,8 +559,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
    * Returns the array component type if this type represents an array ({@code int[]}, {@code T[]},
    * {@code <? extends Map<String, Integer>[]>} etc.), or else {@code null} is returned.
    */
-  @Nullable
-  public final TypeToken<?> getComponentType() {
+  public final @Nullable TypeToken<?> getComponentType() {
     Type componentType = Types.getComponentType(runtimeType);
     if (componentType == null) {
       return null;
@@ -1133,8 +1130,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
    * Returns the owner type of a {@link ParameterizedType} or enclosing class of a {@link Class}, or
    * null otherwise.
    */
-  @Nullable
-  private Type getOwnerTypeIfPresent() {
+  private @Nullable Type getOwnerTypeIfPresent() {
     if (runtimeType instanceof ParameterizedType) {
       return ((ParameterizedType) runtimeType).getOwnerType();
     } else if (runtimeType instanceof Class<?>) {
@@ -1310,8 +1306,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
             return type.getGenericInterfaces();
           }
 
-          @Nullable
           @Override
+          @Nullable
           TypeToken<?> getSuperclass(TypeToken<?> type) {
             return type.getGenericSuperclass();
           }
@@ -1329,8 +1325,8 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
             return Arrays.asList(type.getInterfaces());
           }
 
-          @Nullable
           @Override
+          @Nullable
           Class<?> getSuperclass(Class<?> type) {
             return type.getSuperclass();
           }
@@ -1412,8 +1408,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
 
     abstract Iterable<? extends K> getInterfaces(K type);
 
-    @Nullable
-    abstract K getSuperclass(K type);
+    abstract @Nullable K getSuperclass(K type);
 
     private static class ForwardingTypeCollector<K> extends TypeCollector<K> {
 

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -105,15 +105,15 @@ final class Types {
   /** Decides what owner type to use for constructing {@link ParameterizedType} from a raw class. */
   private enum ClassOwnership {
     OWNED_BY_ENCLOSING_CLASS {
-      @Nullable
       @Override
+      @Nullable
       Class<?> getOwnerType(Class<?> rawType) {
         return rawType.getEnclosingClass();
       }
     },
     LOCAL_CLASS_HAS_NO_OWNER {
-      @Nullable
       @Override
+      @Nullable
       Class<?> getOwnerType(Class<?> rawType) {
         if (rawType.isLocalClass()) {
           return null;
@@ -123,8 +123,7 @@ final class Types {
       }
     };
 
-    @Nullable
-    abstract Class<?> getOwnerType(Class<?> rawType);
+    abstract @Nullable Class<?> getOwnerType(Class<?> rawType);
 
     static final ClassOwnership JVM_BEHAVIOR = detectJvmBehavior();
 
@@ -172,8 +171,7 @@ final class Types {
     return (type instanceof Class) ? ((Class<?>) type).getName() : type.toString();
   }
 
-  @Nullable
-  static Type getComponentType(Type type) {
+  static @Nullable Type getComponentType(Type type) {
     checkNotNull(type);
     final AtomicReference<Type> result = new AtomicReference<>();
     new TypeVisitor() {
@@ -204,8 +202,7 @@ final class Types {
    * Returns {@code ? extends X} if any of {@code bounds} is a subtype of {@code X[]}; or null
    * otherwise.
    */
-  @Nullable
-  private static Type subtypeOfComponentType(Type[] bounds) {
+  private static @Nullable Type subtypeOfComponentType(Type[] bounds) {
     for (Type bound : bounds) {
       Type componentType = getComponentType(bound);
       if (componentType != null) {
@@ -260,7 +257,7 @@ final class Types {
 
   private static final class ParameterizedTypeImpl implements ParameterizedType, Serializable {
 
-    @Nullable private final Type ownerType;
+    private final @Nullable Type ownerType;
     private final ImmutableList<Type> argumentsList;
     private final Class<?> rawType;
 

--- a/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -141,8 +141,7 @@ abstract class AbstractCatchingFuture<V, X extends Throwable, F, T>
 
   /** Template method for subtypes to actually run the fallback. */
   @ForOverride
-  @Nullable
-  abstract T doFallback(F fallback, X throwable) throws Exception;
+  abstract @Nullable T doFallback(F fallback, X throwable) throws Exception;
 
   /** Template method for subtypes to actually set the result. */
   @ForOverride

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -170,8 +170,8 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
   private static final class Waiter {
     static final Waiter TOMBSTONE = new Waiter(false /* ignored param */);
 
-    @Nullable volatile Thread thread;
-    @Nullable volatile Waiter next;
+    volatile @Nullable Thread thread;
+    volatile @Nullable Waiter next;
 
     /**
      * Constructor for the TOMBSTONE, avoids use of ATOMIC_HELPER in case this class is loaded
@@ -293,7 +293,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     }
 
     final boolean wasInterrupted;
-    @Nullable final Throwable cause;
+    final @Nullable Throwable cause;
 
     Cancellation(boolean wasInterrupted, @Nullable Throwable cause) {
       this.wasInterrupted = wasInterrupted;
@@ -341,13 +341,13 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    *       argument.
    * </ul>
    */
-  @Nullable private volatile Object value;
+  private volatile @Nullable Object value;
 
   /** All listeners. */
-  @Nullable private volatile Listener listeners;
+  private volatile @Nullable Listener listeners;
 
   /** All waiting threads. */
-  @Nullable private volatile Waiter waiters;
+  private volatile @Nullable Waiter waiters;
 
   /** Constructor for use by subclasses. */
   protected AbstractFuture() {}
@@ -978,8 +978,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    * @return null if an explanation cannot be provided because the future is done.
    * @since 23.0
    */
-  @Nullable
-  protected String pendingToString() {
+  protected @Nullable String pendingToString() {
     Object localValue = value;
     if (localValue instanceof SetFuture) {
       return "setFuture=[" + userObjectToString(((SetFuture) localValue).future) + "]";

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -466,8 +466,7 @@ public abstract class AbstractScheduledService implements Service {
 
       /** The future that represents the next execution of this task. */
       @GuardedBy("lock")
-      @Nullable
-      private Future<Void> currentFuture;
+      private @Nullable Future<Void> currentFuture;
 
       ReschedulableCallable(
           AbstractService service, ScheduledExecutorService executor, Runnable runnable) {

--- a/guava/src/com/google/common/util/concurrent/AbstractService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractService.java
@@ -551,7 +551,7 @@ public abstract class AbstractService implements Service {
      * The exception that caused this service to fail. This will be {@code null} unless the service
      * has failed.
      */
-    @Nullable final Throwable failure;
+    final @Nullable Throwable failure;
 
     StateSnapshot(State internalState) {
       this(internalState, false, null);

--- a/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
@@ -162,8 +162,7 @@ abstract class AbstractTransformFuture<I, O, F, T> extends AbstractFuture.Truste
 
   /** Template method for subtypes to actually run the transform. */
   @ForOverride
-  @Nullable
-  abstract T doTransform(F function, @Nullable I result) throws Exception;
+  abstract @Nullable T doTransform(F function, @Nullable I result) throws Exception;
 
   /** Template method for subtypes to actually set the result. */
   @ForOverride

--- a/guava/src/com/google/common/util/concurrent/AggregateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AggregateFuture.java
@@ -44,7 +44,7 @@ abstract class AggregateFuture<InputT, OutputT> extends AbstractFuture.TrustedFu
    * In certain circumstances, this field might theoretically not be visible to an afterDone() call
    * triggered by cancel(). For details, see the comments on the fields of TimeoutFuture.
    */
-  @Nullable private RunningState runningState;
+  private @Nullable RunningState runningState;
 
   @Override
   protected final void afterDone() {

--- a/guava/src/com/google/common/util/concurrent/Callables.java
+++ b/guava/src/com/google/common/util/concurrent/Callables.java
@@ -34,7 +34,7 @@ public final class Callables {
   private Callables() {}
 
   /** Creates a {@code Callable} which immediately returns a preset value each time it is called. */
-  public static <T> Callable<T> returning(@Nullable final T value) {
+  public static <T> Callable<T> returning(final @Nullable T value) {
     return new Callable<T>() {
       @Override
       public T call() {

--- a/guava/src/com/google/common/util/concurrent/CycleDetectingLockFactory.java
+++ b/guava/src/com/google/common/util/concurrent/CycleDetectingLockFactory.java
@@ -674,8 +674,7 @@ public class CycleDetectingLockFactory {
      * @return If a path was found, a chained {@link ExampleStackTrace} illustrating the path to the
      *     {@code lock}, or {@code null} if no path was found.
      */
-    @Nullable
-    private ExampleStackTrace findPathTo(LockGraphNode node, Set<LockGraphNode> seen) {
+    private @Nullable ExampleStackTrace findPathTo(LockGraphNode node, Set<LockGraphNode> seen) {
       if (!seen.add(this)) {
         return null; // Already traversed this node.
       }

--- a/guava/src/com/google/common/util/concurrent/ExecutionList.java
+++ b/guava/src/com/google/common/util/concurrent/ExecutionList.java
@@ -49,8 +49,7 @@ public final class ExecutionList {
    * RunnableExecutorPair#next} field.
    */
   @GuardedBy("this")
-  @Nullable
-  private RunnableExecutorPair runnables;
+  private @Nullable RunnableExecutorPair runnables;
 
   @GuardedBy("this")
   private boolean executed;

--- a/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
+++ b/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
@@ -257,8 +257,7 @@ final class FuturesGetChecked {
               })
           .reverse();
 
-  @Nullable
-  private static <X> X newFromConstructor(Constructor<X> constructor, Throwable cause) {
+  private static <X> @Nullable X newFromConstructor(Constructor<X> constructor, Throwable cause) {
     Class<?>[] paramTypes = constructor.getParameterTypes();
     Object[] params = new Object[paramTypes.length];
     for (int i = 0; i < paramTypes.length; i++) {

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -73,7 +73,7 @@ abstract class ImmediateFuture<V> extends FluentFuture<V> {
 
   static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
     static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
-    @Nullable private final V value;
+    private final @Nullable V value;
 
     ImmediateSuccessfulFuture(@Nullable V value) {
       this.value = value;
@@ -95,7 +95,7 @@ abstract class ImmediateFuture<V> extends FluentFuture<V> {
   @GwtIncompatible // TODO
   static class ImmediateSuccessfulCheckedFuture<V, X extends Exception> extends ImmediateFuture<V>
       implements CheckedFuture<V, X> {
-    @Nullable private final V value;
+    private final @Nullable V value;
 
     ImmediateSuccessfulCheckedFuture(@Nullable V value) {
       this.value = value;

--- a/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
+++ b/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
@@ -70,8 +70,8 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
    * write-barriers).
    */
 
-  @Nullable private ListenableFuture<V> delegateRef;
-  @Nullable private Future<?> timer;
+  private @Nullable ListenableFuture<V> delegateRef;
+  private @Nullable Future<?> timer;
 
   private TimeoutFuture(ListenableFuture<V> delegate) {
     this.delegateRef = Preconditions.checkNotNull(delegate);


### PR DESCRIPTION
To improve readability, the Java Language Specification recommends that type annotations are written "immediately before the type to which they apply" (https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7.4).  This pull request makes Guava conform to that style guideline.