### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/base/SplitterTest.java
+++ b/android/guava-tests/test/com/google/common/base/SplitterTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
 import java.util.Iterator;
@@ -773,5 +774,12 @@ public class SplitterTest extends TestCase {
       fail();
     } catch (IllegalArgumentException expected) {
     }
+  }
+
+  public void testMapSplitter_varyingTrimLevels() {
+    MapSplitter splitter = COMMA_SPLITTER.trimResults().withKeyValueSeparator(Splitter.on("->"));
+    Map<String, String> split = splitter.split(" x -> y, z-> a ");
+    assertThat(split).containsEntry("x ", " y");
+    assertThat(split).containsEntry("z", " a");
   }
 }

--- a/android/guava-tests/test/com/google/common/graph/PackageSanityTests.java
+++ b/android/guava-tests/test/com/google/common/graph/PackageSanityTests.java
@@ -51,6 +51,7 @@ public class PackageSanityTests extends AbstractPackageSanityTests {
     setDistinctValues(Graph.class, IMMUTABLE_GRAPH_A, IMMUTABLE_GRAPH_B);
     setDistinctValues(NetworkBuilder.class, NETWORK_BUILDER_A, NETWORK_BUILDER_B);
     setDistinctValues(Network.class, IMMUTABLE_NETWORK_A, IMMUTABLE_NETWORK_B);
+    setDefault(EndpointPair.class, EndpointPair.ordered("A", "B"));
   }
 
   @Override

--- a/android/guava/src/com/google/common/base/Splitter.java
+++ b/android/guava/src/com/google/common/base/Splitter.java
@@ -453,7 +453,7 @@ public final class Splitter {
    * Splitter outerSplitter = Splitter.on(',').trimResults();
    * MapSplitter mapSplitter = outerSplitter.withKeyValueSeparator(Splitter.on("->"));
    * Map<String, String> result = mapSplitter.split(toSplit);
-   * assertThat(result).isEqualTo(ImmutableMap.of(" x", " y", "z", " a"));
+   * assertThat(result).isEqualTo(ImmutableMap.of("x ", " y", "z", " a"));
    * }</pre>
    *
    * @since 10.0

--- a/android/guava/src/com/google/common/collect/DenseImmutableTable.java
+++ b/android/guava/src/com/google/common/collect/DenseImmutableTable.java
@@ -14,8 +14,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableMap.IteratorBasedImmutableMap;
 import com.google.errorprone.annotations.Immutable;
@@ -69,7 +67,7 @@ final class DenseImmutableTable<R, C, V> extends RegularImmutableTable<R, C, V> 
       int rowIndex = rowKeyToIndex.get(rowKey);
       int columnIndex = columnKeyToIndex.get(columnKey);
       V existingValue = values[rowIndex][columnIndex];
-      checkArgument(existingValue == null, "duplicate key: (%s, %s)", rowKey, columnKey);
+      checkNoDuplicate(rowKey, columnKey, existingValue, cell.getValue());
       values[rowIndex][columnIndex] = cell.getValue();
       rowCounts[rowIndex]++;
       columnCounts[columnIndex]++;

--- a/android/guava/src/com/google/common/collect/RegularImmutableTable.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableTable.java
@@ -14,6 +14,7 @@
 
 package com.google.common.collect;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
@@ -166,5 +167,20 @@ abstract class RegularImmutableTable<R, C, V> extends ImmutableTable<R, C, V> {
     return (cellList.size() > (((long) rowSpace.size() * columnSpace.size()) / 2))
         ? new DenseImmutableTable<R, C, V>(cellList, rowSpace, columnSpace)
         : new SparseImmutableTable<R, C, V>(cellList, rowSpace, columnSpace);
+  }
+
+  /** @throws IllegalArgumentException if {@code existingValue} is not null. */
+  /*
+   * We could have declared this method 'static' but the additional compile-time checks achieved by
+   * referencing the type variables seem worthwhile.
+   */
+  final void checkNoDuplicate(R rowKey, C columnKey, V existingValue, V newValue) {
+    checkArgument(
+        existingValue == null,
+        "Duplicate key: (row=%s, column=%s), values: [%s, %s].",
+        rowKey,
+        columnKey,
+        newValue,
+        existingValue);
   }
 }

--- a/android/guava/src/com/google/common/collect/SparseImmutableTable.java
+++ b/android/guava/src/com/google/common/collect/SparseImmutableTable.java
@@ -65,17 +65,7 @@ final class SparseImmutableTable<R, C, V> extends RegularImmutableTable<R, C, V>
       Map<C, V> thisRow = rows.get(rowKey);
       cellColumnInRowIndices[i] = thisRow.size();
       V oldValue = thisRow.put(columnKey, value);
-      if (oldValue != null) {
-        throw new IllegalArgumentException(
-            "Duplicate value for row="
-                + rowKey
-                + ", column="
-                + columnKey
-                + ": "
-                + value
-                + ", "
-                + oldValue);
-      }
+      checkNoDuplicate(rowKey, columnKey, oldValue, value);
       columns.get(columnKey).put(rowKey, value);
     }
     this.cellRowIndices = cellRowIndices;

--- a/guava-gwt/test/com/google/common/base/SplitterTest_gwt.java
+++ b/guava-gwt/test/com/google/common/base/SplitterTest_gwt.java
@@ -268,6 +268,11 @@ public void testMapSplitter_trimmedKeyValue() throws Exception {
   testCase.testMapSplitter_trimmedKeyValue();
 }
 
+public void testMapSplitter_varyingTrimLevels() throws Exception {
+  com.google.common.base.SplitterTest testCase = new com.google.common.base.SplitterTest();
+  testCase.testMapSplitter_varyingTrimLevels();
+}
+
 public void testSplitNullString() throws Exception {
   com.google.common.base.SplitterTest testCase = new com.google.common.base.SplitterTest();
   testCase.testSplitNullString();

--- a/guava-tests/test/com/google/common/base/SplitterTest.java
+++ b/guava-tests/test/com/google/common/base/SplitterTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.Splitter.MapSplitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
 import java.util.Iterator;
@@ -773,5 +774,12 @@ public class SplitterTest extends TestCase {
       fail();
     } catch (IllegalArgumentException expected) {
     }
+  }
+
+  public void testMapSplitter_varyingTrimLevels() {
+    MapSplitter splitter = COMMA_SPLITTER.trimResults().withKeyValueSeparator(Splitter.on("->"));
+    Map<String, String> split = splitter.split(" x -> y, z-> a ");
+    assertThat(split).containsEntry("x ", " y");
+    assertThat(split).containsEntry("z", " a");
   }
 }

--- a/guava-tests/test/com/google/common/graph/PackageSanityTests.java
+++ b/guava-tests/test/com/google/common/graph/PackageSanityTests.java
@@ -51,6 +51,7 @@ public class PackageSanityTests extends AbstractPackageSanityTests {
     setDistinctValues(Graph.class, IMMUTABLE_GRAPH_A, IMMUTABLE_GRAPH_B);
     setDistinctValues(NetworkBuilder.class, NETWORK_BUILDER_A, NETWORK_BUILDER_B);
     setDistinctValues(Network.class, IMMUTABLE_NETWORK_A, IMMUTABLE_NETWORK_B);
+    setDefault(EndpointPair.class, EndpointPair.ordered("A", "B"));
   }
 
   @Override

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -454,7 +454,7 @@ public final class Splitter {
    * Splitter outerSplitter = Splitter.on(',').trimResults();
    * MapSplitter mapSplitter = outerSplitter.withKeyValueSeparator(Splitter.on("->"));
    * Map<String, String> result = mapSplitter.split(toSplit);
-   * assertThat(result).isEqualTo(ImmutableMap.of(" x", " y", "z", " a"));
+   * assertThat(result).isEqualTo(ImmutableMap.of("x ", " y", "z", " a"));
    * }</pre>
    *
    * @since 10.0

--- a/guava/src/com/google/common/collect/DenseImmutableTable.java
+++ b/guava/src/com/google/common/collect/DenseImmutableTable.java
@@ -14,8 +14,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableMap.IteratorBasedImmutableMap;
 import com.google.errorprone.annotations.Immutable;
@@ -69,7 +67,7 @@ final class DenseImmutableTable<R, C, V> extends RegularImmutableTable<R, C, V> 
       int rowIndex = rowKeyToIndex.get(rowKey);
       int columnIndex = columnKeyToIndex.get(columnKey);
       V existingValue = values[rowIndex][columnIndex];
-      checkArgument(existingValue == null, "duplicate key: (%s, %s)", rowKey, columnKey);
+      checkNoDuplicate(rowKey, columnKey, existingValue, cell.getValue());
       values[rowIndex][columnIndex] = cell.getValue();
       rowCounts[rowIndex]++;
       columnCounts[columnIndex]++;

--- a/guava/src/com/google/common/collect/RegularImmutableTable.java
+++ b/guava/src/com/google/common/collect/RegularImmutableTable.java
@@ -14,6 +14,7 @@
 
 package com.google.common.collect;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
@@ -166,5 +167,20 @@ abstract class RegularImmutableTable<R, C, V> extends ImmutableTable<R, C, V> {
     return (cellList.size() > (((long) rowSpace.size() * columnSpace.size()) / 2))
         ? new DenseImmutableTable<R, C, V>(cellList, rowSpace, columnSpace)
         : new SparseImmutableTable<R, C, V>(cellList, rowSpace, columnSpace);
+  }
+
+  /** @throws IllegalArgumentException if {@code existingValue} is not null. */
+  /*
+   * We could have declared this method 'static' but the additional compile-time checks achieved by
+   * referencing the type variables seem worthwhile.
+   */
+  final void checkNoDuplicate(R rowKey, C columnKey, V existingValue, V newValue) {
+    checkArgument(
+        existingValue == null,
+        "Duplicate key: (row=%s, column=%s), values: [%s, %s].",
+        rowKey,
+        columnKey,
+        newValue,
+        existingValue);
   }
 }

--- a/guava/src/com/google/common/collect/SparseImmutableTable.java
+++ b/guava/src/com/google/common/collect/SparseImmutableTable.java
@@ -65,17 +65,7 @@ final class SparseImmutableTable<R, C, V> extends RegularImmutableTable<R, C, V>
       Map<C, V> thisRow = rows.get(rowKey);
       cellColumnInRowIndices[i] = thisRow.size();
       V oldValue = thisRow.put(columnKey, value);
-      if (oldValue != null) {
-        throw new IllegalArgumentException(
-            "Duplicate value for row="
-                + rowKey
-                + ", column="
-                + columnKey
-                + ": "
-                + value
-                + ", "
-                + oldValue);
-      }
+      checkNoDuplicate(rowKey, columnKey, oldValue, value);
       columns.get(columnKey).put(rowKey, value);
     }
     this.cellRowIndices = cellRowIndices;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Correct documentation for Splitter#withKeyValueSeparator(Splitter)

8340e5a770401494da5194e33153079754381006

-------

<p> Standardise message format for "duplicate key" IllegalArgumentException thrown from ImmutableTable.Builder.build().

Internally, ImmutableTable.Builder.build() delegates to two classes, {Dense,Sparse}ImmutableTable and these currently have inconsistent error messages when a duplicate key is detected.

Prior to this CL, SparseImmutableTable had a message formatted like:
  "Duplicate value for row=%rowKey%, column=%columnKey%: %newValue%, %oldValue%"
Whereas DenseImmutableTable had:
  "duplicate key: (%rowKey%, %columnKey%)"

After this CL both classes will format the message like:
  "Duplicate key: (row=%rowKey%, column=%columnKey%), values: [%newValue%, %oldValue%]."

RELNOTES=Standardise message format for "duplicate key" IllegalArgumentException thrown from ImmutableTable.Builder.build().

96e21ae4f9fce2dc622658cff322b01f1721012e

-------

<p> common.graph PackageSanityTests: specify a default object for EndpointPair inputs.
This should resolve a few internal flaky test issues

4210f57678985b51439b0fa37779ec5b369024b8