### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
+++ b/android/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
@@ -326,6 +326,7 @@ public class EqualsTesterTest extends TestCase {
       this.aspect2 = aspect2;
     }
 
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object o) {
       if (!(o instanceof InvalidHashCodeObject)) {

--- a/android/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
+++ b/android/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
@@ -1384,6 +1384,7 @@ public class NullPointerTesterTest extends TestCase {
   }
 
   static class OverridesEquals {
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object o) {
       return true;

--- a/android/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
+++ b/android/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
@@ -80,6 +80,7 @@ public class SerializableTesterTest extends TestCase {
   private static class ClassWhichIsAlwaysEqualButHasDifferentHashcodes implements Serializable {
     private static final long serialVersionUID = 2L;
 
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object other) {
       return (other instanceof ClassWhichIsAlwaysEqualButHasDifferentHashcodes);

--- a/android/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
+++ b/android/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
@@ -116,6 +116,8 @@ public class ForwardingWrapperTesterTest extends TestCase {
           @Override
           public Runnable apply(final Runnable runnable) {
             return new ForwardingRunnable(runnable) {
+
+              @SuppressWarnings("EqualsHashCode")
               @Override
               public boolean equals(Object o) {
                 if (o instanceof ForwardingRunnable) {

--- a/android/guava/src/com/google/common/base/Platform.java
+++ b/android/guava/src/com/google/common/base/Platform.java
@@ -36,6 +36,7 @@ final class Platform {
   private Platform() {}
 
   /** Calls {@link System#nanoTime()}. */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   static long systemNanoTime() {
     return System.nanoTime();
   }

--- a/android/guava/src/com/google/common/base/Stopwatch.java
+++ b/android/guava/src/com/google/common/base/Stopwatch.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
  * @since 10.0
  */
 @GwtCompatible
+@SuppressWarnings("GoodTime") // lots of violations
 public final class Stopwatch {
   private final Ticker ticker;
   private boolean isRunning;

--- a/android/guava/src/com/google/common/base/Suppliers.java
+++ b/android/guava/src/com/google/common/base/Suppliers.java
@@ -213,6 +213,7 @@ public final class Suppliers {
   }
 
   @VisibleForTesting
+  @SuppressWarnings("GoodTime") // lots of violations
   static class ExpiringMemoizingSupplier<T> implements Supplier<T>, Serializable {
     final Supplier<T> delegate;
     final long durationNanos;

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -43,6 +43,9 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code Graph} using {@link #from(Graph)}.
  * @since 20.0
  */
 @Beta

--- a/android/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/android/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -46,6 +46,12 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code Network} using {@link #from(Network)}.
+ * @param <N> The most general edge type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #edgeOrder}, or the builder is
+ *     constructed based on an existing {@code Network} using {@link #from(Network)}.
  * @since 20.0
  */
 @Beta

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -44,6 +44,12 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code ValueGraph} using {@link #from(ValueGraph)}.
+ * @param <V> The most general value type this builder will support. This is normally {@code Object}
+ *     unless the builder is constructed based on an existing {@code Graph} using {@link
+ *     #from(ValueGraph)}.
  * @since 20.0
  */
 @Beta

--- a/android/guava/src/com/google/common/hash/Hashing.java
+++ b/android/guava/src/com/google/common/hash/Hashing.java
@@ -87,6 +87,7 @@ public final class Hashing {
    * Used to randomize {@link #goodFastHash} instances, so that programs which persist anything
    * dependent on the hash codes they produce will fail sooner.
    */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   static final int GOOD_FAST_HASH_SEED = (int) System.currentTimeMillis();
 
   /**

--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -397,6 +397,7 @@ public final class Files {
    */
   public static File createTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    @SuppressWarnings("GoodTime") // reading system time without TimeSource
     String baseName = System.currentTimeMillis() + "-";
 
     for (int counter = 0; counter < TEMP_DIR_ATTEMPTS; counter++) {
@@ -423,6 +424,7 @@ public final class Files {
    * @param file the file to create or update
    * @throws IOException if an I/O error occurs
    */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   public static void touch(File file) throws IOException {
     checkNotNull(file);
     if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {

--- a/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Platform.java
+++ b/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Platform.java
@@ -33,6 +33,7 @@ final class Platform {
     return matcher;
   }
 
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   static long systemNanoTime() {
     // System.nanoTime() is not available in GWT, so we get milliseconds
     // and convert to nanos.

--- a/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
@@ -326,6 +326,7 @@ public class EqualsTesterTest extends TestCase {
       this.aspect2 = aspect2;
     }
 
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object o) {
       if (!(o instanceof InvalidHashCodeObject)) {

--- a/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/NullPointerTesterTest.java
@@ -1437,6 +1437,7 @@ public class NullPointerTesterTest extends TestCase {
   }
 
   static class OverridesEquals {
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object o) {
       return true;

--- a/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/SerializableTesterTest.java
@@ -80,6 +80,7 @@ public class SerializableTesterTest extends TestCase {
   private static class ClassWhichIsAlwaysEqualButHasDifferentHashcodes implements Serializable {
     private static final long serialVersionUID = 2L;
 
+    @SuppressWarnings("EqualsHashCode")
     @Override
     public boolean equals(Object other) {
       return (other instanceof ClassWhichIsAlwaysEqualButHasDifferentHashcodes);

--- a/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
@@ -116,6 +116,8 @@ public class ForwardingWrapperTesterTest extends TestCase {
           @Override
           public Runnable apply(final Runnable runnable) {
             return new ForwardingRunnable(runnable) {
+
+              @SuppressWarnings("EqualsHashCode")
               @Override
               public boolean equals(Object o) {
                 if (o instanceof ForwardingRunnable) {

--- a/guava/src/com/google/common/base/Platform.java
+++ b/guava/src/com/google/common/base/Platform.java
@@ -36,6 +36,7 @@ final class Platform {
   private Platform() {}
 
   /** Calls {@link System#nanoTime()}. */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   static long systemNanoTime() {
     return System.nanoTime();
   }

--- a/guava/src/com/google/common/base/Stopwatch.java
+++ b/guava/src/com/google/common/base/Stopwatch.java
@@ -80,6 +80,7 @@ import java.util.concurrent.TimeUnit;
  * @since 10.0
  */
 @GwtCompatible(emulated = true)
+@SuppressWarnings("GoodTime") // lots of violations
 public final class Stopwatch {
   private final Ticker ticker;
   private boolean isRunning;

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -213,6 +213,7 @@ public final class Suppliers {
   }
 
   @VisibleForTesting
+  @SuppressWarnings("GoodTime") // lots of violations
   static class ExpiringMemoizingSupplier<T> implements Supplier<T>, Serializable {
     final Supplier<T> delegate;
     final long durationNanos;

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -43,6 +43,9 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code Graph} using {@link #from(Graph)}.
  * @since 20.0
  */
 @Beta

--- a/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -46,6 +46,12 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code Network} using {@link #from(Network)}.
+ * @param <N> The most general edge type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #edgeOrder}, or the builder is
+ *     constructed based on an existing {@code Network} using {@link #from(Network)}.
  * @since 20.0
  */
 @Beta

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -44,6 +44,12 @@ import com.google.common.base.Optional;
  *
  * @author James Sexton
  * @author Joshua O'Madadhain
+ * @param <N> The most general node type this builder will support. This is normally {@code Object}
+ *     unless it is constrained by using a method like {@link #nodeOrder}, or the builder is
+ *     constructed based on an existing {@code ValueGraph} using {@link #from(ValueGraph)}.
+ * @param <V> The most general value type this builder will support. This is normally {@code Object}
+ *     unless the builder is constructed based on an existing {@code Graph} using {@link
+ *     #from(ValueGraph)}.
  * @since 20.0
  */
 @Beta

--- a/guava/src/com/google/common/hash/Hashing.java
+++ b/guava/src/com/google/common/hash/Hashing.java
@@ -87,6 +87,7 @@ public final class Hashing {
    * Used to randomize {@link #goodFastHash} instances, so that programs which persist anything
    * dependent on the hash codes they produce will fail sooner.
    */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   static final int GOOD_FAST_HASH_SEED = (int) System.currentTimeMillis();
 
   /**

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -397,6 +397,7 @@ public final class Files {
    */
   public static File createTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    @SuppressWarnings("GoodTime") // reading system time without TimeSource
     String baseName = System.currentTimeMillis() + "-";
 
     for (int counter = 0; counter < TEMP_DIR_ATTEMPTS; counter++) {
@@ -423,6 +424,7 @@ public final class Files {
    * @param file the file to create or update
    * @throws IOException if an I/O error occurs
    */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   public static void touch(File file) throws IOException {
     checkNotNull(file);
     if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {

--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -391,6 +391,7 @@ public final class MoreFiles {
    * Like the unix command of the same name, creates an empty file or updates the last modified
    * timestamp of the existing file at the given path to the current system time.
    */
+  @SuppressWarnings("GoodTime") // reading system time without TimeSource
   public static void touch(Path path) throws IOException {
     checkNotNull(path);
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Enable goodtime-api for Guava (with some exceptions).

603ecca60c11d9a343423ae908bbc325521a7f50

-------

<p> *Builder.java: add @param documentation for the node/value/edge types that clarifies their behavior.

This is in response to (and should resolve) https://github.com/google/guava/issues/3299.

9db70c6519ef588697a9c522ee36aea439f36241

-------

<p> Suppress warnings in classes that implement equals() without also implementing
hashCode().

The contract for Object.hashCode states that if two objects are equal, then
calling the hashCode() method on each of the two objects must produce the same
result. Implementing equals() but not hashCode() causes broken behaviour when
trying to store the object in a collection.

73f7e84a345805dc4fcc9927201e03fdbf408c5f