### PR TITLE
Unhandled overflow in the `concat()` method of per-type primitive utility classes

### DIFF
--- a/guava-tests/test/com/google/common/primitives/LongsTest.java
+++ b/guava-tests/test/com/google/common/primitives/LongsTest.java
@@ -16,6 +16,7 @@
 
 package com.google.common.primitives;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.lang.Long.MAX_VALUE;
 import static java.lang.Long.MIN_VALUE;
 
@@ -185,6 +186,46 @@ public class LongsTest extends TestCase {
     assertTrue(
         Arrays.equals(
             new long[] {(long) 1, (long) 2, (long) 3, (long) 4}, Longs.concat(ARRAY1, ARRAY234)));
+  }
+
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat((long) dim1 * dim2).isNotEqualTo((long) (dim1 * dim2));
+    assertThat(dim1 * dim2).isLessThan(0);
+
+    long[][] arrays = new long[dim1][];
+    // it's shared to avoid using too much memory in tests
+    long[] sharedArray = new long[dim2];
+    for (int i = 0; i < dim1; i++) {
+      arrays[i] = sharedArray;
+    }
+
+    try {
+      Longs.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat((long) dim1 * dim2).isNotEqualTo((long) (dim1 * dim2));
+    assertThat(dim1 * dim2).isAtLeast(0);
+
+    long[][] arrays = new long[dim1][];
+    // it's shared to avoid using too much memory in tests
+    long[] sharedArray = new long[dim2];
+    for (int i = 0; i < dim1; i++) {
+      arrays[i] = sharedArray;
+    }
+
+    try {
+      Longs.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   private static void assertByteArrayEquals(byte[] expected, byte[] actual) {

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -247,19 +247,28 @@ public final class Longs {
    *
    * @param arrays zero or more {@code long} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not
+   *     fit in an {@code int}
    */
   public static long[] concat(long[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (long[] array : arrays) {
       length += array.length;
     }
-    long[] result = new long[length];
+    checkNoOverflow(length);
+    long[] result = new long[(int) length];
     int pos = 0;
     for (long[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static void checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements in the arrays must fit in an int");
   }
 
   /**


### PR DESCRIPTION
The `concat()` method in the per-type primitive utility classes throws unexpected `NegativeArraySizeException` or `ArrayIndexOutOfBoundsException` if the input arrays contain too many elements.

Added test cases to demonstrate both overflow cases. A possible fix is provided.

In this commit, only the module `guava` and only the utility class `Longs` is covered along with its unit tests.

See https://github.com/google/guava/issues/3303