### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/base/Ticker.java
+++ b/android/guava/src/com/google/common/base/Ticker.java
@@ -16,7 +16,6 @@ package com.google.common.base;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * A time source; returns a time value representing the number of nanoseconds elapsed since some
@@ -36,7 +35,6 @@ public abstract class Ticker {
   protected Ticker() {}
 
   /** Returns the number of nanoseconds elapsed since this ticker's fixed point of reference. */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public abstract long read();
 
   /**

--- a/android/guava/src/com/google/common/cache/AbstractCache.java
+++ b/android/guava/src/com/google/common/cache/AbstractCache.java
@@ -216,12 +216,14 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
       missCount.add(count);
     }
 
+    @SuppressWarnings("GoodTime") // b/122668874
     @Override
     public void recordLoadSuccess(long loadTime) {
       loadSuccessCount.increment();
       totalLoadTime.add(loadTime);
     }
 
+    @SuppressWarnings("GoodTime") // b/122668874
     @Override
     public void recordLoadException(long loadTime) {
       loadExceptionCount.increment();

--- a/android/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/android/guava/src/com/google/common/cache/CacheBuilder.java
@@ -156,7 +156,11 @@ import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
 public final class CacheBuilder<K, V> {
   private static final int DEFAULT_INITIAL_CAPACITY = 16;
   private static final int DEFAULT_CONCURRENCY_LEVEL = 4;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private static final int DEFAULT_EXPIRATION_NANOS = 0;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private static final int DEFAULT_REFRESH_NANOS = 0;
 
   static final Supplier<? extends StatsCounter> NULL_STATS_COUNTER =
@@ -168,9 +172,11 @@ public final class CacheBuilder<K, V> {
             @Override
             public void recordMisses(int count) {}
 
+            @SuppressWarnings("GoodTime") // b/122668874
             @Override
             public void recordLoadSuccess(long loadTime) {}
 
+            @SuppressWarnings("GoodTime") // b/122668874
             @Override
             public void recordLoadException(long loadTime) {}
 
@@ -231,8 +237,13 @@ public final class CacheBuilder<K, V> {
   @MonotonicNonNullDecl Strength keyStrength;
   @MonotonicNonNullDecl Strength valueStrength;
 
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long expireAfterWriteNanos = UNSET_INT;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long expireAfterAccessNanos = UNSET_INT;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long refreshNanos = UNSET_INT;
 
   @MonotonicNonNullDecl Equivalence<Object> keyEquivalence;

--- a/android/guava/src/com/google/common/cache/CacheBuilderSpec.java
+++ b/android/guava/src/com/google/common/cache/CacheBuilderSpec.java
@@ -77,6 +77,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Adam Winer
  * @since 12.0
  */
+@SuppressWarnings("GoodTime") // lots of violations (nanosecond math)
 @GwtIncompatible
 public final class CacheBuilderSpec {
   /** Parses a single value. */

--- a/android/guava/src/com/google/common/cache/CacheStats.java
+++ b/android/guava/src/com/google/common/cache/CacheStats.java
@@ -60,7 +60,10 @@ public final class CacheStats {
   private final long missCount;
   private final long loadSuccessCount;
   private final long loadExceptionCount;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private final long totalLoadTime;
+
   private final long evictionCount;
 
   /**

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -94,6 +94,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Bob Lee ({@code com.google.common.collect.MapMaker})
  * @author Doug Lea ({@code ConcurrentHashMap})
  */
+@SuppressWarnings("GoodTime") // lots of violations (nanosecond math)
 @GwtCompatible(emulated = true)
 class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
 

--- a/android/guava/src/com/google/common/cache/ReferenceEntry.java
+++ b/android/guava/src/com/google/common/cache/ReferenceEntry.java
@@ -67,6 +67,7 @@ interface ReferenceEntry<K, V> {
   long getAccessTime();
 
   /** Sets the entry access time in ns. */
+  @SuppressWarnings("GoodTime") // b/122668874
   void setAccessTime(long time);
 
   /** Returns the next entry in the access queue. */
@@ -91,6 +92,7 @@ interface ReferenceEntry<K, V> {
   long getWriteTime();
 
   /** Sets the entry write time in ns. */
+  @SuppressWarnings("GoodTime") // b/122668874
   void setWriteTime(long time);
 
   /** Returns the next entry in the write queue. */

--- a/android/guava/src/com/google/common/collect/ClassToInstanceMap.java
+++ b/android/guava/src/com/google/common/collect/ClassToInstanceMap.java
@@ -47,7 +47,6 @@ public interface ClassToInstanceMap<B> extends Map<Class<? extends B>, B> {
    * is present. This will only return a value that was bound to this specific class, not a value
    * that may have been bound to a subtype.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   <T extends B> T getInstance(Class<T> type);
 
   /**

--- a/android/guava/src/com/google/common/collect/Iterators.java
+++ b/android/guava/src/com/google/common/collect/Iterators.java
@@ -297,7 +297,6 @@ public final class Iterators {
    * @throws IllegalArgumentException if the iterator contains multiple elements. The state of the
    *     iterator is unspecified.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   public static <T> T getOnlyElement(Iterator<T> iterator) {
     T first = iterator.next();
     if (!iterator.hasNext()) {
@@ -323,7 +322,6 @@ public final class Iterators {
    * @throws IllegalArgumentException if the iterator contains multiple elements. The state of the
    *     iterator is unspecified.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   @NullableDecl
   public static <T> T getOnlyElement(Iterator<? extends T> iterator, @NullableDecl T defaultValue) {
     return iterator.hasNext() ? getOnlyElement(iterator) : defaultValue;

--- a/android/guava/src/com/google/common/collect/Ordering.java
+++ b/android/guava/src/com/google/common/collect/Ordering.java
@@ -544,7 +544,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    *     ordering.
    * @since 11.0
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(Iterator<E> iterator) {
     // let this throw NoSuchElementException as necessary
     E minSoFar = iterator.next();
@@ -571,7 +570,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(Iterable<E> iterable) {
     return min(iterable.iterator());
   }
@@ -591,7 +589,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(@NullableDecl E a, @NullableDecl E b) {
     return (compare(a, b) <= 0) ? a : b;
   }
@@ -610,7 +607,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(@NullableDecl E a, @NullableDecl E b, @NullableDecl E c, E... rest) {
     E minSoFar = min(min(a, b), c);
 
@@ -636,7 +632,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    *     ordering.
    * @since 11.0
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(Iterator<E> iterator) {
     // let this throw NoSuchElementException as necessary
     E maxSoFar = iterator.next();
@@ -663,7 +658,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(Iterable<E> iterable) {
     return max(iterable.iterator());
   }
@@ -683,7 +677,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(@NullableDecl E a, @NullableDecl E b) {
     return (compare(a, b) >= 0) ? a : b;
   }
@@ -702,7 +695,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(@NullableDecl E a, @NullableDecl E b, @NullableDecl E c, E... rest) {
     E maxSoFar = max(max(a, b), c);
 

--- a/android/guava/src/com/google/common/collect/Sets.java
+++ b/android/guava/src/com/google/common/collect/Sets.java
@@ -784,7 +784,7 @@ public final class Sets {
 
       @Override
       public boolean isEmpty() {
-        return Collections.disjoint(set1, set2);
+        return Collections.disjoint(set2, set1);
       }
 
       @Override

--- a/android/guava/src/com/google/common/hash/BloomFilterStrategies.java
+++ b/android/guava/src/com/google/common/hash/BloomFilterStrategies.java
@@ -191,7 +191,7 @@ enum BloomFilterStrategies implements BloomFilter.Strategy {
     }
 
     boolean get(long bitIndex) {
-      return (data.get((int) (bitIndex >>> 6)) & (1L << bitIndex)) != 0;
+      return (data.get((int) (bitIndex >>> LONG_ADDRESSABLE_BITS)) & (1L << bitIndex)) != 0;
     }
 
     /**

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -397,7 +397,35 @@ public final class HttpHeaders {
   public static final String PING_TO = "Ping-To";
 
   /**
-   * The HTTP <a href="https://github.com/mikewest/sec-metadata">{@code Sec-Metadata}</a> header
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Dest}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_DEST = "Sec-Fetch-Dest";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Mode}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_MODE = "Sec-Fetch-Mode";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Site}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_SITE = "Sec-Fetch-Site";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-User}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_USER = "Sec-Fetch-User";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Metadata}</a> header
    * field name.
    *
    * @since 26.0

--- a/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
+++ b/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
@@ -241,6 +241,7 @@ public class LocalCache<K, V> implements ConcurrentMap<K, V> {
     }
   }
 
+  @SuppressWarnings("GoodTime") // timestamps as numeric primitives
   private V load(Object key) throws ExecutionException {
     long startTime = ticker.read();
     V calculatedValue;
@@ -300,6 +301,7 @@ public class LocalCache<K, V> implements ConcurrentMap<K, V> {
     return load(key);
   }
 
+  @SuppressWarnings("GoodTime") // timestamps as numeric primitives
   private static class Timestamped<V> {
     private final V value;
     private final Ticker ticker;

--- a/guava/src/com/google/common/base/Ticker.java
+++ b/guava/src/com/google/common/base/Ticker.java
@@ -16,7 +16,6 @@ package com.google.common.base;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
  * A time source; returns a time value representing the number of nanoseconds elapsed since some
@@ -36,7 +35,6 @@ public abstract class Ticker {
   protected Ticker() {}
 
   /** Returns the number of nanoseconds elapsed since this ticker's fixed point of reference. */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public abstract long read();
 
   /**

--- a/guava/src/com/google/common/cache/AbstractCache.java
+++ b/guava/src/com/google/common/cache/AbstractCache.java
@@ -216,12 +216,14 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
       missCount.add(count);
     }
 
+    @SuppressWarnings("GoodTime") // b/122668874
     @Override
     public void recordLoadSuccess(long loadTime) {
       loadSuccessCount.increment();
       totalLoadTime.add(loadTime);
     }
 
+    @SuppressWarnings("GoodTime") // b/122668874
     @Override
     public void recordLoadException(long loadTime) {
       loadExceptionCount.increment();

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -157,7 +157,11 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 public final class CacheBuilder<K, V> {
   private static final int DEFAULT_INITIAL_CAPACITY = 16;
   private static final int DEFAULT_CONCURRENCY_LEVEL = 4;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private static final int DEFAULT_EXPIRATION_NANOS = 0;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private static final int DEFAULT_REFRESH_NANOS = 0;
 
   static final Supplier<? extends StatsCounter> NULL_STATS_COUNTER =
@@ -169,9 +173,11 @@ public final class CacheBuilder<K, V> {
             @Override
             public void recordMisses(int count) {}
 
+            @SuppressWarnings("GoodTime") // b/122668874
             @Override
             public void recordLoadSuccess(long loadTime) {}
 
+            @SuppressWarnings("GoodTime") // b/122668874
             @Override
             public void recordLoadException(long loadTime) {}
 
@@ -232,8 +238,13 @@ public final class CacheBuilder<K, V> {
   @MonotonicNonNull Strength keyStrength;
   @MonotonicNonNull Strength valueStrength;
 
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long expireAfterWriteNanos = UNSET_INT;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long expireAfterAccessNanos = UNSET_INT;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   long refreshNanos = UNSET_INT;
 
   @MonotonicNonNull Equivalence<Object> keyEquivalence;
@@ -644,6 +655,7 @@ public final class CacheBuilder<K, V> {
    */
   @J2ObjCIncompatible
   @GwtIncompatible // java.time.Duration
+  @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> expireAfterWrite(java.time.Duration duration) {
     return expireAfterWrite(duration.toNanos(), TimeUnit.NANOSECONDS);
   }
@@ -710,6 +722,7 @@ public final class CacheBuilder<K, V> {
    */
   @J2ObjCIncompatible
   @GwtIncompatible // java.time.Duration
+  @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> expireAfterAccess(java.time.Duration duration) {
     return expireAfterAccess(duration.toNanos(), TimeUnit.NANOSECONDS);
   }
@@ -784,6 +797,7 @@ public final class CacheBuilder<K, V> {
    */
   @J2ObjCIncompatible
   @GwtIncompatible // java.time.Duration
+  @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> refreshAfterWrite(java.time.Duration duration) {
     return refreshAfterWrite(duration.toNanos(), TimeUnit.NANOSECONDS);
   }

--- a/guava/src/com/google/common/cache/CacheBuilderSpec.java
+++ b/guava/src/com/google/common/cache/CacheBuilderSpec.java
@@ -77,6 +77,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Adam Winer
  * @since 12.0
  */
+@SuppressWarnings("GoodTime") // lots of violations (nanosecond math)
 @GwtIncompatible
 public final class CacheBuilderSpec {
   /** Parses a single value. */

--- a/guava/src/com/google/common/cache/CacheStats.java
+++ b/guava/src/com/google/common/cache/CacheStats.java
@@ -60,7 +60,10 @@ public final class CacheStats {
   private final long missCount;
   private final long loadSuccessCount;
   private final long loadExceptionCount;
+
+  @SuppressWarnings("GoodTime") // should be a java.time.Duration
   private final long totalLoadTime;
+
   private final long evictionCount;
 
   /**

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -98,6 +98,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Bob Lee ({@code com.google.common.collect.MapMaker})
  * @author Doug Lea ({@code ConcurrentHashMap})
  */
+@SuppressWarnings("GoodTime") // lots of violations (nanosecond math)
 @GwtCompatible(emulated = true)
 class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
 

--- a/guava/src/com/google/common/cache/ReferenceEntry.java
+++ b/guava/src/com/google/common/cache/ReferenceEntry.java
@@ -67,6 +67,7 @@ interface ReferenceEntry<K, V> {
   long getAccessTime();
 
   /** Sets the entry access time in ns. */
+  @SuppressWarnings("GoodTime") // b/122668874
   void setAccessTime(long time);
 
   /** Returns the next entry in the access queue. */
@@ -91,6 +92,7 @@ interface ReferenceEntry<K, V> {
   long getWriteTime();
 
   /** Sets the entry write time in ns. */
+  @SuppressWarnings("GoodTime") // b/122668874
   void setWriteTime(long time);
 
   /** Returns the next entry in the write queue. */

--- a/guava/src/com/google/common/collect/ClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ClassToInstanceMap.java
@@ -47,7 +47,6 @@ public interface ClassToInstanceMap<B> extends Map<Class<? extends B>, B> {
    * is present. This will only return a value that was bound to this specific class, not a value
    * that may have been bound to a subtype.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   <T extends B> T getInstance(Class<T> type);
 
   /**

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -297,7 +297,6 @@ public final class Iterators {
    * @throws IllegalArgumentException if the iterator contains multiple elements. The state of the
    *     iterator is unspecified.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   public static <T> T getOnlyElement(Iterator<T> iterator) {
     T first = iterator.next();
     if (!iterator.hasNext()) {
@@ -323,7 +322,6 @@ public final class Iterators {
    * @throws IllegalArgumentException if the iterator contains multiple elements. The state of the
    *     iterator is unspecified.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this?
   public static <T> @Nullable T getOnlyElement(
       Iterator<? extends T> iterator, @Nullable T defaultValue) {
     return iterator.hasNext() ? getOnlyElement(iterator) : defaultValue;

--- a/guava/src/com/google/common/collect/Ordering.java
+++ b/guava/src/com/google/common/collect/Ordering.java
@@ -544,7 +544,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    *     ordering.
    * @since 11.0
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(Iterator<E> iterator) {
     // let this throw NoSuchElementException as necessary
     E minSoFar = iterator.next();
@@ -571,7 +570,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(Iterable<E> iterable) {
     return min(iterable.iterator());
   }
@@ -591,7 +589,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(@Nullable E a, @Nullable E b) {
     return (compare(a, b) <= 0) ? a : b;
   }
@@ -610,7 +607,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E min(@Nullable E a, @Nullable E b, @Nullable E c, E... rest) {
     E minSoFar = min(min(a, b), c);
 
@@ -636,7 +632,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    *     ordering.
    * @since 11.0
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(Iterator<E> iterator) {
     // let this throw NoSuchElementException as necessary
     E maxSoFar = iterator.next();
@@ -663,7 +658,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(Iterable<E> iterable) {
     return max(iterable.iterator());
   }
@@ -683,7 +677,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(@Nullable E a, @Nullable E b) {
     return (compare(a, b) >= 0) ? a : b;
   }
@@ -702,7 +695,6 @@ public abstract class Ordering<T> implements Comparator<T> {
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> under this
    *     ordering.
    */
-  @CanIgnoreReturnValue // TODO(kak): Consider removing this
   public <E extends T> E max(@Nullable E a, @Nullable E b, @Nullable E c, E... rest) {
     E maxSoFar = max(max(a, b), c);
 

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -868,7 +868,7 @@ public final class Sets {
 
       @Override
       public boolean isEmpty() {
-        return Collections.disjoint(set1, set2);
+        return Collections.disjoint(set2, set1);
       }
 
       @Override

--- a/guava/src/com/google/common/hash/BloomFilterStrategies.java
+++ b/guava/src/com/google/common/hash/BloomFilterStrategies.java
@@ -191,7 +191,7 @@ enum BloomFilterStrategies implements BloomFilter.Strategy {
     }
 
     boolean get(long bitIndex) {
-      return (data.get((int) (bitIndex >>> 6)) & (1L << bitIndex)) != 0;
+      return (data.get((int) (bitIndex >>> LONG_ADDRESSABLE_BITS)) & (1L << bitIndex)) != 0;
     }
 
     /**

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -397,7 +397,35 @@ public final class HttpHeaders {
   public static final String PING_TO = "Ping-To";
 
   /**
-   * The HTTP <a href="https://github.com/mikewest/sec-metadata">{@code Sec-Metadata}</a> header
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Dest}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_DEST = "Sec-Fetch-Dest";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Mode}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_MODE = "Sec-Fetch-Mode";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Site}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_SITE = "Sec-Fetch-Site";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-User}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_FETCH_USER = "Sec-Fetch-User";
+  /**
+   * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Metadata}</a> header
    * field name.
    *
    * @since 26.0


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Enable GoodTimeApi for c.g.common.cache

RELNOTES=Enable GoodTimeApi for c.g.common.cache

7a3e5abd01dea7d0d6d065dc8538af0419087f4f

-------

<p> refactor literal to named constant

Fixes #3364

a2829817926037d99975a9f05399edbe730f9bda

-------

<p> Adds constants for Sec-Fetch-(Dest|Mode|Site|User) headers.

https://github.com/mikewest/sec-metadata

RELNOTES=Adds constants for Sec-Fetch headers.

cfb1208e326c24e8110dc6ef2412074f9d8ead03

-------

<p> Remove @CanIgnoreReturnValue from c.g.c.collect.Ordering.min/max()

RELNOTES=Remove @CanIgnoreReturnValue from c.g.c.collect.Ordering.min/max()

a83bb5f2d7839a746f285ddceddcca205133c74b

-------

<p> Swap the parameter order of the Collections.disjoint call in Sets.intersection

Collections.disjoint is implemented in such a way that it has better
performance if its 2nd parameter is the smaller of the two when both params are
instances of Set. The Sets.intersection javadoc says it has better performance
when set1 is the smaller set, but that is currently not the case for the
isEmpty operation specifically.

Our team ran into a pathological case of this where we check for an empty
intersection of two sets, one being ~5 orders of magnitude larger than the
other.

RELNOTES=Update isEmpty operation of intersection to follow the smaller set first advice in the javadoc.

1162460c408203facbfde8889bb89f74bc78d612

-------

<p> Remove @CanIgnoreReturnValue from c.g.c.collect.ClassToInstanceMap.getInstance()

RELNOTES=Remove @CanIgnoreReturnValue from c.g.c.collect.ClassToInstanceMap.getInstance()

ecb601f6d89ac351b0178364034dc255fe639f03

-------

<p> Remove @CanIgnoreReturnValue from c.g.c.collect.Iterators.getOnlyElement()

RELNOTES=Remove @CanIgnoreReturnValue from c.g.c.collect.Iterators.getOnlyElement()

f8ee1a2bfab18d2d5af1e7fda41e2cb9cecd37ca

-------

<p> Remove @CanIgnoreReturnValue from c.g.c.base.Ticker

RELNOTES=Remove @CanIgnoreReturnValue from c.g.c.base.Ticker

44e129f1930ba4d1b3c7765f38273d5e13586283