### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/net/HostAndPortTest.java
+++ b/android/guava-tests/test/com/google/common/net/HostAndPortTest.java
@@ -193,15 +193,19 @@ public class HostAndPortTest extends TestCase {
   }
 
   public void testHashCodeAndEquals() {
-    HostAndPort hp1 = HostAndPort.fromString("foo::123");
-    HostAndPort hp2 = HostAndPort.fromString("foo::123");
-    HostAndPort hp3 = HostAndPort.fromString("[foo::123]");
-    HostAndPort hp4 = HostAndPort.fromParts("[foo::123]", 80);
-    HostAndPort hp5 = HostAndPort.fromString("[foo::123]:80");
+    HostAndPort hpNoPort1 = HostAndPort.fromString("foo::123");
+    HostAndPort hpNoPort2 = HostAndPort.fromString("foo::123");
+    HostAndPort hpNoPort3 = HostAndPort.fromString("[foo::123]");
+    HostAndPort hpNoPort4 = HostAndPort.fromHost("[foo::123]");
+    HostAndPort hpNoPort5 = HostAndPort.fromHost("foo::123");
+
+    HostAndPort hpWithPort1 = HostAndPort.fromParts("[foo::123]", 80);
+    HostAndPort hpWithPort2 = HostAndPort.fromParts("foo::123", 80);
+    HostAndPort hpWithPort3 = HostAndPort.fromString("[foo::123]:80");
+
     new EqualsTester()
-        .addEqualityGroup(hp1, hp2)
-        .addEqualityGroup(hp3)
-        .addEqualityGroup(hp4, hp5)
+        .addEqualityGroup(hpNoPort1, hpNoPort2, hpNoPort3, hpNoPort4, hpNoPort5)
+        .addEqualityGroup(hpWithPort1, hpWithPort2, hpWithPort3)
         .testEquals();
   }
 

--- a/android/guava/src/com/google/common/net/HostAndPort.java
+++ b/android/guava/src/com/google/common/net/HostAndPort.java
@@ -283,16 +283,14 @@ public final class HostAndPort implements Serializable {
     }
     if (other instanceof HostAndPort) {
       HostAndPort that = (HostAndPort) other;
-      return Objects.equal(this.host, that.host)
-          && this.port == that.port
-          && this.hasBracketlessColons == that.hasBracketlessColons;
+      return Objects.equal(this.host, that.host) && this.port == that.port;
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(host, port, hasBracketlessColons);
+    return Objects.hashCode(host, port);
   }
 
   /** Rebuild the host:port string, including brackets if necessary. */

--- a/guava-tests/test/com/google/common/net/HostAndPortTest.java
+++ b/guava-tests/test/com/google/common/net/HostAndPortTest.java
@@ -193,15 +193,19 @@ public class HostAndPortTest extends TestCase {
   }
 
   public void testHashCodeAndEquals() {
-    HostAndPort hp1 = HostAndPort.fromString("foo::123");
-    HostAndPort hp2 = HostAndPort.fromString("foo::123");
-    HostAndPort hp3 = HostAndPort.fromString("[foo::123]");
-    HostAndPort hp4 = HostAndPort.fromParts("[foo::123]", 80);
-    HostAndPort hp5 = HostAndPort.fromString("[foo::123]:80");
+    HostAndPort hpNoPort1 = HostAndPort.fromString("foo::123");
+    HostAndPort hpNoPort2 = HostAndPort.fromString("foo::123");
+    HostAndPort hpNoPort3 = HostAndPort.fromString("[foo::123]");
+    HostAndPort hpNoPort4 = HostAndPort.fromHost("[foo::123]");
+    HostAndPort hpNoPort5 = HostAndPort.fromHost("foo::123");
+
+    HostAndPort hpWithPort1 = HostAndPort.fromParts("[foo::123]", 80);
+    HostAndPort hpWithPort2 = HostAndPort.fromParts("foo::123", 80);
+    HostAndPort hpWithPort3 = HostAndPort.fromString("[foo::123]:80");
+
     new EqualsTester()
-        .addEqualityGroup(hp1, hp2)
-        .addEqualityGroup(hp3)
-        .addEqualityGroup(hp4, hp5)
+        .addEqualityGroup(hpNoPort1, hpNoPort2, hpNoPort3, hpNoPort4, hpNoPort5)
+        .addEqualityGroup(hpWithPort1, hpWithPort2, hpWithPort3)
         .testEquals();
   }
 

--- a/guava/src/com/google/common/net/HostAndPort.java
+++ b/guava/src/com/google/common/net/HostAndPort.java
@@ -283,16 +283,14 @@ public final class HostAndPort implements Serializable {
     }
     if (other instanceof HostAndPort) {
       HostAndPort that = (HostAndPort) other;
-      return Objects.equal(this.host, that.host)
-          && this.port == that.port
-          && this.hasBracketlessColons == that.hasBracketlessColons;
+      return Objects.equal(this.host, that.host) && this.port == that.port;
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(host, port, hasBracketlessColons);
+    return Objects.hashCode(host, port);
   }
 
   /** Rebuild the host:port string, including brackets if necessary. */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change HostAndPort equals() and hashCode() to stop depending on whether brackets were included

Now they depend only on host and port.

Useful for storing IPv6 addresses in Set and Map

RELNOTES=`net.HostAndPort`: Changed equals() and hashCode() to stop depending on whether brackets were included. Now they depend only on host and port.

6684d0f68ae91d41eac67873d87e13e2ae2b1db0