### PR TITLE
Moe Sync

### DIFF
--- a/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Platform.java
+++ b/guava-gwt/src-super/com/google/common/base/super/com/google/common/base/Platform.java
@@ -67,7 +67,7 @@ final class Platform {
     return string || null;
   }-*/;
 
-  @JsType(isNative = true, name = "Number", namespace = GLOBAL)
+  @JsType(isNative = true, name = "number", namespace = GLOBAL)
   private interface Number {
     double toPrecision(int precision);
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use the primitive "number" type instead of the object counterpart "Number" to avoid a jscompiler error.

An upcoming change to J2CL that simplifies how casting logic is transpiled will make the code "(Number) (Object) 3" here transpile to just "/** @type {Number} */ (3)" and jscompiler will see the "invalid cast" since "3" is not "Number" in the closure type system.

065a831ca171767dcc73b7b74c996029a5f286e3