### PR TITLE
Field, parameter, and variable.

### DIFF
--- a/android/guava/src/com/google/common/collect/AbstractBiMap.java
+++ b/android/guava/src/com/google/common/collect/AbstractBiMap.java
@@ -85,7 +85,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
    * Specifies the delegate maps going in each direction. Called by the constructor and by
    * subclasses during deserialization.
    */
-  void setDelegates(Map<K, V> forward, Map<V, K> backward) {
+  void setDelegates(final Map<K, V> forward, final Map<V, K> backward) {
     checkState(delegate == null);
     checkState(inverse == null);
     checkArgument(forward.isEmpty());
@@ -95,7 +95,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     inverse = makeInverse(backward);
   }
 
-  AbstractBiMap<V, K> makeInverse(Map<V, K> backward) {
+  AbstractBiMap<V, K> makeInverse(final Map<V, K> backward) {
     return new Inverse<>(backward, this);
   }
 
@@ -141,7 +141,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     return oldValue;
   }
 
-  private void updateInverseMap(K key, boolean containedKey, V oldValue, V newValue) {
+  private void updateInverseMap(final K key, final boolean containedKey, final V oldValue, final V newValue) {
     if (containedKey) {
       removeFromInverseMap(oldValue);
     }
@@ -155,20 +155,20 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
   }
 
   @CanIgnoreReturnValue
-  private V removeFromBothMaps(Object key) {
+  private V removeFromBothMaps(final Object key) {
     V oldValue = delegate.remove(key);
     removeFromInverseMap(oldValue);
     return oldValue;
   }
 
-  private void removeFromInverseMap(V oldValue) {
+  private void removeFromInverseMap(final V oldValue) {
     inverse.delegate.remove(oldValue);
   }
 
   // Bulk Operations
 
   @Override
-  public void putAll(Map<? extends K, ? extends V> map) {
+  public void putAll(final Map<? extends K, ? extends V> map) {
     for (Entry<? extends K, ? extends V> entry : map.entrySet()) {
       put(entry.getKey(), entry.getValue());
     }
@@ -208,7 +208,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(final Object key) {
       if (!contains(key)) {
         return false;
       }
@@ -217,12 +217,12 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public boolean removeAll(Collection<?> keysToRemove) {
+    public boolean removeAll(final Collection<?> keysToRemove) {
       return standardRemoveAll(keysToRemove);
     }
 
     @Override
-    public boolean retainAll(Collection<?> keysToRetain) {
+    public boolean retainAll(final Collection<?> keysToRetain) {
       return standardRetainAll(keysToRetain);
     }
 
@@ -264,7 +264,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public <T> T[] toArray(T[] array) {
+    public <T> T[] toArray(final T[] array) {
       return standardToArray(array);
     }
 
@@ -295,7 +295,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public V setValue(V value) {
+    public V setValue(final V value) {
       checkValue(value);
       // Preconditions keep the map and inverse consistent.
       checkState(entrySet().contains(this), "entry no longer in map");
@@ -353,7 +353,7 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public boolean remove(Object object) {
+    public boolean remove(final Object object) {
       if (!esDelegate.contains(object)) {
         return false;
       }
@@ -383,27 +383,27 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
     }
 
     @Override
-    public <T> T[] toArray(T[] array) {
+    public <T> T[] toArray(final T[] array) {
       return standardToArray(array);
     }
 
     @Override
-    public boolean contains(Object o) {
+    public boolean contains(final Object o) {
       return Maps.containsEntryImpl(delegate(), o);
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
+    public boolean containsAll(final Collection<?> c) {
       return standardContainsAll(c);
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
+    public boolean removeAll(final Collection<?> c) {
       return standardRemoveAll(c);
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
+    public boolean retainAll(final Collection<?> c) {
       return standardRetainAll(c);
     }
   }
@@ -424,25 +424,25 @@ abstract class AbstractBiMap<K, V> extends ForwardingMap<K, V>
      */
 
     @Override
-    K checkKey(K key) {
+    K checkKey(final K key) {
       return inverse.checkValue(key);
     }
 
     @Override
-    V checkValue(V value) {
+    V checkValue(final V value) {
       return inverse.checkKey(value);
     }
 
     /** @serialData the forward bimap */
     @GwtIncompatible // java.io.ObjectOutputStream
-    private void writeObject(ObjectOutputStream stream) throws IOException {
+    private void writeObject(final ObjectOutputStream stream) throws IOException {
       stream.defaultWriteObject();
       stream.writeObject(inverse());
     }
 
     @GwtIncompatible // java.io.ObjectInputStream
     @SuppressWarnings("unchecked") // reading data stored by writeObject
-    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+    private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
       stream.defaultReadObject();
       setInverse((AbstractBiMap<V, K>) stream.readObject());
     }


### PR DESCRIPTION
The final modifier can be used in fields, parameters, and local variables to indicate they cannot be re-assigned. This edit improves clarity and it helps with debugging.