### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/collect/Range.java
+++ b/android/guava/src/com/google/common/collect/Range.java
@@ -161,6 +161,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    *
    * @throws IllegalArgumentException if {@code lower} is greater than <i>or equal to</i> {@code
    *     upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> open(C lower, C upper) {
@@ -172,6 +173,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * or equal to {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> closed(C lower, C upper) {
@@ -183,6 +185,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * less than {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> closedOpen(C lower, C upper) {
@@ -194,6 +197,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * equal to {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> openClosed(C lower, C upper) {
@@ -205,6 +209,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * endpoint may be either inclusive (closed) or exclusive (open).
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> range(
@@ -315,7 +320,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * Returns the minimal range that {@linkplain Range#contains(Comparable) contains} all of the
    * given values. The returned range is {@linkplain BoundType#CLOSED closed} on both ends.
    *
-   * @throws ClassCastException if the parameters are not <i>mutually comparable</i>
+   * @throws ClassCastException if the values are not mutually comparable
    * @throws NoSuchElementException if {@code values} is empty
    * @throws NullPointerException if any of {@code values} is null
    * @since 14.0

--- a/guava/src/com/google/common/collect/Range.java
+++ b/guava/src/com/google/common/collect/Range.java
@@ -161,6 +161,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    *
    * @throws IllegalArgumentException if {@code lower} is greater than <i>or equal to</i> {@code
    *     upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> open(C lower, C upper) {
@@ -172,6 +173,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * or equal to {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> closed(C lower, C upper) {
@@ -183,6 +185,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * less than {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> closedOpen(C lower, C upper) {
@@ -194,6 +197,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * equal to {@code upper}.
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> openClosed(C lower, C upper) {
@@ -205,6 +209,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * endpoint may be either inclusive (closed) or exclusive (open).
    *
    * @throws IllegalArgumentException if {@code lower} is greater than {@code upper}
+   * @throws ClassCastException if {@code lower} and {@code upper} are not mutually comparable
    * @since 14.0
    */
   public static <C extends Comparable<?>> Range<C> range(
@@ -315,7 +320,7 @@ public final class Range<C extends Comparable> extends RangeGwtSerializationDepe
    * Returns the minimal range that {@linkplain Range#contains(Comparable) contains} all of the
    * given values. The returned range is {@linkplain BoundType#CLOSED closed} on both ends.
    *
-   * @throws ClassCastException if the parameters are not <i>mutually comparable</i>
+   * @throws ClassCastException if the values are not mutually comparable
    * @throws NoSuchElementException if {@code values} is empty
    * @throws NullPointerException if any of {@code values} is null
    * @since 14.0


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Specify that Range static factories can throw ClassCastException if the provided endpoints are not mutually comparable.

Fixes https://github.com/google/guava/issues/3343

RELNOTES=Specify that Range static factories can throw ClassCastException if the provided endpoints are not mutually comparable.

7b8f8bd9aa435b742079eb7e3fc7d56f122c3bd4