### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -439,8 +439,19 @@ public final class MediaType {
   public static final MediaType MANIFEST_JSON_UTF_8 =
       createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
+  /**
+   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+   * Language)</a>.
+   */
   public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
+
+  /**
+   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+   * Language)</a>, compressed using the ZIP format into KMZ archives.
+   */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
+
+  /** Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>. */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -16,8 +16,6 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.util.concurrent.Futures.getDone;
-import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 import com.google.common.annotations.Beta;
@@ -863,6 +861,27 @@ public abstract class AbstractFuture<V> implements ListenableFuture<V> {
     }
   }
 
+  /**
+   * An inlined private copy of {@link Uninterruptibles#getUninterruptibly} used to break an
+   * internal dependency on other /util/concurrent classes.
+   */
+  private static <V> V getUninterruptibly(Future<V> future) throws ExecutionException {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          return future.get();
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
   /** Unblocks all threads and runs all listeners. */
   private static void complete(AbstractFuture<?> future) {
     Listener next = null;
@@ -1028,7 +1047,7 @@ public abstract class AbstractFuture<V> implements ListenableFuture<V> {
 
   private void addDoneString(StringBuilder builder) {
     try {
-      V value = getDone(this);
+      V value = getUninterruptibly(this);
       builder.append("SUCCESS, result=[").append(userObjectToString(value)).append("]");
     } catch (ExecutionException e) {
       builder.append("FAILURE, cause=[").append(e.getCause()).append("]");

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -439,8 +439,19 @@ public final class MediaType {
   public static final MediaType MANIFEST_JSON_UTF_8 =
       createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
+  /**
+   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+   * Language)</a>.
+   */
   public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
+
+  /**
+   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
+   * Language)</a>, compressed using the ZIP format into KMZ archives.
+   */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
+
+  /** Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>. */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add Javadoc for MediaType.KML+KMZ+MBOX

Via https://github.com/google/guava/pull/3244

Original Author=Simon Legner (simon04)

7ac917c8d73768129499bd76fe41aa651391ba93

-------

<p> [guava concurrent] Inlined getDone() and getUninterruptibly() to break the source dependency from AbstractFuture to other classes in /util/concurrent.

b6726e17f9aa455ff5aa8ee7cee6089d37feb1ba