### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/base/Strings.java
+++ b/android/guava/src/com/google/common/base/Strings.java
@@ -213,15 +213,29 @@ public final class Strings {
   }
 
   /**
+   * True when a valid surrogate pair starts at the given {@code index} in the given {@code string}.
+   * Out-of-range indexes return false.
+   */
+  @VisibleForTesting
+  static boolean validSurrogatePairAt(CharSequence string, int index) {
+    return index >= 0
+        && index <= (string.length() - 2)
+        && Character.isHighSurrogate(string.charAt(index))
+        && Character.isLowSurrogate(string.charAt(index + 1));
+  }
+
+  /**
    * Returns the given {@code template} string with each occurrence of {@code "%s"} replaced with
    * the corresponding argument value from {@code args}; or, if the placeholder and argument counts
    * do not match, returns a best-effort form of that string. Will not throw an exception under
    * normal conditions.
    *
-   * <p><b>Note:</b> For most string-formatting needs, use {@link String#format}, {@link
-   * PrintWriter#format}, and related methods. These support the full range of {@linkplain
-   * Formatter#syntax format specifiers}, and alert you to usage errors by throwing {@link
-   * InvalidFormatException}.
+   * <p><b>Note:</b> For most string-formatting needs, use {@link String#format String.format},
+   * {@link java.io.PrintWriter#format PrintWriter.format}, and related methods. These support the
+   * full range of <a
+   * href="https://docs.oracle.com/javase/9/docs/api/java/util/Formatter.html#syntax">format
+   * specifiers</a>, and alert you to usage errors by throwing {@link
+   * java.util.IllegalFormatException}.
    *
    * <p>In certain cases, such as outputting debugging information or constructing a message to be
    * used for another unchecked exception, an exception during string formatting would serve little
@@ -295,17 +309,5 @@ public final class Strings {
           .log(WARNING, "Exception during lenientFormat for " + objectToString, e);
       return "<" + objectToString + " threw " + e.getClass().getName() + ">";
     }
-  }
-
-  /**
-   * True when a valid surrogate pair starts at the given {@code index} in the given {@code string}.
-   * Out-of-range indexes return false.
-   */
-  @VisibleForTesting
-  static boolean validSurrogatePairAt(CharSequence string, int index) {
-    return index >= 0
-        && index <= (string.length() - 2)
-        && Character.isHighSurrogate(string.charAt(index))
-        && Character.isLowSurrogate(string.charAt(index + 1));
   }
 }

--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -95,6 +95,10 @@
       <classifier>gwt</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/guava/src/com/google/common/base/Strings.java
+++ b/guava/src/com/google/common/base/Strings.java
@@ -212,15 +212,29 @@ public final class Strings {
   }
 
   /**
+   * True when a valid surrogate pair starts at the given {@code index} in the given {@code string}.
+   * Out-of-range indexes return false.
+   */
+  @VisibleForTesting
+  static boolean validSurrogatePairAt(CharSequence string, int index) {
+    return index >= 0
+        && index <= (string.length() - 2)
+        && Character.isHighSurrogate(string.charAt(index))
+        && Character.isLowSurrogate(string.charAt(index + 1));
+  }
+
+  /**
    * Returns the given {@code template} string with each occurrence of {@code "%s"} replaced with
    * the corresponding argument value from {@code args}; or, if the placeholder and argument counts
    * do not match, returns a best-effort form of that string. Will not throw an exception under
    * normal conditions.
    *
-   * <p><b>Note:</b> For most string-formatting needs, use {@link String#format}, {@link
-   * PrintWriter#format}, and related methods. These support the full range of {@linkplain
-   * Formatter#syntax format specifiers}, and alert you to usage errors by throwing {@link
-   * InvalidFormatException}.
+   * <p><b>Note:</b> For most string-formatting needs, use {@link String#format String.format},
+   * {@link java.io.PrintWriter#format PrintWriter.format}, and related methods. These support the
+   * full range of <a
+   * href="https://docs.oracle.com/javase/9/docs/api/java/util/Formatter.html#syntax">format
+   * specifiers</a>, and alert you to usage errors by throwing {@link
+   * java.util.IllegalFormatException}.
    *
    * <p>In certain cases, such as outputting debugging information or constructing a message to be
    * used for another unchecked exception, an exception during string formatting would serve little
@@ -295,17 +309,5 @@ public final class Strings {
           .log(WARNING, "Exception during lenientFormat for " + objectToString, e);
       return "<" + objectToString + " threw " + e.getClass().getName() + ">";
     }
-  }
-
-  /**
-   * True when a valid surrogate pair starts at the given {@code index} in the given {@code string}.
-   * Out-of-range indexes return false.
-   */
-  @VisibleForTesting
-  static boolean validSurrogatePairAt(CharSequence string, int index) {
-    return index >= 0
-        && index <= (string.length() - 2)
-        && Character.isHighSurrogate(string.charAt(index))
-        && Character.isLowSurrogate(string.charAt(index + 1));
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a direct dependency from guava-gwt to checker-qual.

The GWT sources (specifically, GwtSerializationDependencies) use @Nullable directly, so we shouldn't rely on relying on it indirectly through guava-jre.

However, what actually prompted this is a strange behavior in Compile-Testing, which Truth uses. This CL should help, though it might not be a fully solution.
https://github.com/google/compile-testing/issues/149

5cb6f0a87d75c6b3cd6c79c31d66e3a28620101d

-------

<p> Fix mangled Javadocs.

5928882017809a1d0e57bd1b55dd6abdcf5604d0