### PR TITLE
Add ofNull() method to Suppliers.

### DIFF
--- a/guava-tests/test/com/google/common/base/SuppliersTest.java
+++ b/guava-tests/test/com/google/common/base/SuppliersTest.java
@@ -278,8 +278,12 @@ public class SuppliersTest extends TestCase {
     assertNull(nullSupplier.get());
   }
 
-  @GwtIncompatible // Thread
+  public void testOfNullSuppliesNull() {
+    Supplier<?> tested = Suppliers.ofNull();
+    assertNull(tested.get());
+  }
 
+  @GwtIncompatible // Thread
   public void testExpiringMemoizedSupplierThreadSafe() throws Throwable {
     Function<Supplier<Boolean>, Supplier<Boolean>> memoizer =
         new Function<Supplier<Boolean>, Supplier<Boolean>>() {
@@ -292,7 +296,6 @@ public class SuppliersTest extends TestCase {
   }
 
   @GwtIncompatible // Thread
-
   public void testMemoizedSupplierThreadSafe() throws Throwable {
     Function<Supplier<Boolean>, Supplier<Boolean>> memoizer =
         new Function<Supplier<Boolean>, Supplier<Boolean>>() {
@@ -381,7 +384,6 @@ public class SuppliersTest extends TestCase {
   }
 
   @GwtIncompatible // Thread
-
   public void testSynchronizedSupplierThreadSafe() throws InterruptedException {
     final Supplier<Integer> nonThreadSafe =
         new Supplier<Integer>() {

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -261,6 +261,11 @@ public final class Suppliers {
     private static final long serialVersionUID = 0;
   }
 
+  /** Returns a supplier that always supplies {@code null}. */
+  public static <T> Supplier<T> ofNull() {
+    return new SupplierOfInstance<T>(null);
+  }
+
   /** Returns a supplier that always supplies {@code instance}. */
   public static <T> Supplier<T> ofInstance(@Nullable T instance) {
     return new SupplierOfInstance<T>(instance);


### PR DESCRIPTION
Despite the fact that I avoid the use of nullable references, there are often few alternatives, especially if third-party libraries are used.

If, in such cases, a supplier is needed that returns `null` continuously, the current solution with the Guava library is to call the `ofInstance()` method with the argument `null` . This is not really clean and can be easily improved.

My added method makes the user's code cleaner and more readable.

_Without my method:_
```java
Supplier<?> nullSupplier = Suppliers.ofInstance(null);
```

_With my method:_
```java
Supplier<?> nullSupplier = Suppliers.ofNull();
```