### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -165,6 +165,13 @@ public final class MediaType {
   public static final MediaType TSV_UTF_8 = createConstantUtf8(TEXT_TYPE, "tab-separated-values");
 
   public static final MediaType VCARD_UTF_8 = createConstantUtf8(TEXT_TYPE, "vcard");
+
+  /**
+   * UTF-8 encoded <a href="https://en.wikipedia.org/wiki/Wireless_Markup_Language">Wireless Markup
+   * Language</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType WML_UTF_8 = createConstantUtf8(TEXT_TYPE, "vnd.wap.wml");
 
   /**
@@ -182,11 +189,16 @@ public final class MediaType {
    */
   public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
-  /* image types */
+  /**
+   * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
+   * files).
+   *
+   * @since 13.0
+   */
   public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
 
   /**
-   * The media type for the <a href="http://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
+   * The media type for the <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
    * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
    * found in {@code /etc/mime.types}, e.g. in <a href=
    * "http://anonscm.debian.org/gitweb/?p=collab-maint/mime-support.git;a=blob;f=mime.types;hb=HEAD"
@@ -222,6 +234,12 @@ public final class MediaType {
 
   public static final MediaType SVG_UTF_8 = createConstantUtf8(IMAGE_TYPE, "svg+xml");
   public static final MediaType TIFF = createConstant(IMAGE_TYPE, "tiff");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/WebP">WebP image format</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
   /* audio types */
@@ -344,6 +362,8 @@ public final class MediaType {
    * As described in <a href="http://www.ietf.org/rfc/rfc3023.txt">RFC 3023</a>, this constant
    * ({@code application/xml}) is used for XML documents that are "unreadable by casual users."
    * {@link #XML_UTF_8} is provided for documents that may be read by users.
+   *
+   * @since 14.0
    */
   public static final MediaType APPLICATION_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xml");
 
@@ -451,7 +471,11 @@ public final class MediaType {
    */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
-  /** Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>. */
+  /**
+   * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**
@@ -537,7 +561,16 @@ public final class MediaType {
    */
   public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
 
+  /**
+   * <a href="https://en.wikipedia.org/wiki/RDF/XML">RDF/XML</a> documents, which are XML
+   * serializations of <a
+   * href="https://en.wikipedia.org/wiki/Resource_Description_Framework">Resource Description
+   * Framework</a> graphs.
+   *
+   * @since 14.0
+   */
   public static final MediaType RDF_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rdf+xml");
+
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
@@ -553,6 +586,13 @@ public final class MediaType {
 
   public static final MediaType SHOCKWAVE_FLASH =
       createConstant(APPLICATION_TYPE, "x-shockwave-flash");
+
+  /**
+   * {@code skp} files produced by the 3D Modeling software <a
+   * href="https://www.sketchup.com/">SketchUp</a>
+   *
+   * @since 13.0
+   */
   public static final MediaType SKETCHUP = createConstant(APPLICATION_TYPE, "vnd.sketchup.skp");
 
   /**
@@ -595,6 +635,8 @@ public final class MediaType {
    * it is specified by OASIS in the <a
    * href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD definition</a> and
    * implemented in projects such as <a href="http://code.google.com/p/webfinger/">WebFinger</a>.
+   *
+   * @since 14.0
    */
   public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
 

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -198,9 +198,9 @@ public final class MediaType {
   public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
 
   /**
-   * The media type for the <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
-   * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
-   * found in {@code /etc/mime.types}, e.g. in <a href=
+   * The <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon Image File
+   * Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is found in
+   * {@code /etc/mime.types}, e.g. in <a href=
    * "http://anonscm.debian.org/gitweb/?p=collab-maint/mime-support.git;a=blob;f=mime.types;hb=HEAD"
    * >Debian 3.48-1</a>.
    *
@@ -214,7 +214,7 @@ public final class MediaType {
   public static final MediaType PNG = createConstant(IMAGE_TYPE, "png");
 
   /**
-   * The media type for the Photoshop File Format ({@code psd} files) as defined by <a
+   * The Photoshop File Format ({@code psd} files) as defined by <a
    * href="http://www.iana.org/assignments/media-types/image/vnd.adobe.photoshop">IANA</a>, and
    * found in {@code /etc/mime.types}, e.g. <a
    * href="http://svn.apache.org/repos/asf/httpd/httpd/branches/1.3.x/conf/mime.types"></a> of the
@@ -249,31 +249,29 @@ public final class MediaType {
   public static final MediaType WEBM_AUDIO = createConstant(AUDIO_TYPE, "webm");
 
   /**
-   * Media type for L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC
-   * 2586</a>.
+   * L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC 2586</a>.
    *
    * @since 24.1
    */
   public static final MediaType L16_AUDIO = createConstant(AUDIO_TYPE, "l16");
 
   /**
-   * Media type for L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC
-   * 3190</a>.
+   * L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC 3190</a>.
    *
    * @since 20.0
    */
   public static final MediaType L24_AUDIO = createConstant(AUDIO_TYPE, "l24");
 
   /**
-   * Media type for Basic Audio, as defined by <a
-   * href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC 2046</a>.
+   * Basic Audio, as defined by <a href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC
+   * 2046</a>.
    *
    * @since 20.0
    */
   public static final MediaType BASIC_AUDIO = createConstant(AUDIO_TYPE, "basic");
 
   /**
-   * Media type for Advanced Audio Coding. For more information, see <a
+   * Advanced Audio Coding. For more information, see <a
    * href="https://en.wikipedia.org/wiki/Advanced_Audio_Coding">Advanced Audio Coding</a>.
    *
    * @since 20.0
@@ -281,15 +279,14 @@ public final class MediaType {
   public static final MediaType AAC_AUDIO = createConstant(AUDIO_TYPE, "aac");
 
   /**
-   * Media type for Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC
-   * 5215</a>.
+   * Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC 5215</a>.
    *
    * @since 20.0
    */
   public static final MediaType VORBIS_AUDIO = createConstant(AUDIO_TYPE, "vorbis");
 
   /**
-   * Media type for Windows Media Audio. For more information, see <a
+   * Windows Media Audio. For more information, see <a
    * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
    * name extensions for Windows Media metafiles</a>.
    *
@@ -298,7 +295,7 @@ public final class MediaType {
   public static final MediaType WMA_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wma");
 
   /**
-   * Media type for Windows Media metafiles. For more information, see <a
+   * Windows Media metafiles. For more information, see <a
    * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
    * name extensions for Windows Media metafiles</a>.
    *
@@ -307,7 +304,7 @@ public final class MediaType {
   public static final MediaType WAX_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wax");
 
   /**
-   * Media type for Real Audio. For more information, see <a
+   * Real Audio. For more information, see <a
    * href="http://service.real.com/help/faq/rp8/configrp8win.html">this link</a>.
    *
    * @since 20.0
@@ -315,8 +312,7 @@ public final class MediaType {
   public static final MediaType VND_REAL_AUDIO = createConstant(AUDIO_TYPE, "vnd.rn-realaudio");
 
   /**
-   * Media type for WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC
-   * 2361</a>.
+   * WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC 2361</a>.
    *
    * @since 20.0
    */
@@ -331,7 +327,7 @@ public final class MediaType {
   public static final MediaType WMV = createConstant(VIDEO_TYPE, "x-ms-wmv");
 
   /**
-   * Media type for Flash video. For more information, see <a href=
+   * Flash video. For more information, see <a href=
    * "http://help.adobe.com/en_US/ActionScript/3.0_ProgrammingAS3/WS5b3ccc516d4fbf351e63e3d118a9b90204-7d48.html"
    * >this link</a>.
    *
@@ -340,7 +336,7 @@ public final class MediaType {
   public static final MediaType FLV_VIDEO = createConstant(VIDEO_TYPE, "x-flv");
 
   /**
-   * Media type for the 3GP multimedia container format. For more information, see <a
+   * The 3GP multimedia container format. For more information, see <a
    * href="ftp://www.3gpp.org/tsg_sa/TSG_SA/TSGS_23/Docs/PDF/SP-040065.pdf#page=10">3GPP TS
    * 26.244</a>.
    *
@@ -349,7 +345,7 @@ public final class MediaType {
   public static final MediaType THREE_GPP_VIDEO = createConstant(VIDEO_TYPE, "3gpp");
 
   /**
-   * Media type for the 3G2 multimedia container format. For more information, see <a
+   * The 3G2 multimedia container format. For more information, see <a
    * href="http://www.3gpp2.org/Public_html/specs/C.S0050-B_v1.0_070521.pdf#page=16">3GPP2
    * C.S0050-B</a>.
    *
@@ -371,14 +367,15 @@ public final class MediaType {
   public static final MediaType BZIP2 = createConstant(APPLICATION_TYPE, "x-bzip2");
 
   /**
-   * Media type for <a href="https://www.dartlang.org/articles/embedding-in-html/">dart files</a>.
+   * Files in the <a href="https://www.dartlang.org/articles/embedding-in-html/">dart</a>
+   * programming language.
    *
    * @since 19.0
    */
   public static final MediaType DART_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "dart");
 
   /**
-   * Media type for <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
+   * <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
    *
    * @since 19.0
    */
@@ -386,9 +383,8 @@ public final class MediaType {
       createConstant(APPLICATION_TYPE, "vnd.apple.pkpass");
 
   /**
-   * Media type for <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a>
-   * fonts. This is <a
-   * href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
+   * <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a> fonts. This is
+   * <a href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
    * </a> with the IANA.
    *
    * @since 17.0
@@ -433,8 +429,8 @@ public final class MediaType {
   public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
   /**
-   * Media type for the <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON
-   * Hypertext Application Language (HAL) documents</a>.
+   * <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
+   * Application Language (HAL) documents</a>.
    *
    * @since 26.0
    */
@@ -451,8 +447,7 @@ public final class MediaType {
   public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
 
   /**
-   * Media type for the <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web
-   * application</a>.
+   * The <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web application</a>.
    *
    * @since 19.0
    */
@@ -460,61 +455,59 @@ public final class MediaType {
       createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
   /**
-   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-   * Language)</a>.
+   * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>.
    */
   public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
 
   /**
-   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-   * Language)</a>, compressed using the ZIP format into KMZ archives.
+   * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>,
+   * compressed using the ZIP format into KMZ archives.
    */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
   /**
-   * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+   * The <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
    *
    * @since 13.0
    */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**
-   * Media type for <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration
-   * profiles</a>.
+   * <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration profiles</a>.
    *
    * @since 18.0
    */
   public static final MediaType APPLE_MOBILE_CONFIG =
       createConstant(APPLICATION_TYPE, "x-apple-aspen-config");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Excel</a> spreadsheets. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Excel</a> spreadsheets. */
   public static final MediaType MICROSOFT_EXCEL = createConstant(APPLICATION_TYPE, "vnd.ms-excel");
 
   /**
-   * Media type for <a href="http://goo.gl/XrTEqG">Microsoft Outlook</a> items.
+   * <a href="http://goo.gl/XrTEqG">Microsoft Outlook</a> items.
    *
    * @since NEXT
    */
   public static final MediaType MICROSOFT_OUTLOOK =
       createConstant(APPLICATION_TYPE, "vnd.ms-outlook");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Powerpoint</a> presentations. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Powerpoint</a> presentations. */
   public static final MediaType MICROSOFT_POWERPOINT =
       createConstant(APPLICATION_TYPE, "vnd.ms-powerpoint");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Word</a> documents. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Word</a> documents. */
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
-   * Media type for WASM applications. For more information see <a
-   * href="https://webassembly.org/">the Web Assembly overview</a>.
+   * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
+   * overview</a>.
    *
    * @since 27.0
    */
   public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
 
   /**
-   * Media type for NaCl applications. For more information see <a
+   * NaCl applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.
    *
@@ -523,7 +516,7 @@ public final class MediaType {
   public static final MediaType NACL_APPLICATION = createConstant(APPLICATION_TYPE, "x-nacl");
 
   /**
-   * Media type for NaCl portable applications. For more information see <a
+   * NaCl portable applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.
    *
@@ -574,8 +567,7 @@ public final class MediaType {
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
-   * Media type for SFNT fonts (which includes <a
-   * href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
+   * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
    * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
    * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
    * the IANA.
@@ -611,8 +603,8 @@ public final class MediaType {
   public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
 
   /**
-   * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-   * Format</a> (WOFF) <a href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
+   * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
    * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
    * the IANA.
    *
@@ -621,8 +613,8 @@ public final class MediaType {
   public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
 
   /**
-   * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-   * Format</a> (WOFF) version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
+   * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
    *
    * @since 20.0
    */
@@ -631,10 +623,10 @@ public final class MediaType {
   public static final MediaType XHTML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xhtml+xml");
 
   /**
-   * Media type for Extensible Resource Descriptors. This is not yet registered with the IANA, but
-   * it is specified by OASIS in the <a
-   * href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD definition</a> and
-   * implemented in projects such as <a href="http://code.google.com/p/webfinger/">WebFinger</a>.
+   * Extensible Resource Descriptors. This is not yet registered with the IANA, but it is specified
+   * by OASIS in the <a href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD
+   * definition</a> and implemented in projects such as <a
+   * href="http://code.google.com/p/webfinger/">WebFinger</a>.
    *
    * @since 14.0
    */

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -165,6 +165,13 @@ public final class MediaType {
   public static final MediaType TSV_UTF_8 = createConstantUtf8(TEXT_TYPE, "tab-separated-values");
 
   public static final MediaType VCARD_UTF_8 = createConstantUtf8(TEXT_TYPE, "vcard");
+
+  /**
+   * UTF-8 encoded <a href="https://en.wikipedia.org/wiki/Wireless_Markup_Language">Wireless Markup
+   * Language</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType WML_UTF_8 = createConstantUtf8(TEXT_TYPE, "vnd.wap.wml");
 
   /**
@@ -182,11 +189,16 @@ public final class MediaType {
    */
   public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
-  /* image types */
+  /**
+   * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
+   * files).
+   *
+   * @since 13.0
+   */
   public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
 
   /**
-   * The media type for the <a href="http://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
+   * The media type for the <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
    * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
    * found in {@code /etc/mime.types}, e.g. in <a href=
    * "http://anonscm.debian.org/gitweb/?p=collab-maint/mime-support.git;a=blob;f=mime.types;hb=HEAD"
@@ -222,6 +234,12 @@ public final class MediaType {
 
   public static final MediaType SVG_UTF_8 = createConstantUtf8(IMAGE_TYPE, "svg+xml");
   public static final MediaType TIFF = createConstant(IMAGE_TYPE, "tiff");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/WebP">WebP image format</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
   /* audio types */
@@ -344,6 +362,8 @@ public final class MediaType {
    * As described in <a href="http://www.ietf.org/rfc/rfc3023.txt">RFC 3023</a>, this constant
    * ({@code application/xml}) is used for XML documents that are "unreadable by casual users."
    * {@link #XML_UTF_8} is provided for documents that may be read by users.
+   *
+   * @since 14.0
    */
   public static final MediaType APPLICATION_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xml");
 
@@ -451,7 +471,11 @@ public final class MediaType {
    */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
-  /** Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>. */
+  /**
+   * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+   *
+   * @since 13.0
+   */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**
@@ -537,7 +561,16 @@ public final class MediaType {
    */
   public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
 
+  /**
+   * <a href="https://en.wikipedia.org/wiki/RDF/XML">RDF/XML</a> documents, which are XML
+   * serializations of <a
+   * href="https://en.wikipedia.org/wiki/Resource_Description_Framework">Resource Description
+   * Framework</a> graphs.
+   *
+   * @since 14.0
+   */
   public static final MediaType RDF_XML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rdf+xml");
+
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
@@ -553,6 +586,13 @@ public final class MediaType {
 
   public static final MediaType SHOCKWAVE_FLASH =
       createConstant(APPLICATION_TYPE, "x-shockwave-flash");
+
+  /**
+   * {@code skp} files produced by the 3D Modeling software <a
+   * href="https://www.sketchup.com/">SketchUp</a>
+   *
+   * @since 13.0
+   */
   public static final MediaType SKETCHUP = createConstant(APPLICATION_TYPE, "vnd.sketchup.skp");
 
   /**
@@ -595,6 +635,8 @@ public final class MediaType {
    * it is specified by OASIS in the <a
    * href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD definition</a> and
    * implemented in projects such as <a href="http://code.google.com/p/webfinger/">WebFinger</a>.
+   *
+   * @since 14.0
    */
   public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
 

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -198,9 +198,9 @@ public final class MediaType {
   public static final MediaType BMP = createConstant(IMAGE_TYPE, "bmp");
 
   /**
-   * The media type for the <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon
-   * Image File Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is
-   * found in {@code /etc/mime.types}, e.g. in <a href=
+   * The <a href="https://en.wikipedia.org/wiki/Camera_Image_File_Format">Canon Image File
+   * Format</a> ({@code crw} files), a widely-used "raw image" format for cameras. It is found in
+   * {@code /etc/mime.types}, e.g. in <a href=
    * "http://anonscm.debian.org/gitweb/?p=collab-maint/mime-support.git;a=blob;f=mime.types;hb=HEAD"
    * >Debian 3.48-1</a>.
    *
@@ -214,7 +214,7 @@ public final class MediaType {
   public static final MediaType PNG = createConstant(IMAGE_TYPE, "png");
 
   /**
-   * The media type for the Photoshop File Format ({@code psd} files) as defined by <a
+   * The Photoshop File Format ({@code psd} files) as defined by <a
    * href="http://www.iana.org/assignments/media-types/image/vnd.adobe.photoshop">IANA</a>, and
    * found in {@code /etc/mime.types}, e.g. <a
    * href="http://svn.apache.org/repos/asf/httpd/httpd/branches/1.3.x/conf/mime.types"></a> of the
@@ -249,31 +249,29 @@ public final class MediaType {
   public static final MediaType WEBM_AUDIO = createConstant(AUDIO_TYPE, "webm");
 
   /**
-   * Media type for L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC
-   * 2586</a>.
+   * L16 audio, as defined by <a href="https://tools.ietf.org/html/rfc2586">RFC 2586</a>.
    *
    * @since 24.1
    */
   public static final MediaType L16_AUDIO = createConstant(AUDIO_TYPE, "l16");
 
   /**
-   * Media type for L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC
-   * 3190</a>.
+   * L24 audio, as defined by <a href="https://tools.ietf.org/html/rfc3190">RFC 3190</a>.
    *
    * @since 20.0
    */
   public static final MediaType L24_AUDIO = createConstant(AUDIO_TYPE, "l24");
 
   /**
-   * Media type for Basic Audio, as defined by <a
-   * href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC 2046</a>.
+   * Basic Audio, as defined by <a href="http://tools.ietf.org/html/rfc2046#section-4.3">RFC
+   * 2046</a>.
    *
    * @since 20.0
    */
   public static final MediaType BASIC_AUDIO = createConstant(AUDIO_TYPE, "basic");
 
   /**
-   * Media type for Advanced Audio Coding. For more information, see <a
+   * Advanced Audio Coding. For more information, see <a
    * href="https://en.wikipedia.org/wiki/Advanced_Audio_Coding">Advanced Audio Coding</a>.
    *
    * @since 20.0
@@ -281,15 +279,14 @@ public final class MediaType {
   public static final MediaType AAC_AUDIO = createConstant(AUDIO_TYPE, "aac");
 
   /**
-   * Media type for Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC
-   * 5215</a>.
+   * Vorbis Audio, as defined by <a href="http://tools.ietf.org/html/rfc5215">RFC 5215</a>.
    *
    * @since 20.0
    */
   public static final MediaType VORBIS_AUDIO = createConstant(AUDIO_TYPE, "vorbis");
 
   /**
-   * Media type for Windows Media Audio. For more information, see <a
+   * Windows Media Audio. For more information, see <a
    * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
    * name extensions for Windows Media metafiles</a>.
    *
@@ -298,7 +295,7 @@ public final class MediaType {
   public static final MediaType WMA_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wma");
 
   /**
-   * Media type for Windows Media metafiles. For more information, see <a
+   * Windows Media metafiles. For more information, see <a
    * href="https://msdn.microsoft.com/en-us/library/windows/desktop/dd562994(v=vs.85).aspx">file
    * name extensions for Windows Media metafiles</a>.
    *
@@ -307,7 +304,7 @@ public final class MediaType {
   public static final MediaType WAX_AUDIO = createConstant(AUDIO_TYPE, "x-ms-wax");
 
   /**
-   * Media type for Real Audio. For more information, see <a
+   * Real Audio. For more information, see <a
    * href="http://service.real.com/help/faq/rp8/configrp8win.html">this link</a>.
    *
    * @since 20.0
@@ -315,8 +312,7 @@ public final class MediaType {
   public static final MediaType VND_REAL_AUDIO = createConstant(AUDIO_TYPE, "vnd.rn-realaudio");
 
   /**
-   * Media type for WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC
-   * 2361</a>.
+   * WAVE format, as defined by <a href="https://tools.ietf.org/html/rfc2361">RFC 2361</a>.
    *
    * @since 20.0
    */
@@ -331,7 +327,7 @@ public final class MediaType {
   public static final MediaType WMV = createConstant(VIDEO_TYPE, "x-ms-wmv");
 
   /**
-   * Media type for Flash video. For more information, see <a href=
+   * Flash video. For more information, see <a href=
    * "http://help.adobe.com/en_US/ActionScript/3.0_ProgrammingAS3/WS5b3ccc516d4fbf351e63e3d118a9b90204-7d48.html"
    * >this link</a>.
    *
@@ -340,7 +336,7 @@ public final class MediaType {
   public static final MediaType FLV_VIDEO = createConstant(VIDEO_TYPE, "x-flv");
 
   /**
-   * Media type for the 3GP multimedia container format. For more information, see <a
+   * The 3GP multimedia container format. For more information, see <a
    * href="ftp://www.3gpp.org/tsg_sa/TSG_SA/TSGS_23/Docs/PDF/SP-040065.pdf#page=10">3GPP TS
    * 26.244</a>.
    *
@@ -349,7 +345,7 @@ public final class MediaType {
   public static final MediaType THREE_GPP_VIDEO = createConstant(VIDEO_TYPE, "3gpp");
 
   /**
-   * Media type for the 3G2 multimedia container format. For more information, see <a
+   * The 3G2 multimedia container format. For more information, see <a
    * href="http://www.3gpp2.org/Public_html/specs/C.S0050-B_v1.0_070521.pdf#page=16">3GPP2
    * C.S0050-B</a>.
    *
@@ -371,14 +367,15 @@ public final class MediaType {
   public static final MediaType BZIP2 = createConstant(APPLICATION_TYPE, "x-bzip2");
 
   /**
-   * Media type for <a href="https://www.dartlang.org/articles/embedding-in-html/">dart files</a>.
+   * Files in the <a href="https://www.dartlang.org/articles/embedding-in-html/">dart</a>
+   * programming language.
    *
    * @since 19.0
    */
   public static final MediaType DART_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "dart");
 
   /**
-   * Media type for <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
+   * <a href="https://goo.gl/2QoMvg">Apple Passbook</a>.
    *
    * @since 19.0
    */
@@ -386,9 +383,8 @@ public final class MediaType {
       createConstant(APPLICATION_TYPE, "vnd.apple.pkpass");
 
   /**
-   * Media type for <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a>
-   * fonts. This is <a
-   * href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
+   * <a href="http://en.wikipedia.org/wiki/Embedded_OpenType">Embedded OpenType</a> fonts. This is
+   * <a href="http://www.iana.org/assignments/media-types/application/vnd.ms-fontobject">registered
    * </a> with the IANA.
    *
    * @since 17.0
@@ -433,8 +429,8 @@ public final class MediaType {
   public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
   /**
-   * Media type for the <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON
-   * Hypertext Application Language (HAL) documents</a>.
+   * <a href="https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3">JSON Hypertext
+   * Application Language (HAL) documents</a>.
    *
    * @since 26.0
    */
@@ -451,8 +447,7 @@ public final class MediaType {
   public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
 
   /**
-   * Media type for the <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web
-   * application</a>.
+   * The <a href="http://www.w3.org/TR/appmanifest/">Manifest for a web application</a>.
    *
    * @since 19.0
    */
@@ -460,61 +455,59 @@ public final class MediaType {
       createConstantUtf8(APPLICATION_TYPE, "manifest+json");
 
   /**
-   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-   * Language)</a>.
+   * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>.
    */
   public static final MediaType KML = createConstant(APPLICATION_TYPE, "vnd.google-earth.kml+xml");
 
   /**
-   * Media type for <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup
-   * Language)</a>, compressed using the ZIP format into KMZ archives.
+   * <a href="http://www.opengeospatial.org/standards/kml/">OGC KML (Keyhole Markup Language)</a>,
+   * compressed using the ZIP format into KMZ archives.
    */
   public static final MediaType KMZ = createConstant(APPLICATION_TYPE, "vnd.google-earth.kmz");
 
   /**
-   * Media type for the <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
+   * The <a href="https://tools.ietf.org/html/rfc4155">mbox database format</a>.
    *
    * @since 13.0
    */
   public static final MediaType MBOX = createConstant(APPLICATION_TYPE, "mbox");
 
   /**
-   * Media type for <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration
-   * profiles</a>.
+   * <a href="http://goo.gl/1pGBFm">Apple over-the-air mobile configuration profiles</a>.
    *
    * @since 18.0
    */
   public static final MediaType APPLE_MOBILE_CONFIG =
       createConstant(APPLICATION_TYPE, "x-apple-aspen-config");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Excel</a> spreadsheets. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Excel</a> spreadsheets. */
   public static final MediaType MICROSOFT_EXCEL = createConstant(APPLICATION_TYPE, "vnd.ms-excel");
 
   /**
-   * Media type for <a href="http://goo.gl/XrTEqG">Microsoft Outlook</a> items.
+   * <a href="http://goo.gl/XrTEqG">Microsoft Outlook</a> items.
    *
    * @since NEXT
    */
   public static final MediaType MICROSOFT_OUTLOOK =
       createConstant(APPLICATION_TYPE, "vnd.ms-outlook");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Powerpoint</a> presentations. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Powerpoint</a> presentations. */
   public static final MediaType MICROSOFT_POWERPOINT =
       createConstant(APPLICATION_TYPE, "vnd.ms-powerpoint");
 
-  /** Media type for <a href="http://goo.gl/XDQ1h2">Microsoft Word</a> documents. */
+  /** <a href="http://goo.gl/XDQ1h2">Microsoft Word</a> documents. */
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
-   * Media type for WASM applications. For more information see <a
-   * href="https://webassembly.org/">the Web Assembly overview</a>.
+   * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
+   * overview</a>.
    *
    * @since 27.0
    */
   public static final MediaType WASM_APPLICATION = createConstant(APPLICATION_TYPE, "wasm");
 
   /**
-   * Media type for NaCl applications. For more information see <a
+   * NaCl applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.
    *
@@ -523,7 +516,7 @@ public final class MediaType {
   public static final MediaType NACL_APPLICATION = createConstant(APPLICATION_TYPE, "x-nacl");
 
   /**
-   * Media type for NaCl portable applications. For more information see <a
+   * NaCl portable applications. For more information see <a
    * href="https://developer.chrome.com/native-client/devguide/coding/application-structure">the
    * Developer Guide for Native Client Application Structure</a>.
    *
@@ -574,8 +567,7 @@ public final class MediaType {
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
-   * Media type for SFNT fonts (which includes <a
-   * href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
+   * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
    * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
    * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
    * the IANA.
@@ -611,8 +603,8 @@ public final class MediaType {
   public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
 
   /**
-   * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-   * Format</a> (WOFF) <a href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
+   * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
    * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
    * the IANA.
    *
@@ -621,8 +613,8 @@ public final class MediaType {
   public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
 
   /**
-   * Media type for the <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font
-   * Format</a> (WOFF) version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
+   * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
    *
    * @since 20.0
    */
@@ -631,10 +623,10 @@ public final class MediaType {
   public static final MediaType XHTML_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xhtml+xml");
 
   /**
-   * Media type for Extensible Resource Descriptors. This is not yet registered with the IANA, but
-   * it is specified by OASIS in the <a
-   * href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD definition</a> and
-   * implemented in projects such as <a href="http://code.google.com/p/webfinger/">WebFinger</a>.
+   * Extensible Resource Descriptors. This is not yet registered with the IANA, but it is specified
+   * by OASIS in the <a href="http://docs.oasis-open.org/xri/xrd/v1.0/cd02/xrd-1.0-cd02.html">XRD
+   * definition</a> and implemented in projects such as <a
+   * href="http://code.google.com/p/webfinger/">WebFinger</a>.
    *
    * @since 14.0
    */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add missing documentation and @since tags to MediaType entries that were added
after its initial relase of 12.0

b545d0ed1066906d238852f2f510132cbfcc4af8

-------

<p> Remove "Media type for" or similar phrasing for visible constants in the MediaType class.

172bb45c149601a52e45bff8b2e3aa409f66d658