### PR TITLE
Document the JDK 9+ alternative to `Maps#immutableEntry`

### DIFF
--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1371,6 +1371,9 @@ public final class Maps {
    *
    * <p>The returned entry is serializable.
    *
+   * <p><b>Java 9 users:</b> consider using {@code java.util.Map.entry(key, value)} if the key and
+   * value are non-null and the entry does not need to be serializable.
+   *
    * @param key the key to be associated with the returned entry
    * @param value the value to be associated with the returned entry
    */


### PR DESCRIPTION
I think this suggestion is worthwhile for two reasons:
- The JDK 9+ alternative is null-hostile, fully in line with Guava's philosophy. (In fact, my colleagues and I were surprised to learn that `Maps.immutableEntry` allows nulls.)
- The excellent arguments in favour of `Immutable*` types put forth in #2969 do not hold here, since `Maps.immutableEntry` does not have a special return type that communicates its immutability.