### PR TITLE
Implement getRandom() for Iterables

### DIFF
--- a/guava-tests/test/com/google/common/collect/IterablesTest.java
+++ b/guava-tests/test/com/google/common/collect/IterablesTest.java
@@ -1440,6 +1440,11 @@ public class IterablesTest extends TestCase {
         .testNulls();
   }
 
+  public void testGetRandom() {
+      ArrayList<String> strings = Lists.newArrayList("d", "a", "o");
+      strings.forEach(string -> assertTrue(strings.contains(Iterables.getRandom(strings))));
+  }
+
   private static void verifyMergeSorted(
       Iterable<Iterable<Integer>> iterables, Iterable<Integer> unsortedExpected) {
     Iterable<Integer> expected = Ordering.natural().sortedCopy(unsortedExpected);

--- a/guava/src/com/google/common/collect/Iterables.java
+++ b/guava/src/com/google/common/collect/Iterables.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -34,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
+import java.util.Random;
 import java.util.RandomAccess;
 import java.util.Set;
 import java.util.Spliterator;
@@ -1015,6 +1017,18 @@ public final class Iterables {
           }
         };
     return new UnmodifiableIterable<>(iterable);
+  }
+
+  /**
+   * Picks up random value from {@link Iterable}.
+   * <p>
+   *     Consider providing {@link Iterable} with at least 1 element,
+   *     in other way you will get {@link IllegalArgumentException}.
+   * </p>
+   */
+  public static <T> T getRandom(final Iterable<T> iterable) {
+    Preconditions.checkNotNull(iterable);
+    return Iterables.get(iterable, new Random().nextInt(Iterables.size(iterable)));
   }
 
   // TODO(user): Is this the best place for this? Move to fluent functions?


### PR DESCRIPTION
Hi, I want you to present my minor improvement for **Iterables** class.

In commercial application I am working with I faced a problem that I need to take random element from **ArrayList**. Thing that confused me the most that such functionality has been rejected for _Apache Commons (Collections)_ long time ago and has not been reviewed.

I hope that _Guava_ community does not think the same way.
Thanks.