### PR TITLE
Joiner returned from skipNulls() now returns this from an override of skipNulls()

### DIFF
--- a/android/guava/src/com/google/common/base/Joiner.java
+++ b/android/guava/src/com/google/common/base/Joiner.java
@@ -272,6 +272,11 @@ public class Joiner {
       }
 
       @Override
+      public Joiner skipNulls() {
+        return this;
+      }
+
+      @Override
       public MapJoiner withKeyValueSeparator(String kvs) {
         throw new UnsupportedOperationException("can't use .skipNulls() with maps");
       }

--- a/guava/src/com/google/common/base/Joiner.java
+++ b/guava/src/com/google/common/base/Joiner.java
@@ -268,6 +268,11 @@ public class Joiner {
       }
 
       @Override
+      public Joiner skipNulls() {
+        return this;
+      }
+
+      @Override
       public MapJoiner withKeyValueSeparator(String kvs) {
         throw new UnsupportedOperationException("can't use .skipNulls() with maps");
       }


### PR DESCRIPTION
`Joiner` returned from `skipNulls()` now returns `this` from an override of `skipNulls()`.

This prevents creating additional anonymous inner class `Joiner`s on subsequent calls to `skipNulls()`.

Such calls are probably rare, but, given that each new anonymous inner class `Joiner` instance will keep a reference to its parent, it's best to minimize the number of these instantiations in any ways possible.