### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To add a dependency on Guava using Maven, use the following:
 
 To add a dependency using Gradle:
 
-```
+```gradle
 dependencies {
   compile 'com.google.guava:guava:26.0-jre'
   // or, for Android:

--- a/android/guava-tests/test/com/google/common/collect/RangeTest.java
+++ b/android/guava-tests/test/com/google/common/collect/RangeTest.java
@@ -451,6 +451,54 @@ public class RangeTest extends TestCase {
     }
   }
 
+  public void testGap_overlapping() {
+    Range<Integer> range = Range.closedOpen(3, 5);
+
+    try {
+      range.gap(Range.closed(4, 6));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      range.gap(Range.closed(2, 4));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      range.gap(Range.closed(2, 3));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testGap_connectedAdjacentYieldsEmpty() {
+    Range<Integer> range = Range.open(3, 4);
+
+    assertEquals(Range.closedOpen(4, 4), range.gap(Range.atLeast(4)));
+    assertEquals(Range.openClosed(3, 3), range.gap(Range.atMost(3)));
+  }
+
+  public void testGap_general() {
+    Range<Integer> openRange = Range.open(4, 8);
+    Range<Integer> closedRange = Range.closed(4, 8);
+
+    // first range open end, second range open start
+    assertEquals(Range.closed(2, 4), Range.lessThan(2).gap(openRange));
+    assertEquals(Range.closed(2, 4), openRange.gap(Range.lessThan(2)));
+
+    // first range closed end, second range open start
+    assertEquals(Range.openClosed(2, 4), Range.atMost(2).gap(openRange));
+    assertEquals(Range.openClosed(2, 4), openRange.gap(Range.atMost(2)));
+
+    // first range open end, second range closed start
+    assertEquals(Range.closedOpen(2, 4), Range.lessThan(2).gap(closedRange));
+    assertEquals(Range.closedOpen(2, 4), closedRange.gap(Range.lessThan(2)));
+
+    // first range closed end, second range closed start
+    assertEquals(Range.open(2, 4), Range.atMost(2).gap(closedRange));
+    assertEquals(Range.open(2, 4), closedRange.gap(Range.atMost(2)));
+  }
+
   public void testSpan_general() {
     Range<Integer> range = Range.closed(4, 8);
 

--- a/android/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
@@ -40,7 +40,7 @@ import junit.framework.TestCase;
 @GwtCompatible(emulated = true)
 public class FluentFutureTest extends TestCase {
   public void testFromFluentFuture() {
-    FluentFuture<String> f = SettableFuture.create();
+    FluentFuture<String> f = FluentFuture.from(SettableFuture.<String>create());
     assertThat(FluentFuture.from(f)).isSameAs(f);
   }
 
@@ -131,7 +131,8 @@ public class FluentFutureTest extends TestCase {
   public void testWithTimeout() throws Exception {
     ScheduledExecutorService executor = newScheduledThreadPool(1);
     try {
-      FluentFuture<?> f = SettableFuture.create().withTimeout(0, SECONDS, executor);
+      FluentFuture<?> f =
+          FluentFuture.from(SettableFuture.create()).withTimeout(0, SECONDS, executor);
       try {
         f.get();
         fail();

--- a/android/guava/src/com/google/common/collect/Range.java
+++ b/android/guava/src/com/google/common/collect/Range.java
@@ -554,6 +554,30 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
   }
 
   /**
+   * Returns the maximal range lying between this range and {@code otherRange}, if such a range
+   * exists. The resulting range may be empty if the two ranges are adjacent but non-overlapping.
+   *
+   * <p>For example, the gap of {@code [1..5]} and {@code (7..10)} is {@code (5..7]}. The resulting
+   * range may be empty; for example, the gap between {@code [1..5)} {@code [5..7)} yields the empty
+   * range {@code [5..5)}.
+   *
+   * <p>The gap exists if and only if the two ranges are either disconnected or immediately adjacent
+   * (any intersection must be an empty range).
+   *
+   * <p>The gap operation is commutative.
+   *
+   * @throws IllegalArgumentException if this range and {@code otherRange} have a nonempty
+   *     intersection
+   * @since NEXT
+   */
+  public Range<C> gap(Range<C> otherRange) {
+    boolean isThisFirst = this.lowerBound.compareTo(otherRange.lowerBound) < 0;
+    Range<C> firstRange = isThisFirst ? this : otherRange;
+    Range<C> secondRange = isThisFirst ? otherRange : this;
+    return create(firstRange.upperBound, secondRange.lowerBound);
+  }
+
+  /**
    * Returns the minimal range that {@linkplain #encloses encloses} both this range and {@code
    * other}. For example, the span of {@code [1..3]} and {@code (5..7)} is {@code [1..7)}.
    *

--- a/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 /** Implementations of {@code Futures.catching*}. */
 @GwtCompatible
 abstract class AbstractCatchingFuture<V, X extends Throwable, F, T>
-    extends AbstractFuture.TrustedFuture<V> implements Runnable {
+    extends FluentFuture.TrustedFuture<V> implements Runnable {
   static <V, X extends Throwable> ListenableFuture<V> create(
       ListenableFuture<? extends V> input,
       Class<X> exceptionType,

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -817,7 +817,6 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    * <p>This is approximately the inverse of {@link #getDoneValue(Object)}
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
-    Object valueToSet;
     if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
@@ -838,19 +837,18 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
       }
       return v;
     } else {
-      // Otherwise calculate valueToSet by calling .get()
+      // Otherwise calculate the value by calling .get()
       try {
         Object v = getDone(future);
-        valueToSet = v == null ? NULL : v;
+        return v == null ? NULL : v;
       } catch (ExecutionException exception) {
-        valueToSet = new Failure(exception.getCause());
+        return new Failure(exception.getCause());
       } catch (CancellationException cancellation) {
-        valueToSet = new Cancellation(false, cancellation);
+        return new Cancellation(false, cancellation);
       } catch (Throwable t) {
-        valueToSet = new Failure(t);
+        return new Failure(t);
       }
     }
-    return valueToSet;
   }
 
   /** Unblocks all threads and runs all listeners. */

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -63,7 +63,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 @SuppressWarnings("ShortCircuitBoolean") // we use non-short circuiting comparisons intentionally
 @GwtCompatible(emulated = true)
 @ReflectionSupport(value = ReflectionSupport.Level.FULL)
-public abstract class AbstractFuture<V> extends FluentFuture<V> {
+public abstract class AbstractFuture<V> implements ListenableFuture<V> {
   // NOTE: Whenever both tests are cheap and functional, it's faster to use &, | instead of &&, ||
 
   private static final boolean GENERATE_CANCELLATION_CAUSES =
@@ -71,10 +71,10 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
-   * Tag interface marking trusted subclasses. This enables some optimizations.
-   * The implementation of this interface must also be an AbstractureFuture and
-   * must not override or expose for overriding all the public methods of ListenableFuture.
-   * */
+   * Tag interface marking trusted subclasses. This enables some optimizations. The implementation
+   * of this interface must also be an AbstractFuture and must not override or expose for overriding
+   * any of the public methods of ListenableFuture.
+   */
   interface Trusted<V> extends ListenableFuture<V> {}
 
   /**
@@ -965,7 +965,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     return reversedList;
   }
 
-  // TODO(user) move this up into FluentFuture, or parts as a default method on ListenableFuture?
+  // TODO(user): move parts into a default method on ListenableFuture?
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder().append(super.toString()).append("[status=");

--- a/android/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Implementations of {@code Futures.transform*}. */
 @GwtCompatible
-abstract class AbstractTransformFuture<I, O, F, T> extends AbstractFuture.TrustedFuture<O>
+abstract class AbstractTransformFuture<I, O, F, T> extends FluentFuture.TrustedFuture<O>
     implements Runnable {
   static <I, O> ListenableFuture<O> create(
       ListenableFuture<I> input,

--- a/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -68,6 +69,48 @@ import java.util.concurrent.TimeoutException;
 @Beta
 @GwtCompatible(emulated = true)
 public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecialization<V> {
+
+  /**
+   * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
+   * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
+   */
+  abstract static class TrustedFuture<V> extends FluentFuture<V>
+      implements AbstractFuture.Trusted<V> {
+    @CanIgnoreReturnValue
+    @Override
+    public final V get() throws InterruptedException, ExecutionException {
+      return super.get();
+    }
+
+    @CanIgnoreReturnValue
+    @Override
+    public final V get(long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return super.get(timeout, unit);
+    }
+
+    @Override
+    public final boolean isDone() {
+      return super.isDone();
+    }
+
+    @Override
+    public final boolean isCancelled() {
+      return super.isCancelled();
+    }
+
+    @Override
+    public final void addListener(Runnable listener, Executor executor) {
+      super.addListener(listener, executor);
+    }
+
+    @CanIgnoreReturnValue
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+      return super.cancel(mayInterruptIfRunning);
+    }
+  }
+
   FluentFuture() {}
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
+++ b/android/guava/src/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.GwtCompatible;
  * FluentFuture.catching} family of methods. Those versions have slightly different signatures.
  */
 @GwtCompatible(emulated = true)
-abstract class GwtFluentFutureCatchingSpecialization<V> implements ListenableFuture<V> {
+abstract class GwtFluentFutureCatchingSpecialization<V> extends AbstractFuture<V> {
   /*
    * This server copy of the class is empty. The corresponding GWT copy contains alternative
    * versions of catching() and catchingAsync() with slightly different signatures from the ones

--- a/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Implementations of {@code Futures.immediate*}. */
 @GwtCompatible(emulated = true)
-abstract class ImmediateFuture<V> extends FluentFuture<V> {
+abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
 
   @Override

--- a/android/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -71,7 +72,7 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
    */
 
   @NullableDecl private ListenableFuture<V> delegateRef;
-  @NullableDecl private Future<?> timer;
+  @NullableDecl private ScheduledFuture<?> timer;
 
   private TimeoutFuture(ListenableFuture<V> delegate) {
     this.delegateRef = Preconditions.checkNotNull(delegate);
@@ -115,9 +116,16 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
         timeoutFuture.setFuture(delegate);
       } else {
         try {
-          // TODO(lukes): this stack trace is particularly useless (all it does is point at the
-          // scheduledexecutorservice thread), consider eliminating it altogether?
-          timeoutFuture.setException(new TimeoutException("Future timed out: " + delegate));
+          ScheduledFuture<?> timer = timeoutFuture.timer;
+          String message = "Timed out";
+          if (timer != null) {
+            long overDelayMs = Math.abs(timer.getDelay(TimeUnit.MILLISECONDS));
+            if (overDelayMs > 10) { // Not all timing drift is worth reporting
+              message += " (timeout delayed by " + overDelayMs + " ms after scheduled time)";
+            }
+          }
+          timeoutFuture.timer = null; // Don't include already elapsed delay in delegate.toString()
+          timeoutFuture.setException(new TimeoutFutureException(message + ": " + delegate));
         } finally {
           delegate.cancel(true);
         }
@@ -125,11 +133,32 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
     }
   }
 
+  private static final class TimeoutFutureException extends TimeoutException {
+    private TimeoutFutureException(String message) {
+      super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      setStackTrace(new StackTraceElement[0]);
+      return this; // no stack trace, wouldn't be useful anyway
+    }
+  }
+
   @Override
   protected String pendingToString() {
     ListenableFuture<? extends V> localInputFuture = delegateRef;
+    ScheduledFuture<?> localTimer = timer;
     if (localInputFuture != null) {
-      return "inputFuture=[" + localInputFuture + "]";
+      String message = "inputFuture=[" + localInputFuture + "]";
+      if (localTimer != null) {
+        final long delay = localTimer.getDelay(TimeUnit.MILLISECONDS);
+        // Negative delays look confusing in an error message
+        if (delay > 0) {
+          message += ", remaining delay=[" + delay + " ms]";
+        }
+      }
+      return message;
     }
     return null;
   }

--- a/android/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
@@ -34,7 +34,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * interrupted and cancelled if it times out.
  */
 @GwtIncompatible
-final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
+final class TimeoutFuture<V> extends FluentFuture.TrustedFuture<V> {
   static <V> ListenableFuture<V> create(
       ListenableFuture<V> delegate,
       long time,

--- a/android/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
+++ b/android/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * performance reasons.
  */
 @GwtCompatible
-class TrustedListenableFutureTask<V> extends AbstractFuture.TrustedFuture<V>
+class TrustedListenableFutureTask<V> extends FluentFuture.TrustedFuture<V>
     implements RunnableFuture<V> {
 
   static <V> TrustedListenableFutureTask<V> create(AsyncCallable<V> callable) {

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Executor;
  * versions of the {@link FluentFuture#catching(Class, com.google.common.base.Function)
  * FluentFuture.catching} family of methods. Those versions have slightly different signatures.
  */
-abstract class GwtFluentFutureCatchingSpecialization<V> implements ListenableFuture<V> {
+abstract class GwtFluentFutureCatchingSpecialization<V> extends AbstractFuture<V> {
   /*
    * In the GWT versions of the methods (below), every exceptionType parameter is required to be
    * Class<Throwable>. To handle only certain kinds of exceptions under GWT, you'll need to write

--- a/guava-gwt/test/com/google/common/collect/RangeTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/RangeTest_gwt.java
@@ -113,6 +113,21 @@ public void testEquivalentFactories() throws Exception {
   testCase.testEquivalentFactories();
 }
 
+public void testGap_connectedAdjacentYieldsEmpty() throws Exception {
+  com.google.common.collect.RangeTest testCase = new com.google.common.collect.RangeTest();
+  testCase.testGap_connectedAdjacentYieldsEmpty();
+}
+
+public void testGap_general() throws Exception {
+  com.google.common.collect.RangeTest testCase = new com.google.common.collect.RangeTest();
+  testCase.testGap_general();
+}
+
+public void testGap_overlapping() throws Exception {
+  com.google.common.collect.RangeTest testCase = new com.google.common.collect.RangeTest();
+  testCase.testGap_overlapping();
+}
+
 public void testGreaterThan() throws Exception {
   com.google.common.collect.RangeTest testCase = new com.google.common.collect.RangeTest();
   testCase.testGreaterThan();

--- a/guava-tests/test/com/google/common/collect/RangeTest.java
+++ b/guava-tests/test/com/google/common/collect/RangeTest.java
@@ -451,6 +451,54 @@ public class RangeTest extends TestCase {
     }
   }
 
+  public void testGap_overlapping() {
+    Range<Integer> range = Range.closedOpen(3, 5);
+
+    try {
+      range.gap(Range.closed(4, 6));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      range.gap(Range.closed(2, 4));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      range.gap(Range.closed(2, 3));
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testGap_connectedAdjacentYieldsEmpty() {
+    Range<Integer> range = Range.open(3, 4);
+
+    assertEquals(Range.closedOpen(4, 4), range.gap(Range.atLeast(4)));
+    assertEquals(Range.openClosed(3, 3), range.gap(Range.atMost(3)));
+  }
+
+  public void testGap_general() {
+    Range<Integer> openRange = Range.open(4, 8);
+    Range<Integer> closedRange = Range.closed(4, 8);
+
+    // first range open end, second range open start
+    assertEquals(Range.closed(2, 4), Range.lessThan(2).gap(openRange));
+    assertEquals(Range.closed(2, 4), openRange.gap(Range.lessThan(2)));
+
+    // first range closed end, second range open start
+    assertEquals(Range.openClosed(2, 4), Range.atMost(2).gap(openRange));
+    assertEquals(Range.openClosed(2, 4), openRange.gap(Range.atMost(2)));
+
+    // first range open end, second range closed start
+    assertEquals(Range.closedOpen(2, 4), Range.lessThan(2).gap(closedRange));
+    assertEquals(Range.closedOpen(2, 4), closedRange.gap(Range.lessThan(2)));
+
+    // first range closed end, second range closed start
+    assertEquals(Range.open(2, 4), Range.atMost(2).gap(closedRange));
+    assertEquals(Range.open(2, 4), closedRange.gap(Range.atMost(2)));
+  }
+
   public void testSpan_general() {
     Range<Integer> range = Range.closed(4, 8);
 

--- a/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
@@ -40,7 +40,7 @@ import junit.framework.TestCase;
 @GwtCompatible(emulated = true)
 public class FluentFutureTest extends TestCase {
   public void testFromFluentFuture() {
-    FluentFuture<String> f = SettableFuture.create();
+    FluentFuture<String> f = FluentFuture.from(SettableFuture.<String>create());
     assertThat(FluentFuture.from(f)).isSameAs(f);
   }
 
@@ -131,7 +131,8 @@ public class FluentFutureTest extends TestCase {
   public void testWithTimeout() throws Exception {
     ScheduledExecutorService executor = newScheduledThreadPool(1);
     try {
-      FluentFuture<?> f = SettableFuture.create().withTimeout(0, SECONDS, executor);
+      FluentFuture<?> f =
+          FluentFuture.from(SettableFuture.create()).withTimeout(0, SECONDS, executor);
       try {
         f.get();
         fail();

--- a/guava/src/com/google/common/collect/Range.java
+++ b/guava/src/com/google/common/collect/Range.java
@@ -554,6 +554,30 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
   }
 
   /**
+   * Returns the maximal range lying between this range and {@code otherRange}, if such a range
+   * exists. The resulting range may be empty if the two ranges are adjacent but non-overlapping.
+   *
+   * <p>For example, the gap of {@code [1..5]} and {@code (7..10)} is {@code (5..7]}. The resulting
+   * range may be empty; for example, the gap between {@code [1..5)} {@code [5..7)} yields the empty
+   * range {@code [5..5)}.
+   *
+   * <p>The gap exists if and only if the two ranges are either disconnected or immediately adjacent
+   * (any intersection must be an empty range).
+   *
+   * <p>The gap operation is commutative.
+   *
+   * @throws IllegalArgumentException if this range and {@code otherRange} have a nonempty
+   *     intersection
+   * @since NEXT
+   */
+  public Range<C> gap(Range<C> otherRange) {
+    boolean isThisFirst = this.lowerBound.compareTo(otherRange.lowerBound) < 0;
+    Range<C> firstRange = isThisFirst ? this : otherRange;
+    Range<C> secondRange = isThisFirst ? otherRange : this;
+    return create(firstRange.upperBound, secondRange.lowerBound);
+  }
+
+  /**
    * Returns the minimal range that {@linkplain #encloses encloses} both this range and {@code
    * other}. For example, the span of {@code [1..3]} and {@code (5..7)} is {@code [1..7)}.
    *

--- a/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /** Implementations of {@code Futures.catching*}. */
 @GwtCompatible
 abstract class AbstractCatchingFuture<V, X extends Throwable, F, T>
-    extends AbstractFuture.TrustedFuture<V> implements Runnable {
+    extends FluentFuture.TrustedFuture<V> implements Runnable {
   static <V, X extends Throwable> ListenableFuture<V> create(
       ListenableFuture<? extends V> input,
       Class<X> exceptionType,

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -817,7 +817,6 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
    * <p>This is approximately the inverse of {@link #getDoneValue(Object)}
    */
   private static Object getFutureValue(ListenableFuture<?> future) {
-    Object valueToSet;
     if (future instanceof Trusted) {
       // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
       // override .get() (since it is final) and therefore this is equivalent to calling .get()
@@ -838,19 +837,18 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
       }
       return v;
     } else {
-      // Otherwise calculate valueToSet by calling .get()
+      // Otherwise calculate the value by calling .get()
       try {
         Object v = getDone(future);
-        valueToSet = v == null ? NULL : v;
+        return v == null ? NULL : v;
       } catch (ExecutionException exception) {
-        valueToSet = new Failure(exception.getCause());
+        return new Failure(exception.getCause());
       } catch (CancellationException cancellation) {
-        valueToSet = new Cancellation(false, cancellation);
+        return new Cancellation(false, cancellation);
       } catch (Throwable t) {
-        valueToSet = new Failure(t);
+        return new Failure(t);
       }
     }
-    return valueToSet;
   }
 
   /** Unblocks all threads and runs all listeners. */

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -63,7 +63,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings("ShortCircuitBoolean") // we use non-short circuiting comparisons intentionally
 @GwtCompatible(emulated = true)
 @ReflectionSupport(value = ReflectionSupport.Level.FULL)
-public abstract class AbstractFuture<V> extends FluentFuture<V> {
+public abstract class AbstractFuture<V> implements ListenableFuture<V> {
   // NOTE: Whenever both tests are cheap and functional, it's faster to use &, | instead of &&, ||
 
   private static final boolean GENERATE_CANCELLATION_CAUSES =
@@ -71,10 +71,10 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
           System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
 
   /**
-   * Tag interface marking trusted subclasses. This enables some optimizations.
-   * The implementation of this interface must also be an AbstractureFuture and
-   * must not override or expose for overriding all the public methods of ListenableFuture.
-   * */
+   * Tag interface marking trusted subclasses. This enables some optimizations. The implementation
+   * of this interface must also be an AbstractFuture and must not override or expose for overriding
+   * any of the public methods of ListenableFuture.
+   */
   interface Trusted<V> extends ListenableFuture<V> {}
 
   /**
@@ -965,7 +965,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     return reversedList;
   }
 
-  // TODO(user) move this up into FluentFuture, or parts as a default method on ListenableFuture?
+  // TODO(user): move parts into a default method on ListenableFuture?
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder().append(super.toString()).append("[status=");

--- a/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractTransformFuture.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Implementations of {@code Futures.transform*}. */
 @GwtCompatible
-abstract class AbstractTransformFuture<I, O, F, T> extends AbstractFuture.TrustedFuture<O>
+abstract class AbstractTransformFuture<I, O, F, T> extends FluentFuture.TrustedFuture<O>
     implements Runnable {
   static <I, O> ListenableFuture<O> create(
       ListenableFuture<I> input,

--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -68,6 +69,48 @@ import java.util.concurrent.TimeoutException;
 @Beta
 @GwtCompatible(emulated = true)
 public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecialization<V> {
+
+  /**
+   * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
+   * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
+   */
+  abstract static class TrustedFuture<V> extends FluentFuture<V>
+      implements AbstractFuture.Trusted<V> {
+    @CanIgnoreReturnValue
+    @Override
+    public final V get() throws InterruptedException, ExecutionException {
+      return super.get();
+    }
+
+    @CanIgnoreReturnValue
+    @Override
+    public final V get(long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return super.get(timeout, unit);
+    }
+
+    @Override
+    public final boolean isDone() {
+      return super.isDone();
+    }
+
+    @Override
+    public final boolean isCancelled() {
+      return super.isCancelled();
+    }
+
+    @Override
+    public final void addListener(Runnable listener, Executor executor) {
+      super.addListener(listener, executor);
+    }
+
+    @CanIgnoreReturnValue
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+      return super.cancel(mayInterruptIfRunning);
+    }
+  }
+
   FluentFuture() {}
 
   /**

--- a/guava/src/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
+++ b/guava/src/com/google/common/util/concurrent/GwtFluentFutureCatchingSpecialization.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.GwtCompatible;
  * FluentFuture.catching} family of methods. Those versions have slightly different signatures.
  */
 @GwtCompatible(emulated = true)
-abstract class GwtFluentFutureCatchingSpecialization<V> implements ListenableFuture<V> {
+abstract class GwtFluentFutureCatchingSpecialization<V> extends AbstractFuture<V> {
   /*
    * This server copy of the class is empty. The corresponding GWT copy contains alternative
    * versions of catching() and catchingAsync() with slightly different signatures from the ones

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -28,7 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Implementations of {@code Futures.immediate*}. */
 @GwtCompatible(emulated = true)
-abstract class ImmediateFuture<V> extends FluentFuture<V> {
+abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
 
   @Override

--- a/guava/src/com/google/common/util/concurrent/Monitor.java
+++ b/guava/src/com/google/common/util/concurrent/Monitor.java
@@ -371,6 +371,8 @@ public final class Monitor {
   /**
    * Creates a new {@link Guard} for {@code this} monitor. @Param isSatisfied The guards boolean
    * condition. See {@link Guard#isSatisfied}.
+   *
+   * @since 21.0
    */
   public Guard newGuard(final BooleanSupplier isSatisfied) {
     checkNotNull(isSatisfied, "isSatisfied");

--- a/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
+++ b/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -71,7 +72,7 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
    */
 
   private @Nullable ListenableFuture<V> delegateRef;
-  private @Nullable Future<?> timer;
+  private @Nullable ScheduledFuture<?> timer;
 
   private TimeoutFuture(ListenableFuture<V> delegate) {
     this.delegateRef = Preconditions.checkNotNull(delegate);
@@ -115,9 +116,16 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
         timeoutFuture.setFuture(delegate);
       } else {
         try {
-          // TODO(lukes): this stack trace is particularly useless (all it does is point at the
-          // scheduledexecutorservice thread), consider eliminating it altogether?
-          timeoutFuture.setException(new TimeoutException("Future timed out: " + delegate));
+          ScheduledFuture<?> timer = timeoutFuture.timer;
+          String message = "Timed out";
+          if (timer != null) {
+            long overDelayMs = Math.abs(timer.getDelay(TimeUnit.MILLISECONDS));
+            if (overDelayMs > 10) { // Not all timing drift is worth reporting
+              message += " (timeout delayed by " + overDelayMs + " ms after scheduled time)";
+            }
+          }
+          timeoutFuture.timer = null; // Don't include already elapsed delay in delegate.toString()
+          timeoutFuture.setException(new TimeoutFutureException(message + ": " + delegate));
         } finally {
           delegate.cancel(true);
         }
@@ -125,11 +133,32 @@ final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
     }
   }
 
+  private static final class TimeoutFutureException extends TimeoutException {
+    private TimeoutFutureException(String message) {
+      super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      setStackTrace(new StackTraceElement[0]);
+      return this; // no stack trace, wouldn't be useful anyway
+    }
+  }
+
   @Override
   protected String pendingToString() {
     ListenableFuture<? extends V> localInputFuture = delegateRef;
+    ScheduledFuture<?> localTimer = timer;
     if (localInputFuture != null) {
-      return "inputFuture=[" + localInputFuture + "]";
+      String message = "inputFuture=[" + localInputFuture + "]";
+      if (localTimer != null) {
+        final long delay = localTimer.getDelay(TimeUnit.MILLISECONDS);
+        // Negative delays look confusing in an error message
+        if (delay > 0) {
+          message += ", remaining delay=[" + delay + " ms]";
+        }
+      }
+      return message;
     }
     return null;
   }

--- a/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
+++ b/guava/src/com/google/common/util/concurrent/TimeoutFuture.java
@@ -34,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * interrupted and cancelled if it times out.
  */
 @GwtIncompatible
-final class TimeoutFuture<V> extends AbstractFuture.TrustedFuture<V> {
+final class TimeoutFuture<V> extends FluentFuture.TrustedFuture<V> {
   static <V> ListenableFuture<V> create(
       ListenableFuture<V> delegate,
       long time,

--- a/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
+++ b/guava/src/com/google/common/util/concurrent/TrustedListenableFutureTask.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * performance reasons.
  */
 @GwtCompatible
-class TrustedListenableFutureTask<V> extends AbstractFuture.TrustedFuture<V>
+class TrustedListenableFutureTask<V> extends FluentFuture.TrustedFuture<V>
     implements RunnableFuture<V> {
 
   static <V> TrustedListenableFutureTask<V> create(AsyncCallable<V> callable) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a gap method to Range which computes the range that lies between two ranges. This operation is particularly useful as a replacement for Joda Time's Interval.gap when migrating to Java Time which has no Interval class.

Joda Time:
Interval interval = ...;
Interval gap = interval.gap(interval);

Java Time (after this CL):
Range<Instant> interval = ...;
Range<Instant> gap = interval.gap(otherInterval);

RELNOTES=Adds a gap() method to Range that computes the Range that lies between them.

856f3bc431f7f145f35c6a42a07e1f7158964467

-------

<p> Use gradle formatting

Fixes https://github.com/google/guava/pull/3216

44abd86cf18afa64d1776b19a7bedabda395877f

-------

<p> Add missing @since tag.

https://google.github.io/guava/releases/21.0/api/diffs/changes/com.google.common.util.concurrent.Monitor.html#com.google.common.util.concurrent.Monitor.newGuard_added(java.util.function.BooleanSupplier)

Noticed because of https://github.com/google/guava/issues/2853#issuecomment-412360793

2e93145e51699a3e533c72db2633456f65542ad7

-------

<p> Add information about thread wakeup or scheduling delays to TimeoutExceptions thrown from guava futures.

b155e35606632c756e8db2c414145237a02ef9ca

-------

<p> Remove unnecessary local.

It is a holdover from when we used the value locally, rather than just returned it: 353ae349a24fb6c9b3e233ca03e4012761c7f3d8

94134ff0559baefa9ecc8df2a7c61945b6dfc523

-------

<p> Make delayed get() test more resilient to thread scheduling delays.

cc18f991f9934b4cd06d8d7fc0dbd1cc7ea1b83f

-------

<p> Switch FluentFuture and AbstractFuture in inheritance chain

RELNOTES=AbstractFuture doesn't expose FluentFuture APIs anymore.

4d8e0a81d78cea279441625adc96467a5b7d0879