### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -15,7 +15,6 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.Futures.getDone;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -966,7 +965,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
       }
       // The future may complete during or before the call to getPendingToString, so we use null
       // as a signal that we should try checking if the future is done again.
-      if (!isNullOrEmpty(pendingDescription)) {
+      if (pendingDescription != null && !pendingDescription.isEmpty()) {
         builder.append("PENDING, info=[").append(pendingDescription).append("]");
       } else if (isDone()) {
         addDoneString(builder);

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -841,7 +841,8 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     while (true) {
       future.releaseWaiters();
       // We call this before the listeners in order to avoid needing to manage a separate stack data
-      // structure for them.
+      // structure for them.  Also, some implementations rely on this running prior to listeners
+      // so that the cleanup work is visible to listeners.
       // afterDone() should be generally fast and only used for cleanup work... but in theory can
       // also be recursive and create StackOverflowErrors
       future.afterDone();

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.Futures.getDone;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 import com.google.common.annotations.Beta;
@@ -764,7 +763,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         // the listener is responsible for calling completeWithFuture, directExecutor is appropriate
         // since all we are doing is unpacking a completed future which should be fast.
         try {
-          future.addListener(valueToSet, directExecutor());
+          future.addListener(valueToSet, DirectExecutor.INSTANCE);
         } catch (Throwable t) {
           // addListener has thrown an exception! SetFuture.run can't throw any exceptions so this
           // must have been caused by addListener itself. The most likely explanation is a

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -71,10 +71,17 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
+   * Tag interface marking trusted subclasses. This enables some optimizations.
+   * The implementation of this interface must also be an AbstractureFuture and
+   * must not override or expose for overriding all the public methods of ListenableFuture.
+   * */
+  interface Trusted<V> extends ListenableFuture<V> {}
+
+  /**
    * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
    * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
    */
-  abstract static class TrustedFuture<V> extends AbstractFuture<V> {
+  abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
     @CanIgnoreReturnValue
     @Override
     public final V get() throws InterruptedException, ExecutionException {
@@ -590,7 +597,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             // propagate cancellation to the future set in setfuture, this is racy, and we don't
             // care if we are successful or not.
             ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-            if (futureToPropagateTo instanceof TrustedFuture) {
+            if (futureToPropagateTo instanceof Trusted) {
               // If the future is a TrustedFuture then we specifically avoid calling cancel()
               // this has 2 benefits
               // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -797,7 +804,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
     Object valueToSet;
-    if (future instanceof TrustedFuture) {
+    if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
       // and unpacking the exceptions like we do below (just much faster because it is a single

--- a/android/guava/src/com/google/common/util/concurrent/DirectExecutor.java
+++ b/android/guava/src/com/google/common/util/concurrent/DirectExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.concurrent.Executor;
+
+/**
+ * An {@link Executor} that runs each task in the thread that invokes {@link Executor#execute
+ * execute}.
+ */
+@GwtCompatible
+enum DirectExecutor implements Executor {
+  INSTANCE;
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+
+  @Override
+  public String toString() {
+    return "MoreExecutors.directExecutor()";
+  }
+}

--- a/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -25,6 +25,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.DirectExecutor;
 import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -387,21 +388,6 @@ public final class MoreExecutors {
    */
   public static Executor directExecutor() {
     return DirectExecutor.INSTANCE;
-  }
-
-  /** See {@link #directExecutor} for behavioral notes. */
-  private enum DirectExecutor implements Executor {
-    INSTANCE;
-
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
-
-    @Override
-    public String toString() {
-      return "MoreExecutors.directExecutor()";
-    }
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -18,11 +18,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.Futures.getDone;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.util.concurrent.DirectExecutor;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.j2objc.annotations.ReflectionSupport;
@@ -764,7 +764,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         // the listener is responsible for calling completeWithFuture, directExecutor is appropriate
         // since all we are doing is unpacking a completed future which should be fast.
         try {
-          future.addListener(valueToSet, directExecutor());
+          future.addListener(valueToSet, DirectExecutor.INSTANCE);
         } catch (Throwable t) {
           // addListener has thrown an exception! SetFuture.run can't throw any exceptions so this
           // must have been caused by addListener itself. The most likely explanation is a

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -15,7 +15,6 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.Futures.getDone;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -967,7 +966,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
       }
       // The future may complete during or before the call to getPendingToString, so we use null
       // as a signal that we should try checking if the future is done again.
-      if (!isNullOrEmpty(pendingDescription)) {
+      if (pendingDescription != null && !pendingDescription.isEmpty()) {
         builder.append("PENDING, info=[").append(pendingDescription).append("]");
       } else if (isDone()) {
         addDoneString(builder);

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.util.concurrent.DirectExecutor;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.j2objc.annotations.ReflectionSupport;
@@ -71,17 +72,10 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
-   * Tag interface marking trusted subclasses. This enables some optimizations.
-   * The implementation of this interface must also be an AbstractureFuture and
-   * must not override or expose for overriding all the public methods of ListenableFuture.
-   * */
-  interface Trusted<V> extends ListenableFuture<V> {}
-
-  /**
    * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
    * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
    */
-  abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
+  abstract static class TrustedFuture<V> extends AbstractFuture<V> {
     @CanIgnoreReturnValue
     @Override
     public final V get() throws InterruptedException, ExecutionException {
@@ -597,7 +591,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             // propagate cancellation to the future set in setfuture, this is racy, and we don't
             // care if we are successful or not.
             ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-            if (futureToPropagateTo instanceof Trusted) {
+            if (futureToPropagateTo instanceof TrustedFuture) {
               // If the future is a TrustedFuture then we specifically avoid calling cancel()
               // this has 2 benefits
               // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -804,7 +798,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
     Object valueToSet;
-    if (future instanceof Trusted) {
+    if (future instanceof TrustedFuture) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
       // and unpacking the exceptions like we do below (just much faster because it is a single

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -21,7 +21,6 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.util.concurrent.DirectExecutor;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.j2objc.annotations.ReflectionSupport;
@@ -72,10 +71,17 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
+   * Tag interface marking trusted subclasses. This enables some optimizations.
+   * The implementation of this interface must also be an AbstractureFuture and
+   * must not override or expose for overriding all the public methods of ListenableFuture.
+   * */
+  interface Trusted<V> extends ListenableFuture<V> {}
+
+  /**
    * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
    * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
    */
-  abstract static class TrustedFuture<V> extends AbstractFuture<V> {
+  abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
     @CanIgnoreReturnValue
     @Override
     public final V get() throws InterruptedException, ExecutionException {
@@ -591,7 +597,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             // propagate cancellation to the future set in setfuture, this is racy, and we don't
             // care if we are successful or not.
             ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-            if (futureToPropagateTo instanceof TrustedFuture) {
+            if (futureToPropagateTo instanceof Trusted) {
               // If the future is a TrustedFuture then we specifically avoid calling cancel()
               // this has 2 benefits
               // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -798,7 +804,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
     Object valueToSet;
-    if (future instanceof TrustedFuture) {
+    if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
       // and unpacking the exceptions like we do below (just much faster because it is a single

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -29,6 +29,7 @@ import com.google.j2objc.annotations.ReflectionSupport;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -40,7 +41,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.Locale;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -841,7 +841,8 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     while (true) {
       future.releaseWaiters();
       // We call this before the listeners in order to avoid needing to manage a separate stack data
-      // structure for them.
+      // structure for them.  Also, some implementations rely on this running prior to listeners
+      // so that the cleanup work is visible to listeners.
       // afterDone() should be generally fast and only used for cleanup work... but in theory can
       // also be recursive and create StackOverflowErrors
       future.afterDone();

--- a/guava/src/com/google/common/util/concurrent/DirectExecutor.java
+++ b/guava/src/com/google/common/util/concurrent/DirectExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.concurrent.Executor;
+
+/**
+ * An {@link Executor} that runs each task in the thread that invokes {@link Executor#execute
+ * execute}.
+ */
+@GwtCompatible
+enum DirectExecutor implements Executor {
+  INSTANCE;
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+
+  @Override
+  public String toString() {
+    return "MoreExecutors.directExecutor()";
+  }
+}

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -25,6 +25,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.DirectExecutor;
 import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -387,21 +388,6 @@ public final class MoreExecutors {
    */
   public static Executor directExecutor() {
     return DirectExecutor.INSTANCE;
-  }
-
-  /** See {@link #directExecutor} for behavioral notes. */
-  private enum DirectExecutor implements Executor {
-    INSTANCE;
-
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
-
-    @Override
-    public String toString() {
-      return "MoreExecutors.directExecutor()";
-    }
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a note about the relative ordering of afterDone and listener execution

25ab9de6336c2040a36aff7bed96b20fc5c30111

-------

<p> Insulate AbstractFuture from Futures.java/MoreExecutors.java dependency

Made DirectExecutor package-private so that we can refer to it directly in AbstractFuture.

660d9154e553b97df367979ccfe19971c9154bff

-------

<p> Remove reference to Strings.isNullOrEmpty from AbstractFuture.

c72e9c73cf468c2c55092912a0178a668f975e2e

-------

<p> Introduce Trusted interface.

So we can create FluentFuture.Trusted without introduction of a dependency on FluentFuture in AbstractFuture.

227d67fc6600a6041a3a3881f1e1b6652d3cf75c

-------

<p> Automated rollback of 227d67fc6600a6041a3a3881f1e1b6652d3cf75c

*** Original change description ***

Introduce Trusted interface.

So we can create FluentFuture.Trusted without introduction of a dependency on FluentFuture in AbstractFuture.

***

e058d91f7d676a8791cba1bdda6b745ccc44f8b8