### PR TITLE
Update truth, animal sniffer, error prone annotations, and JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
   <properties>
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
-    <truth.version>0.41</truth.version>
-    <animal.sniffer.version>1.14</animal.sniffer.version>
+    <truth.version>0.42</truth.version>
+    <animal.sniffer.version>1.17</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
   </properties>
   <issueManagement>
@@ -227,7 +227,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.1.3</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>
@@ -237,7 +237,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
All of these dependencies are out of date from those used in gRPC, and preventing
me from getting a current build of Guava into gRPC.