### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureCancellationCauseTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureCancellationCauseTest.java
@@ -16,9 +16,16 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
 import junit.framework.TestCase;
 
 /** Tests for {@link AbstractFuture} with the cancellation cause system property set */
@@ -39,10 +46,22 @@ public class AbstractFutureCancellationCauseTest extends TestCase {
     final String concurrentPackage = SettableFuture.class.getPackage().getName();
     classReloader =
         new URLClassLoader(ClassPathUtil.getClassPathUrls()) {
+          @GuardedBy("loadedClasses")
+          final Map<String, Class<?>> loadedClasses = new HashMap<>();
+
           @Override
           public Class<?> loadClass(String name) throws ClassNotFoundException {
-            if (name.startsWith(concurrentPackage)) {
-              return super.findClass(name);
+            if (name.startsWith(concurrentPackage)
+                // Use other classloader for ListenableFuture, so that the objects can interact
+                && !ListenableFuture.class.getName().equals(name)) {
+              synchronized (loadedClasses) {
+                Class<?> toReturn = loadedClasses.get(name);
+                if (toReturn == null) {
+                  toReturn = super.findClass(name);
+                  loadedClasses.put(name, toReturn);
+                }
+                return toReturn;
+              }
             }
             return super.loadClass(name);
           }
@@ -81,6 +100,55 @@ public class AbstractFutureCancellationCauseTest extends TestCase {
       fail("Expected CancellationException");
     } catch (CancellationException e) {
       assertNotNull(e.getCause());
+    }
+  }
+
+  public void testSetFuture_misbehavingFutureDoesNotThrow() throws Exception {
+    ListenableFuture<String> badFuture =
+        new ListenableFuture<String>() {
+          @Override
+          public boolean cancel(boolean interrupt) {
+            return false;
+          }
+
+          @Override
+          public boolean isDone() {
+            return true;
+          }
+
+          @Override
+          public boolean isCancelled() {
+            return true; // BAD!!
+          }
+
+          @Override
+          public String get() {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public String get(long time, TimeUnit unit) {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public void addListener(Runnable runnable, Executor executor) {
+            executor.execute(runnable);
+          }
+        };
+    Future<?> future = newFutureInstance();
+    future
+        .getClass()
+        .getMethod(
+            "setFuture",
+            future.getClass().getClassLoader().loadClass(ListenableFuture.class.getName()))
+        .invoke(future, badFuture);
+    try {
+      future.get();
+      fail();
+    } catch (CancellationException expected) {
+      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
+      assertThat(expected).hasCauseThat().hasMessageThat().contains(badFuture.toString());
     }
   }
 

--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -782,7 +782,7 @@ public class AbstractFutureTest extends TestCase {
     assertTrue(orig.isDone());
   }
 
-  public void testSetFuture_misbehavingFuture() throws Exception {
+  public void testSetFuture_misbehavingFutureThrows() throws Exception {
     SettableFuture<String> future = SettableFuture.create();
     ListenableFuture<String> badFuture =
         new ListenableFuture<String>() {
@@ -820,6 +820,44 @@ public class AbstractFutureTest extends TestCase {
     ExecutionException expected = getExpectingExecutionException(future);
     assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
     assertThat(expected).hasCauseThat().hasMessageThat().contains(badFuture.toString());
+  }
+
+  public void testSetFuture_misbehavingFutureDoesNotThrow() throws Exception {
+    SettableFuture<String> future = SettableFuture.create();
+    ListenableFuture<String> badFuture =
+        new ListenableFuture<String>() {
+          @Override
+          public boolean cancel(boolean interrupt) {
+            return false;
+          }
+
+          @Override
+          public boolean isDone() {
+            return true;
+          }
+
+          @Override
+          public boolean isCancelled() {
+            return true; // BAD!!
+          }
+
+          @Override
+          public String get() {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public String get(long time, TimeUnit unit) {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public void addListener(Runnable runnable, Executor executor) {
+            executor.execute(runnable);
+          }
+        };
+    future.setFuture(badFuture);
+    assertThat(future.isCancelled()).isTrue();
   }
 
   public void testCancel_stackOverflow() {

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -844,8 +844,25 @@ public abstract class AbstractFuture<V> implements ListenableFuture<V> {
     // Otherwise calculate the value by calling .get()
     try {
       Object v = getUninterruptibly(future);
+      if (wasCancelled) {
+        return new Cancellation(
+            false,
+            new IllegalArgumentException(
+                "get() did not throw CancellationException, despite reporting "
+                    + "isCancelled() == true: "
+                    + future));
+      }
       return v == null ? NULL : v;
     } catch (ExecutionException exception) {
+      if (wasCancelled) {
+        return new Cancellation(
+            false,
+            new IllegalArgumentException(
+                "get() did not throw CancellationException, despite reporting "
+                    + "isCancelled() == true: "
+                    + future,
+                exception));
+      }
       return new Failure(exception.getCause());
     } catch (CancellationException cancellation) {
       if (!wasCancelled) {

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureCancellationCauseTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureCancellationCauseTest.java
@@ -16,9 +16,16 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
 import junit.framework.TestCase;
 
 /** Tests for {@link AbstractFuture} with the cancellation cause system property set */
@@ -39,10 +46,22 @@ public class AbstractFutureCancellationCauseTest extends TestCase {
     final String concurrentPackage = SettableFuture.class.getPackage().getName();
     classReloader =
         new URLClassLoader(ClassPathUtil.getClassPathUrls()) {
+          @GuardedBy("loadedClasses")
+          final Map<String, Class<?>> loadedClasses = new HashMap<>();
+
           @Override
           public Class<?> loadClass(String name) throws ClassNotFoundException {
-            if (name.startsWith(concurrentPackage)) {
-              return super.findClass(name);
+            if (name.startsWith(concurrentPackage)
+                // Use other classloader for ListenableFuture, so that the objects can interact
+                && !ListenableFuture.class.getName().equals(name)) {
+              synchronized (loadedClasses) {
+                Class<?> toReturn = loadedClasses.get(name);
+                if (toReturn == null) {
+                  toReturn = super.findClass(name);
+                  loadedClasses.put(name, toReturn);
+                }
+                return toReturn;
+              }
             }
             return super.loadClass(name);
           }
@@ -81,6 +100,55 @@ public class AbstractFutureCancellationCauseTest extends TestCase {
       fail("Expected CancellationException");
     } catch (CancellationException e) {
       assertNotNull(e.getCause());
+    }
+  }
+
+  public void testSetFuture_misbehavingFutureDoesNotThrow() throws Exception {
+    ListenableFuture<String> badFuture =
+        new ListenableFuture<String>() {
+          @Override
+          public boolean cancel(boolean interrupt) {
+            return false;
+          }
+
+          @Override
+          public boolean isDone() {
+            return true;
+          }
+
+          @Override
+          public boolean isCancelled() {
+            return true; // BAD!!
+          }
+
+          @Override
+          public String get() {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public String get(long time, TimeUnit unit) {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public void addListener(Runnable runnable, Executor executor) {
+            executor.execute(runnable);
+          }
+        };
+    Future<?> future = newFutureInstance();
+    future
+        .getClass()
+        .getMethod(
+            "setFuture",
+            future.getClass().getClassLoader().loadClass(ListenableFuture.class.getName()))
+        .invoke(future, badFuture);
+    try {
+      future.get();
+      fail();
+    } catch (CancellationException expected) {
+      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
+      assertThat(expected).hasCauseThat().hasMessageThat().contains(badFuture.toString());
     }
   }
 

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -782,7 +782,7 @@ public class AbstractFutureTest extends TestCase {
     assertTrue(orig.isDone());
   }
 
-  public void testSetFuture_misbehavingFuture() throws Exception {
+  public void testSetFuture_misbehavingFutureThrows() throws Exception {
     SettableFuture<String> future = SettableFuture.create();
     ListenableFuture<String> badFuture =
         new ListenableFuture<String>() {
@@ -820,6 +820,44 @@ public class AbstractFutureTest extends TestCase {
     ExecutionException expected = getExpectingExecutionException(future);
     assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
     assertThat(expected).hasCauseThat().hasMessageThat().contains(badFuture.toString());
+  }
+
+  public void testSetFuture_misbehavingFutureDoesNotThrow() throws Exception {
+    SettableFuture<String> future = SettableFuture.create();
+    ListenableFuture<String> badFuture =
+        new ListenableFuture<String>() {
+          @Override
+          public boolean cancel(boolean interrupt) {
+            return false;
+          }
+
+          @Override
+          public boolean isDone() {
+            return true;
+          }
+
+          @Override
+          public boolean isCancelled() {
+            return true; // BAD!!
+          }
+
+          @Override
+          public String get() {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public String get(long time, TimeUnit unit) {
+            return "foo"; // BAD!!
+          }
+
+          @Override
+          public void addListener(Runnable runnable, Executor executor) {
+            executor.execute(runnable);
+          }
+        };
+    future.setFuture(badFuture);
+    assertThat(future.isCancelled()).isTrue();
   }
 
   public void testCancel_stackOverflow() {

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -844,8 +844,25 @@ public abstract class AbstractFuture<V> implements ListenableFuture<V> {
     // Otherwise calculate the value by calling .get()
     try {
       Object v = getUninterruptibly(future);
+      if (wasCancelled) {
+        return new Cancellation(
+            false,
+            new IllegalArgumentException(
+                "get() did not throw CancellationException, despite reporting "
+                    + "isCancelled() == true: "
+                    + future));
+      }
       return v == null ? NULL : v;
     } catch (ExecutionException exception) {
+      if (wasCancelled) {
+        return new Cancellation(
+            false,
+            new IllegalArgumentException(
+                "get() did not throw CancellationException, despite reporting "
+                    + "isCancelled() == true: "
+                    + future,
+                exception));
+      }
       return new Failure(exception.getCause());
     } catch (CancellationException cancellation) {
       if (!wasCancelled) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add more validation to AbstractFuture when cancellation causes are enabled, so that it matches the behavior when they are disabled.

49c73aaf7aef734e1f488aa0eb8d1b1bfebf5255

-------

<p> Bail early without a CancellationException in AbstractTransformFuture.

2ba14fdad20628de9eb7ea537af22e198d4d31a0