### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -828,8 +828,9 @@ public final class Files {
    * a directory, no exception will be thrown and the returned {@link Iterable} will contain a
    * single element: that file.
    *
-   * <p>Example: {@code Files.fileTraverser().breadthFirst("/")} may return files with the following
-   * paths: {@code ["/", "/etc", "/home", "/usr", "/etc/config.txt", "/etc/fonts", ...]}
+   * <p>Example: {@code Files.fileTraverser().depthFirstPreOrder(new File("/"))} may return files
+   * with the following paths: {@code ["/", "/etc", "/etc/config.txt", "/etc/fonts", "/home",
+   * "/home/alice", ...]}
    *
    * @since 23.5
    */

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -828,8 +828,9 @@ public final class Files {
    * a directory, no exception will be thrown and the returned {@link Iterable} will contain a
    * single element: that file.
    *
-   * <p>Example: {@code Files.fileTraverser().breadthFirst("/")} may return files with the following
-   * paths: {@code ["/", "/etc", "/home", "/usr", "/etc/config.txt", "/etc/fonts", ...]}
+   * <p>Example: {@code Files.fileTraverser().depthFirstPreOrder(new File("/"))} may return files
+   * with the following paths: {@code ["/", "/etc", "/etc/config.txt", "/etc/fonts", "/home",
+   * "/home/alice", ...]}
    *
    * @since 23.5
    */

--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -283,8 +283,9 @@ public final class MoreFiles {
    * created by this traverser if an {@link IOException} is thrown by a call to {@link
    * #listFiles(Path)}.
    *
-   * <p>Example: {@code MoreFiles.fileTraverser().breadthFirst("/")} may return files with the
-   * following paths: {@code ["/", "/etc", "/home", "/usr", "/etc/config.txt", "/etc/fonts", ...]}
+   * <p>Example: {@code MoreFiles.fileTraverser().depthFirstPreOrder(Paths.get("/"))} may return the
+   * following paths: {@code ["/", "/etc", "/etc/config.txt", "/etc/fonts", "/home", "/home/alice",
+   * ...]}
    *
    * @since 23.5
    */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make example compile (i.e. supply a Path/File) and use depth first instead of breadth first.

Reason: Depth first is more common for file traversal.

RELNOTES=N/A

e7b80454e4d463af61fc81c3beb96b5e46b07312