### PR TITLE
Change ImmutableSet.Builder to keep overflow hashtables and only deduplicate within table to improve performance

### DIFF
--- a/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
@@ -309,6 +309,18 @@ public class ImmutableSetTest extends AbstractImmutableSetTest {
         .expectCollects(ImmutableSet.of("a", "b", "c", "d"), "a", "b", "a", "c", "b", "b", "d");
   }
 
+  public void testCombineBuilders() {
+    Builder<Integer> builder1 = ImmutableSet.builder();
+    for (int i = 0; i < 100; i++) {
+      builder1.add(i);
+    }
+    Builder<Integer> builder2 = ImmutableSet.builder();
+    for (int i = 100; i < 200; i++) {
+      builder2.add(i);
+    }
+    assertEquals(200, builder1.combine(builder2).build().size());
+  }
+
   public void testToImmutableSet_duplicates() {
     class TypeWithDuplicates {
       final int a;


### PR DESCRIPTION
This fixes #3223 

Building large sets in ImmutableSet.RegularSetBuilderImpl regressed with change mentioned in the issue, with a slightly gain over the original performance.

Instead of deduplicating all elements and rehashing when table needs to expand, we keep a list of overflow tables, and only deduplicate within each hashtable. This saves work from consistently rehashing elements while still allowing deduplication of elements as they come.

JMH benchmarks results (Note: small set is 3 distinct elements, large set is 1000000 insertions, 500000 distinct elements, elements are Integers, building is `add()` and `build()` operations)

testname | Without Regression: | With Regression | With this change
----------|---------------------|------------------|------------------
addAndBuildSmallSet | 12315677.054 ±  690237.444  ops/s | 14177773.234 ± 1175789.157  ops/s  ops/s | 12664284.533 ± 1089245.357  ops/s
addAndBuildLargeSet | 17.900 ± 1.522  ops/s |  11.184 ± 1.794  ops/s | 19.312 ± 2.329  ops/s

https://gist.github.com/bobyangyf/05189f515d37b6c3a471ff1659024e12