### PR TITLE
Use newGuard() to make example in Monitor class javadoc more concise.

### DIFF
--- a/guava/src/com/google/common/util/concurrent/Monitor.java
+++ b/guava/src/com/google/common/util/concurrent/Monitor.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
-import com.google.common.base.Throwables;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.j2objc.annotations.Weak;
 import java.util.concurrent.TimeUnit;
@@ -122,10 +121,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <pre>{@code
  * public class SafeBox<V> {
+ *   private V value;
  *   private final ReentrantLock lock = new ReentrantLock();
  *   private final Condition valuePresent = lock.newCondition();
  *   private final Condition valueAbsent = lock.newCondition();
- *   private V value;
  *
  *   public V get() throws InterruptedException {
  *     lock.lock();
@@ -167,18 +166,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <pre>{@code
  * public class SafeBox<V> {
- *   private final Monitor monitor = new Monitor();
- *   private final Monitor.Guard valuePresent = new Monitor.Guard(monitor) {
- *     public boolean isSatisfied() {
- *       return value != null;
- *     }
- *   };
- *   private final Monitor.Guard valueAbsent = new Monitor.Guard(monitor) {
- *     public boolean isSatisfied() {
- *       return value == null;
- *     }
- *   };
  *   private V value;
+ *   private final Monitor monitor = new Monitor();
+ *   private final Monitor.Guard valuePresent = monitor.newGuard(() -> value != null);
+ *   private final Monitor.Guard valueAbsent = monitor.newGuard(() -> value == null);
  *
  *   public V get() throws InterruptedException {
  *     monitor.enterWhen(valuePresent);
@@ -369,8 +360,10 @@ public final class Monitor {
   }
 
   /**
-   * Creates a new {@link Guard} for {@code this} monitor. @Param isSatisfied The guards boolean
-   * condition. See {@link Guard#isSatisfied}.
+   * Creates a new {@linkplain Guard guard} for this monitor.
+   *
+   * @param isSatisfied the new guard's boolean condition (see {@link Guard#isSatisfied
+   *     isSatisfied()})
    */
   public Guard newGuard(final BooleanSupplier isSatisfied) {
     checkNotNull(isSatisfied, "isSatisfied");
@@ -1031,7 +1024,7 @@ public final class Monitor {
       return guard.isSatisfied();
     } catch (Throwable throwable) {
       signalAllWaiters();
-      throw Throwables.propagate(throwable);
+      throw throwable;
     }
   }
 


### PR DESCRIPTION
This commit also cleans up the method javadoc for newGuard() itself and replaces a lingering `throw Throwables.propagate(throwable)` with simply `throw throwable` (not related to newGuard(), but good to clean up).

_Note:_ I have not modified the copy of Monitor.java under the android directory because the newGuard() method was never added there.