### PR TITLE
Use the class Path to represent a path instead of a String.

### DIFF
--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -43,6 +43,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -497,7 +499,8 @@ public final class ClassPath {
      */
     @VisibleForTesting
     static URL getClassPathEntry(File jarFile, String path) throws MalformedURLException {
-      return new URL(jarFile.toURI().toURL(), path);
+      Path fpath = Paths.get(path);
+      return new URL(jarFile.toURI().toURL(), fpath.toString());
     }
   }
 


### PR DESCRIPTION
Strings can be used to represent a file system path even though some classes are specifically designed for this task. For instance, java.nio.Path. It is useful to change the type of the variable to Path, since strings can be combined in an undisciplined way, which can lead to invalid paths. Second, different operating systems use different file separators, which can cause bugs.