### PR TITLE
Update the “No removed APIs since” counter to 26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ensure that you do not use any `@Beta` APIs!**
 
 2. APIs without `@Beta` will remain binary-compatible for the indefinite
 future. (Previously, we sometimes removed such APIs after a deprecation period.
-The last release to remove non-`@Beta` APIs was Guava 21.0.) Even `@Deprecated`
+The last release to remove non-`@Beta` APIs was Guava 26.0.) Even `@Deprecated`
 APIs will remain (again, unless they are `@Beta`). We have no plans to start
 removing things again, but officially, we're leaving our options open in case
 of surprises (like, say, a serious security problem).


### PR DESCRIPTION
Removal of one of the catchingAsync overloads caused me some grief
because one of my projects’ transitive dependencies was using it.

https://github.com/google/guava/commit/87d87f5cac5a540d46a6382683722ead7b72d1b3
https://github.com/vitessio/vitess/pull/4214