### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/benchmark/com/google/common/base/WhitespaceMatcherBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/base/WhitespaceMatcherBenchmark.java
@@ -19,7 +19,6 @@ package com.google.common.base;
 import com.google.caliper.BeforeExperiment;
 import com.google.caliper.Benchmark;
 import com.google.caliper.Param;
-import com.google.caliper.runner.CaliperMain;
 import java.util.BitSet;
 import java.util.Random;
 
@@ -50,10 +49,6 @@ public class WhitespaceMatcherBenchmark {
 
   private String teststring;
   private CharMatcher matcher;
-
-  public static void main(String[] args) throws Exception {
-    CaliperMain.main(WhitespaceMatcherBenchmark.class, new String[] {});
-  }
 
   @BeforeExperiment
   protected void setUp() {

--- a/guava-tests/benchmark/com/google/common/base/WhitespaceMatcherBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/base/WhitespaceMatcherBenchmark.java
@@ -19,7 +19,6 @@ package com.google.common.base;
 import com.google.caliper.BeforeExperiment;
 import com.google.caliper.Benchmark;
 import com.google.caliper.Param;
-import com.google.caliper.runner.CaliperMain;
 import java.util.BitSet;
 import java.util.Random;
 
@@ -50,10 +49,6 @@ public class WhitespaceMatcherBenchmark {
 
   private String teststring;
   private CharMatcher matcher;
-
-  public static void main(String[] args) throws Exception {
-    CaliperMain.main(WhitespaceMatcherBenchmark.class, new String[] {});
-  }
 
   @BeforeExperiment
   protected void setUp() {

--- a/guava-tests/test/com/google/common/eventbus/PackageSanityTests.java
+++ b/guava-tests/test/com/google/common/eventbus/PackageSanityTests.java
@@ -18,7 +18,7 @@ package com.google.common.eventbus;
 
 import com.google.common.testing.AbstractPackageSanityTests;
 import java.lang.reflect.Method;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Basic sanity tests for the entire package.
@@ -41,7 +41,7 @@ public class PackageSanityTests extends AbstractPackageSanityTests {
     private final EventBus eventBus = new EventBus();
 
     @Subscribe
-    public void handle(@NullableDecl Object anything) {}
+    public void handle(@Nullable Object anything) {}
 
     Subscriber toSubscriber() throws Exception {
       return Subscriber.create(eventBus, this, subscriberMethod());

--- a/guava-tests/test/com/google/common/eventbus/StringCatcher.java
+++ b/guava-tests/test/com/google/common/eventbus/StringCatcher.java
@@ -19,7 +19,7 @@ package com.google.common.eventbus;
 import com.google.common.collect.Lists;
 import java.util.List;
 import junit.framework.Assert;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A simple EventSubscriber mock that records Strings.
@@ -33,11 +33,11 @@ public class StringCatcher {
   private List<String> events = Lists.newArrayList();
 
   @Subscribe
-  public void hereHaveAString(@NullableDecl String string) {
+  public void hereHaveAString(@Nullable String string) {
     events.add(string);
   }
 
-  public void methodWithoutAnnotation(@NullableDecl String string) {
+  public void methodWithoutAnnotation(@Nullable String string) {
     Assert.fail("Event bus must not call methods without @Subscribe!");
   }
 

--- a/guava/src/com/google/common/escape/ArrayBasedUnicodeEscaper.java
+++ b/guava/src/com/google/common/escape/ArrayBasedUnicodeEscaper.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import java.util.Map;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A {@link UnicodeEscaper} that uses an array to quickly look up replacement characters for a given
@@ -73,7 +73,7 @@ public abstract class ArrayBasedUnicodeEscaper extends UnicodeEscaper {
       Map<Character, String> replacementMap,
       int safeMin,
       int safeMax,
-      @NullableDecl String unsafeReplacement) {
+      @Nullable String unsafeReplacement) {
     this(ArrayBasedEscaperMap.create(replacementMap), safeMin, safeMax, unsafeReplacement);
   }
 
@@ -96,7 +96,7 @@ public abstract class ArrayBasedUnicodeEscaper extends UnicodeEscaper {
       ArrayBasedEscaperMap escaperMap,
       int safeMin,
       int safeMax,
-      @NullableDecl String unsafeReplacement) {
+      @Nullable String unsafeReplacement) {
     checkNotNull(escaperMap); // GWT specific check (do not optimize)
     this.replacements = escaperMap.getReplacementArray();
     this.replacementsLength = replacements.length;

--- a/guava/src/com/google/common/escape/Escapers.java
+++ b/guava/src/com/google/common/escape/Escapers.java
@@ -21,7 +21,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashMap;
 import java.util.Map;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Static utility methods pertaining to {@link Escaper} instances.
@@ -125,7 +125,7 @@ public final class Escapers {
      * @return the builder instance
      */
     @CanIgnoreReturnValue
-    public Builder setUnsafeReplacement(@NullableDecl String unsafeReplacement) {
+    public Builder setUnsafeReplacement(@Nullable String unsafeReplacement) {
       this.unsafeReplacement = unsafeReplacement;
       return this;
     }

--- a/guava/src/com/google/common/eventbus/Subscriber.java
+++ b/guava/src/com/google/common/eventbus/Subscriber.java
@@ -21,7 +21,7 @@ import com.google.j2objc.annotations.Weak;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A subscriber method on a specific object, plus the executor that should be used for dispatching
@@ -108,7 +108,7 @@ class Subscriber {
   }
 
   @Override
-  public final boolean equals(@NullableDecl Object obj) {
+  public final boolean equals(@Nullable Object obj) {
     if (obj instanceof Subscriber) {
       Subscriber that = (Subscriber) obj;
       // Use == so that different equal instances will still receive events.

--- a/guava/src/com/google/common/eventbus/SubscriberRegistry.java
+++ b/guava/src/com/google/common/eventbus/SubscriberRegistry.java
@@ -44,7 +44,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Registry of subscribers to a single event bus.
@@ -242,7 +242,7 @@ final class SubscriberRegistry {
     }
 
     @Override
-    public boolean equals(@NullableDecl Object o) {
+    public boolean equals(@Nullable Object o) {
       if (o instanceof MethodIdentifier) {
         MethodIdentifier ident = (MethodIdentifier) o;
         return name.equals(ident.name) && parameterTypes.equals(ident.parameterTypes);

--- a/guava/src/com/google/common/net/HostAndPort.java
+++ b/guava/src/com/google/common/net/HostAndPort.java
@@ -24,7 +24,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.Immutable;
 import java.io.Serializable;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An immutable representation of a host and port.
@@ -277,7 +277,7 @@ public final class HostAndPort implements Serializable {
   }
 
   @Override
-  public boolean equals(@NullableDecl Object other) {
+  public boolean equals(@Nullable Object other) {
     if (this == other) {
       return true;
     }

--- a/guava/src/com/google/common/net/HostSpecifier.java
+++ b/guava/src/com/google/common/net/HostSpecifier.java
@@ -19,7 +19,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Preconditions;
 import java.net.InetAddress;
 import java.text.ParseException;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A syntactically valid host specifier, suitable for use in a URI. This may be either a numeric IP
@@ -137,7 +137,7 @@ public final class HostSpecifier {
   }
 
   @Override
-  public boolean equals(@NullableDecl Object other) {
+  public boolean equals(@Nullable Object other) {
     if (this == other) {
       return true;
     }

--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -33,7 +33,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Static utility methods pertaining to {@link InetAddress} instances.
@@ -157,8 +157,7 @@ public final class InetAddresses {
     return ipStringToBytes(ipString) != null;
   }
 
-  @NullableDecl
-  private static byte[] ipStringToBytes(String ipString) {
+  private static byte @Nullable [] ipStringToBytes(String ipString) {
     // Make a first pass to categorize the characters in this string.
     boolean hasColon = false;
     boolean hasDot = false;
@@ -191,8 +190,7 @@ public final class InetAddresses {
     return null;
   }
 
-  @NullableDecl
-  private static byte[] textToNumericFormatV4(String ipString) {
+  private static byte @Nullable [] textToNumericFormatV4(String ipString) {
     byte[] bytes = new byte[IPV4_PART_COUNT];
     int i = 0;
     try {
@@ -206,8 +204,7 @@ public final class InetAddresses {
     return i == IPV4_PART_COUNT ? bytes : null;
   }
 
-  @NullableDecl
-  private static byte[] textToNumericFormatV6(String ipString) {
+  private static byte @Nullable [] textToNumericFormatV6(String ipString) {
     // An address can have [2..8] colons, and N colons make N+1 parts.
     List<String> parts = IPV6_SPLITTER.splitToList(ipString);
     if (parts.size() < 3 || parts.size() > IPV6_PART_COUNT + 1) {
@@ -270,8 +267,7 @@ public final class InetAddresses {
     return rawBytes.array();
   }
 
-  @NullableDecl
-  private static String convertDottedQuadToHex(String ipString) {
+  private static @Nullable String convertDottedQuadToHex(String ipString) {
     int lastColon = ipString.lastIndexOf(':');
     String initialPart = ipString.substring(0, lastColon + 1);
     String dottedQuad = ipString.substring(lastColon + 1);
@@ -465,8 +461,7 @@ public final class InetAddresses {
     return addr;
   }
 
-  @NullableDecl
-  private static InetAddress forUriStringNoThrow(String hostAddr) {
+  private static @Nullable InetAddress forUriStringNoThrow(String hostAddr) {
     checkNotNull(hostAddr);
 
     // Decide if this should be an IPv6 or IPv4 address.
@@ -609,7 +604,7 @@ public final class InetAddresses {
      */
     // TODO: why is this public?
     public TeredoInfo(
-        @NullableDecl Inet4Address server, @NullableDecl Inet4Address client, int port, int flags) {
+        @Nullable Inet4Address server, @Nullable Inet4Address client, int port, int flags) {
       checkArgument(
           (port >= 0) && (port <= 0xffff), "port '%s' is out of range (0 <= port <= 0xffff)", port);
       checkArgument(

--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -30,7 +30,7 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.thirdparty.publicsuffix.PublicSuffixPatterns;
 import com.google.thirdparty.publicsuffix.PublicSuffixType;
 import java.util.List;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An immutable well-formed internet domain name, such as {@code com} or {@code foo.co.uk}. Only
@@ -617,7 +617,7 @@ public final class InternetDomainName {
    * version of the same domain name would not be considered equal.
    */
   @Override
-  public boolean equals(@NullableDecl Object object) {
+  public boolean equals(@Nullable Object object) {
     if (object == this) {
       return true;
     }

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -45,7 +45,7 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents an <a href="http://en.wikipedia.org/wiki/Internet_media_type">Internet Media Type</a>
@@ -908,7 +908,7 @@ public final class MediaType {
   }
 
   @Override
-  public boolean equals(@NullableDecl Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     } else if (obj instanceof MediaType) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Continue migrating to type annotations for @Nullable

RELNOTES=N/A

f642763e15c2814c2ed6208fb7302235d6518829

-------

<p> Remove usages of CaliperMain from java_benchmarks targets since the deps for java_benchmarks don't need to (and shouldn't) include CaliperMain anymore.

Such benchmarks should be run via the java_benchmarks generated binary directly.

GITHUB_BREAKING_CHANGES=n/a

84d45bc4e1a9b2a87256e30374c517fed329dcae