### PR TITLE
Document the JDK 9+ alternative to `Iterators#forEnumeration`

### DIFF
--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -1073,6 +1073,9 @@ public final class Iterators {
    * <p>This method has no equivalent in {@link Iterables} because viewing an {@code Enumeration} as
    * an {@code Iterable} is impossible. However, the contents can be <i>copied</i> into a collection
    * using {@link Collections#list}.
+   *
+   * <p><b>Java 9 users:</b> use {@code enumeration.asIterator()} instead, unless it is important
+   * that an {@code UnmodifiableIterator} instead of an {@code Iterator} is produced.
    */
   public static <T> UnmodifiableIterator<T> forEnumeration(final Enumeration<T> enumeration) {
     checkNotNull(enumeration);


### PR DESCRIPTION
- Copied the phrasing from the various `Streams.stream(Optional*)` methods.
- Didn't update the documentation in the Android code base. (Which also mirrors the approach taken for the `Streams.stream(Optional*)` methods.)
- Not completely sure whether the `UnmodifiableIterator`/`Iterator` distinction is worth pointing out.