### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -1154,7 +1154,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncFunction.apply returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1767,7 +1768,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncFunction.apply returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1875,7 +1877,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncCallable.call returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1999,7 +2002,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncCallable.call returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }

--- a/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -339,6 +339,53 @@ public class ServiceManagerTest extends TestCase {
     manager.awaitStopped(10, TimeUnit.MILLISECONDS);
   }
 
+  public void testDoCancelStart() throws TimeoutException {
+    Service a =
+        new AbstractService() {
+          @Override
+          protected void doStart() {
+            // Never starts!
+          }
+
+          @Override
+          protected void doCancelStart() {
+            assertThat(state()).isEqualTo(Service.State.STOPPING);
+            notifyStopped();
+          }
+
+          @Override
+          protected void doStop() {
+            throw new AssertionError(); // Should not be called.
+          }
+        };
+
+    final ServiceManager manager = new ServiceManager(asList(a));
+    manager.startAsync();
+    manager.stopAsync();
+    manager.awaitStopped(10, TimeUnit.MILLISECONDS);
+    assertThat(manager.servicesByState().keySet()).containsExactly(Service.State.TERMINATED);
+  }
+
+  public void testNotifyStoppedAfterFailure() throws TimeoutException {
+    Service a =
+        new AbstractService() {
+          @Override
+          protected void doStart() {
+            notifyFailed(new IllegalStateException("start failure"));
+            notifyStopped(); // This will be a no-op.
+          }
+
+          @Override
+          protected void doStop() {
+            notifyStopped();
+          }
+        };
+    final ServiceManager manager = new ServiceManager(asList(a));
+    manager.startAsync();
+    manager.awaitStopped(10, TimeUnit.MILLISECONDS);
+    assertThat(manager.servicesByState().keySet()).containsExactly(Service.State.FAILED);
+  }
+
   private static void assertState(
       ServiceManager manager, Service.State state, Service... services) {
     Collection<Service> managerServices = manager.servicesByState().get(state);

--- a/android/guava/src/com/google/common/collect/ImmutableCollection.java
+++ b/android/guava/src/com/google/common/collect/ImmutableCollection.java
@@ -171,13 +171,7 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
 
   @Override
   public final Object[] toArray() {
-    int size = size();
-    if (size == 0) {
-      return EMPTY_ARRAY;
-    }
-    Object[] result = new Object[size];
-    copyIntoArray(result, 0);
-    return result;
+    return toArray(EMPTY_ARRAY);
   }
 
   @CanIgnoreReturnValue
@@ -185,13 +179,39 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
   public final <T> T[] toArray(T[] other) {
     checkNotNull(other);
     int size = size();
+
     if (other.length < size) {
+      Object[] internal = internalArray();
+      if (internal != null) {
+        return Platform.copy(internal, internalArrayStart(), internalArrayEnd(), other);
+      }
       other = ObjectArrays.newArray(other, size);
     } else if (other.length > size) {
       other[size] = null;
     }
     copyIntoArray(other, 0);
     return other;
+  }
+
+  /** If this collection is backed by an array of its elements in insertion order, returns it. */
+  Object[] internalArray() {
+    return null;
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements start.
+   */
+  int internalArrayStart() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements end.
+   */
+  int internalArrayEnd() {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/android/guava/src/com/google/common/collect/ImmutableList.java
+++ b/android/guava/src/com/google/common/collect/ImmutableList.java
@@ -445,6 +445,21 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
     }
 
     @Override
+    Object[] internalArray() {
+      return ImmutableList.this.internalArray();
+    }
+
+    @Override
+    int internalArrayStart() {
+      return ImmutableList.this.internalArrayStart() + offset;
+    }
+
+    @Override
+    int internalArrayEnd() {
+      return ImmutableList.this.internalArrayStart() + offset + length;
+    }
+
+    @Override
     public E get(int index) {
       checkElementIndex(index, length);
       return ImmutableList.this.get(index + offset);

--- a/android/guava/src/com/google/common/collect/LinkedListMultimap.java
+++ b/android/guava/src/com/google/common/collect/LinkedListMultimap.java
@@ -58,7 +58,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * between keys, entries and values. For example, calling:
  *
  * <pre>{@code
- * map.remove(key1, foo);
+ * multimap.remove(key1, foo);
  * }</pre>
  *
  * <p>changes the entries iteration order to {@code [key2=bar, key1=baz]} and the key iteration

--- a/android/guava/src/com/google/common/collect/Platform.java
+++ b/android/guava/src/com/google/common/collect/Platform.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,6 +85,11 @@ final class Platform {
     @SuppressWarnings("unchecked")
     T[] result = (T[]) Array.newInstance(type, length);
     return result;
+  }
+
+  /** Equivalent to Arrays.copyOfRange(source, from, to, arrayOfType.getClass()). */
+  static <T> T[] copy(Object[] source, int from, int to, T[] arrayOfType) {
+    return Arrays.copyOfRange(source, from, to, (Class<? extends T[]>) arrayOfType.getClass());
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/RegularImmutableAsList.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableAsList.java
@@ -66,6 +66,21 @@ class RegularImmutableAsList<E> extends ImmutableAsList<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return delegateList.internalArray();
+  }
+
+  @Override
+  int internalArrayStart() {
+    return delegateList.internalArrayStart();
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return delegateList.internalArrayEnd();
+  }
+
+  @Override
   public E get(int index) {
     return delegateList.get(index);
   }

--- a/android/guava/src/com/google/common/collect/RegularImmutableList.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableList.java
@@ -50,6 +50,21 @@ class RegularImmutableList<E> extends ImmutableList<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return array;
+  }
+
+  @Override
+  int internalArrayStart() {
+    return 0;
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return size;
+  }
+
+  @Override
   int copyIntoArray(Object[] dst, int dstOff) {
     System.arraycopy(array, 0, dst, dstOff, size);
     return dstOff + size;

--- a/android/guava/src/com/google/common/collect/RegularImmutableSet.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableSet.java
@@ -75,6 +75,21 @@ final class RegularImmutableSet<E> extends ImmutableSet<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return elements;
+  }
+
+  @Override
+  int internalArrayStart() {
+    return 0;
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return size;
+  }
+
+  @Override
   int copyIntoArray(Object[] dst, int offset) {
     System.arraycopy(elements, 0, dst, offset, size);
     return offset + size;

--- a/android/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
@@ -50,6 +50,21 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return elements.internalArray();
+  }
+
+  @Override
+  int internalArrayStart() {
+    return elements.internalArrayStart();
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return elements.internalArrayEnd();
+  }
+
+  @Override
   public UnmodifiableIterator<E> iterator() {
     return elements.iterator();
   }

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -458,6 +458,13 @@ public final class MediaType {
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
+   * Media type for WASM applications. For more information see <a
+   * href="https://webassembly.org/">the Web Assembly overview</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
+  /**
    * Media type for NaCl applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.

--- a/android/guava/src/com/google/common/primitives/Primitives.java
+++ b/android/guava/src/com/google/common/primitives/Primitives.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,8 +42,8 @@ public final class Primitives {
   // Sad that we can't use a BiMap. :(
 
   static {
-    Map<Class<?>, Class<?>> primToWrap = new HashMap<>(16);
-    Map<Class<?>, Class<?>> wrapToPrim = new HashMap<>(16);
+    Map<Class<?>, Class<?>> primToWrap = new LinkedHashMap<>(16);
+    Map<Class<?>, Class<?>> wrapToPrim = new LinkedHashMap<>(16);
 
     add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
     add(primToWrap, wrapToPrim, byte.class, Byte.class);

--- a/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -177,7 +177,8 @@ abstract class AbstractCatchingFuture<V, X extends Throwable, F, T>
       checkNotNull(
           replacement,
           "AsyncFunction.apply returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          fallback);
       return replacement;
     }
 

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -71,10 +71,17 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
+   * Tag interface marking trusted subclasses. This enables some optimizations.
+   * The implementation of this interface must also be an AbstractureFuture and
+   * must not override or expose for overriding all the public methods of ListenableFuture.
+   * */
+  interface Trusted<V> extends ListenableFuture<V> {}
+
+  /**
    * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
    * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
    */
-  abstract static class TrustedFuture<V> extends AbstractFuture<V> {
+  abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
     @CanIgnoreReturnValue
     @Override
     public final V get() throws InterruptedException, ExecutionException {
@@ -590,7 +597,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             // propagate cancellation to the future set in setfuture, this is racy, and we don't
             // care if we are successful or not.
             ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-            if (futureToPropagateTo instanceof TrustedFuture) {
+            if (futureToPropagateTo instanceof Trusted) {
               // If the future is a TrustedFuture then we specifically avoid calling cancel()
               // this has 2 benefits
               // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -797,7 +804,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
     Object valueToSet;
-    if (future instanceof TrustedFuture) {
+    if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
       // and unpacking the exceptions like we do below (just much faster because it is a single

--- a/android/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
@@ -207,7 +207,8 @@ abstract class AbstractTransformFuture<I, O, F, T> extends AbstractFuture.Truste
       checkNotNull(
           outputFuture,
           "AsyncFunction.apply returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          function);
       return outputFuture;
     }
 

--- a/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -150,7 +150,8 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
       return checkNotNull(
           result,
           "AsyncCallable.call returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          callable);
     }
 
     @Override

--- a/android/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
+++ b/android/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
@@ -73,6 +73,11 @@ public final class ExecutionSequencer {
           public ListenableFuture<T> call() throws Exception {
             return immediateFuture(callable.call());
           }
+
+          @Override
+          public String toString() {
+            return callable.toString();
+          }
         },
         executor);
   }
@@ -96,6 +101,11 @@ public final class ExecutionSequencer {
               return immediateCancelledFuture();
             }
             return callable.call();
+          }
+
+          @Override
+          public String toString() {
+            return callable.toString();
           }
         };
     /*

--- a/android/guava/src/com/google/common/util/concurrent/Service.java
+++ b/android/guava/src/com/google/common/util/concurrent/Service.java
@@ -269,9 +269,9 @@ public interface Service {
      * diagram. Therefore, if this method is called, no other methods will be called on the {@link
      * Listener}.
      *
-     * @param from The previous state that is being transitioned from. The only valid values for
-     *     this are {@linkplain State#NEW NEW}, {@linkplain State#RUNNING RUNNING} or {@linkplain
-     *     State#STOPPING STOPPING}.
+     * @param from The previous state that is being transitioned from. Failure can occur in any
+     *     state with the exception of {@linkplain State#FAILED FAILED} and {@linkplain
+     *     State#TERMINATED TERMINATED}.
      */
     public void terminated(State from) {}
 

--- a/android/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
+++ b/android/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
@@ -159,7 +159,8 @@ class TrustedListenableFutureTask<V> extends AbstractFuture.TrustedFuture<V>
       return checkNotNull(
           callable.call(),
           "AsyncCallable.call returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          callable);
     }
 
     @Override

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableCollection.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableCollection.java
@@ -89,6 +89,28 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
     }
   }
 
+  /** If this collection is backed by an array of its elements in insertion order, returns it. */
+  @Nullable
+  Object[] internalArray() {
+    return null;
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements start.
+   */
+  int internalArrayStart() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements end.
+   */
+  int internalArrayEnd() {
+    throw new UnsupportedOperationException();
+  }
+
   static <E> ImmutableCollection<E> unsafeDelegate(Collection<E> delegate) {
     return new ForwardingImmutableCollection<E>(delegate);
   }

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/Platform.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/Platform.java
@@ -73,6 +73,13 @@ final class Platform {
     ((NativeArray) array).setLength(newSize);
   }
 
+  /** Equivalent to Arrays.copyOfRange(source, from, to, arrayOfType.getClass()). */
+  static <T> T[] copy(Object[] source, int from, int to, T[] arrayOfType) {
+    T[] result = newArray(arrayOfType, to - from);
+    System.arraycopy(source, from, result, 0, to - from);
+    return result;
+  }
+
   // TODO(user): Move this logic to a utility class.
   @JsType(isNative = true, name = "Array", namespace = JsPackage.GLOBAL)
   private interface NativeArray {

--- a/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -1154,7 +1154,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncFunction.apply returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1767,7 +1768,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncFunction.apply returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1875,7 +1877,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncCallable.call returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }
@@ -1999,7 +2002,8 @@ public class FuturesTest extends TestCase {
     } catch (ExecutionException expected) {
       NullPointerException cause = (NullPointerException) expected.getCause();
       assertThat(cause)
-          .hasMessage(
+          .hasMessageThat()
+          .contains(
               "AsyncCallable.call returned null instead of a Future. "
                   + "Did you mean to return immediateFuture(null)?");
     }

--- a/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -339,6 +339,53 @@ public class ServiceManagerTest extends TestCase {
     manager.awaitStopped(10, TimeUnit.MILLISECONDS);
   }
 
+  public void testDoCancelStart() throws TimeoutException {
+    Service a =
+        new AbstractService() {
+          @Override
+          protected void doStart() {
+            // Never starts!
+          }
+
+          @Override
+          protected void doCancelStart() {
+            assertThat(state()).isEqualTo(Service.State.STOPPING);
+            notifyStopped();
+          }
+
+          @Override
+          protected void doStop() {
+            throw new AssertionError(); // Should not be called.
+          }
+        };
+
+    final ServiceManager manager = new ServiceManager(asList(a));
+    manager.startAsync();
+    manager.stopAsync();
+    manager.awaitStopped(10, TimeUnit.MILLISECONDS);
+    assertThat(manager.servicesByState().keySet()).containsExactly(Service.State.TERMINATED);
+  }
+
+  public void testNotifyStoppedAfterFailure() throws TimeoutException {
+    Service a =
+        new AbstractService() {
+          @Override
+          protected void doStart() {
+            notifyFailed(new IllegalStateException("start failure"));
+            notifyStopped(); // This will be a no-op.
+          }
+
+          @Override
+          protected void doStop() {
+            notifyStopped();
+          }
+        };
+    final ServiceManager manager = new ServiceManager(asList(a));
+    manager.startAsync();
+    manager.awaitStopped(10, TimeUnit.MILLISECONDS);
+    assertThat(manager.servicesByState().keySet()).containsExactly(Service.State.FAILED);
+  }
+
   private static void assertState(
       ServiceManager manager, Service.State state, Service... services) {
     Collection<Service> managerServices = manager.servicesByState().get(state);

--- a/guava/src/com/google/common/collect/ImmutableCollection.java
+++ b/guava/src/com/google/common/collect/ImmutableCollection.java
@@ -183,13 +183,7 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
 
   @Override
   public final Object[] toArray() {
-    int size = size();
-    if (size == 0) {
-      return EMPTY_ARRAY;
-    }
-    Object[] result = new Object[size];
-    copyIntoArray(result, 0);
-    return result;
+    return toArray(EMPTY_ARRAY);
   }
 
   @CanIgnoreReturnValue
@@ -197,13 +191,40 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
   public final <T> T[] toArray(T[] other) {
     checkNotNull(other);
     int size = size();
+
     if (other.length < size) {
+      Object[] internal = internalArray();
+      if (internal != null) {
+        return Platform.copy(internal, internalArrayStart(), internalArrayEnd(), other);
+      }
       other = ObjectArrays.newArray(other, size);
     } else if (other.length > size) {
       other[size] = null;
     }
     copyIntoArray(other, 0);
     return other;
+  }
+
+  /** If this collection is backed by an array of its elements in insertion order, returns it. */
+  @Nullable
+  Object[] internalArray() {
+    return null;
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements start.
+   */
+  int internalArrayStart() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * If this collection is backed by an array of its elements in insertion order, returns the offset
+   * where this collection's elements end.
+   */
+  int internalArrayEnd() {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/guava/src/com/google/common/collect/LinkedListMultimap.java
+++ b/guava/src/com/google/common/collect/LinkedListMultimap.java
@@ -60,7 +60,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * between keys, entries and values. For example, calling:
  *
  * <pre>{@code
- * map.remove(key1, foo);
+ * multimap.remove(key1, foo);
  * }</pre>
  *
  * <p>changes the entries iteration order to {@code [key2=bar, key1=baz]} and the key iteration

--- a/guava/src/com/google/common/collect/Platform.java
+++ b/guava/src/com/google/common/collect/Platform.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,6 +85,11 @@ final class Platform {
     @SuppressWarnings("unchecked")
     T[] result = (T[]) Array.newInstance(type, length);
     return result;
+  }
+
+  /** Equivalent to Arrays.copyOfRange(source, from, to, arrayOfType.getClass()). */
+  static <T> T[] copy(Object[] source, int from, int to, T[] arrayOfType) {
+    return Arrays.copyOfRange(source, from, to, (Class<? extends T[]>) arrayOfType.getClass());
   }
 
   /**

--- a/guava/src/com/google/common/collect/RegularImmutableAsList.java
+++ b/guava/src/com/google/common/collect/RegularImmutableAsList.java
@@ -69,6 +69,21 @@ class RegularImmutableAsList<E> extends ImmutableAsList<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return delegateList.internalArray();
+  }
+
+  @Override
+  int internalArrayStart() {
+    return delegateList.internalArrayStart();
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return delegateList.internalArrayEnd();
+  }
+
+  @Override
   public E get(int index) {
     return delegateList.get(index);
   }

--- a/guava/src/com/google/common/collect/RegularImmutableList.java
+++ b/guava/src/com/google/common/collect/RegularImmutableList.java
@@ -48,6 +48,21 @@ class RegularImmutableList<E> extends ImmutableList<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return array;
+  }
+
+  @Override
+  int internalArrayStart() {
+    return 0;
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return array.length;
+  }
+
+  @Override
   int copyIntoArray(Object[] dst, int dstOff) {
     System.arraycopy(array, 0, dst, dstOff, array.length);
     return dstOff + array.length;

--- a/guava/src/com/google/common/collect/RegularImmutableSet.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSet.java
@@ -80,6 +80,21 @@ final class RegularImmutableSet<E> extends ImmutableSet<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return elements;
+  }
+
+  @Override
+  int internalArrayStart() {
+    return 0;
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return elements.length;
+  }
+
+  @Override
   int copyIntoArray(Object[] dst, int offset) {
     System.arraycopy(elements, 0, dst, offset, elements.length);
     return offset + elements.length;

--- a/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
@@ -51,6 +51,21 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
   }
 
   @Override
+  Object[] internalArray() {
+    return elements.internalArray();
+  }
+
+  @Override
+  int internalArrayStart() {
+    return elements.internalArrayStart();
+  }
+
+  @Override
+  int internalArrayEnd() {
+    return elements.internalArrayEnd();
+  }
+
+  @Override
   public UnmodifiableIterator<E> iterator() {
     return elements.iterator();
   }

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -458,6 +458,13 @@ public final class MediaType {
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
+   * Media type for WASM applications. For more information see <a
+   * href="https://webassembly.org/">the Web Assembly overview</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
+  /**
    * Media type for NaCl applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.

--- a/guava/src/com/google/common/primitives/Primitives.java
+++ b/guava/src/com/google/common/primitives/Primitives.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,8 +42,8 @@ public final class Primitives {
   // Sad that we can't use a BiMap. :(
 
   static {
-    Map<Class<?>, Class<?>> primToWrap = new HashMap<>(16);
-    Map<Class<?>, Class<?>> wrapToPrim = new HashMap<>(16);
+    Map<Class<?>, Class<?>> primToWrap = new LinkedHashMap<>(16);
+    Map<Class<?>, Class<?>> wrapToPrim = new LinkedHashMap<>(16);
 
     add(primToWrap, wrapToPrim, boolean.class, Boolean.class);
     add(primToWrap, wrapToPrim, byte.class, Byte.class);

--- a/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -176,7 +176,8 @@ abstract class AbstractCatchingFuture<V, X extends Throwable, F, T>
       checkNotNull(
           replacement,
           "AsyncFunction.apply returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          fallback);
       return replacement;
     }
 

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -21,7 +21,6 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.util.concurrent.DirectExecutor;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.j2objc.annotations.ReflectionSupport;
@@ -72,10 +71,17 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
+   * Tag interface marking trusted subclasses. This enables some optimizations.
+   * The implementation of this interface must also be an AbstractureFuture and
+   * must not override or expose for overriding all the public methods of ListenableFuture.
+   * */
+  interface Trusted<V> extends ListenableFuture<V> {}
+
+  /**
    * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
    * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
    */
-  abstract static class TrustedFuture<V> extends AbstractFuture<V> {
+  abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
     @CanIgnoreReturnValue
     @Override
     public final V get() throws InterruptedException, ExecutionException {
@@ -591,7 +597,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             // propagate cancellation to the future set in setfuture, this is racy, and we don't
             // care if we are successful or not.
             ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-            if (futureToPropagateTo instanceof TrustedFuture) {
+            if (futureToPropagateTo instanceof Trusted) {
               // If the future is a TrustedFuture then we specifically avoid calling cancel()
               // this has 2 benefits
               // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -798,7 +804,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
     Object valueToSet;
-    if (future instanceof TrustedFuture) {
+    if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
       // and unpacking the exceptions like we do below (just much faster because it is a single

--- a/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
@@ -206,7 +206,8 @@ abstract class AbstractTransformFuture<I, O, F, T> extends AbstractFuture.Truste
       checkNotNull(
           outputFuture,
           "AsyncFunction.apply returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          function);
       return outputFuture;
     }
 

--- a/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -150,7 +150,8 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
       return checkNotNull(
           result,
           "AsyncCallable.call returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          callable);
     }
 
     @Override

--- a/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
+++ b/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
@@ -73,6 +73,11 @@ public final class ExecutionSequencer {
           public ListenableFuture<T> call() throws Exception {
             return immediateFuture(callable.call());
           }
+
+          @Override
+          public String toString() {
+            return callable.toString();
+          }
         },
         executor);
   }
@@ -96,6 +101,11 @@ public final class ExecutionSequencer {
               return immediateCancelledFuture();
             }
             return callable.call();
+          }
+
+          @Override
+          public String toString() {
+            return callable.toString();
           }
         };
     /*

--- a/guava/src/com/google/common/util/concurrent/Service.java
+++ b/guava/src/com/google/common/util/concurrent/Service.java
@@ -269,9 +269,9 @@ public interface Service {
      * diagram. Therefore, if this method is called, no other methods will be called on the {@link
      * Listener}.
      *
-     * @param from The previous state that is being transitioned from. The only valid values for
-     *     this are {@linkplain State#NEW NEW}, {@linkplain State#RUNNING RUNNING} or {@linkplain
-     *     State#STOPPING STOPPING}.
+     * @param from The previous state that is being transitioned from. Failure can occur in any
+     *     state with the exception of {@linkplain State#FAILED FAILED} and {@linkplain
+     *     State#TERMINATED TERMINATED}.
      */
     public void terminated(State from) {}
 

--- a/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
+++ b/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
@@ -159,7 +159,8 @@ class TrustedListenableFutureTask<V> extends AbstractFuture.TrustedFuture<V>
       return checkNotNull(
           callable.call(),
           "AsyncCallable.call returned null instead of a Future. "
-              + "Did you mean to return immediateFuture(null)?");
+              + "Did you mean to return immediateFuture(null)? %s",
+          callable);
     }
 
     @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Automated rollback of 45ca38358cac4368877650e591daf9650f5eaae1

*** Reason for rollback ***

The test that caused the inital rollback is buggy

*** Original change description ***

Introduce Trusted interface.

So we can create FluentFuture.Trusted without introduction of a dependency on FluentFuture in AbstractFuture.

***

683eb054a0c9846e73aa9a4f1a47d4821ea5ef60

-------

<p> Optimize ImmutableCollection.toArray(T[]) as per https://shipilev.net/blog/2016/arrays-wisdom-ancients/, the key goal being to avoid the necessity of zeroing a newly created array where possible.

Addresses https://github.com/google/guava/issues/3209.

f5a3541fd118d370488b9f9c15facd408e180b17

-------

<p> Adds WASM as a supported Media type to Google Java utilities.
Adds WASM support to the StaticFileAction in devserver (so that it is served
with the correct Content Type).

RELNOTES=Adds WASM as a supported Media type to Google Java utilities.

67bb79e4ea2e0f6da956c29dd700ad7d756948b7

-------

<p> Allow Service to transition from STARTING to TERMINATED. Add a new "doCancelStart" method that is called when a service is stopped while still starting. This gives implementations a chance to abort code which may be preventing the service from starting.

RELNOTES=Added `doCancelStart` protected method to `AbstractService`

6cdea3a7b0fe3953e181cb9660df5834550ba498

-------

<p> Fix javadoc typo in LinkedListMultimap

Fixes https://github.com/google/guava/issues/3228

1d0eeee14d09912362695e6e1c847fc50bc96ebf

-------

<p> Add callable's toString to null failure message.

I find this happens in mock-heavy tests, and this makes it easier to identify the source of the bad mock call.

9c03abcca29fb267ed55fc80e668327e5d46e230

-------

<p> Enhance toString() for futures returned from ExecutionSequencer.

Also make tests for ExecutionSequencer actually run, by porting them to junit3 :-(

0c2b6fb916214ffe092edc8577bd7818d58fe664

-------

<p> Make ordering of Primitives#all{Wrapper,Primitive}Types deterministic

RELNOTES=N/A

c8ad64d04071f0fc20cbcba0bb9ee944746b5ef2