### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
@@ -85,4 +85,35 @@ public class CompactHashMapTest extends TestCase {
     entry.setValue("one");
     assertThat(map).containsEntry(1, "one");
   }
+
+  public void testAllocArraysDefault() {
+    CompactHashMap<Integer, String> map = CompactHashMap.create();
+    assertThat(map.needsAllocArrays()).isTrue();
+    assertThat(map.entries).isNull();
+    assertThat(map.keys).isNull();
+    assertThat(map.values).isNull();
+
+    map.put(1, "1");
+    assertThat(map.needsAllocArrays()).isFalse();
+    assertThat(map.entries).hasLength(CompactHashMap.DEFAULT_SIZE);
+    assertThat(map.keys).hasLength(CompactHashMap.DEFAULT_SIZE);
+    assertThat(map.values).hasLength(CompactHashMap.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashMap.DEFAULT_SIZE; i++) {
+      CompactHashMap<Integer, String> map = CompactHashMap.createWithExpectedSize(i);
+      assertThat(map.needsAllocArrays()).isTrue();
+      assertThat(map.entries).isNull();
+      assertThat(map.keys).isNull();
+      assertThat(map.values).isNull();
+
+      map.put(1, "1");
+      assertThat(map.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(map.entries).hasLength(expectedSize);
+      assertThat(map.keys).hasLength(expectedSize);
+      assertThat(map.values).hasLength(expectedSize);
+    }
+  }
 }

--- a/android/guava-tests/test/com/google/common/collect/CompactHashSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/CompactHashSetTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.testing.SetTestSuiteBuilder;
 import com.google.common.collect.testing.TestStringSetGenerator;
@@ -83,7 +85,26 @@ public class CompactHashSetTest extends TestCase {
     return suite;
   }
 
-  public void testDummyMethod() {
-    // Just make sure the test runner doesn't complain about no test methods.
+  public void testAllocArraysDefault() {
+    CompactHashSet<Integer> set = CompactHashSet.create();
+    assertThat(set.needsAllocArrays()).isTrue();
+    assertThat(set.elements).isNull();
+
+    set.add(1);
+    assertThat(set.needsAllocArrays()).isFalse();
+    assertThat(set.elements).hasLength(CompactHashSet.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashSet.DEFAULT_SIZE; i++) {
+      CompactHashSet<Integer> set = CompactHashSet.createWithExpectedSize(i);
+      assertThat(set.needsAllocArrays()).isTrue();
+      assertThat(set.elements).isNull();
+
+      set.add(1);
+      assertThat(set.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(set.elements).hasLength(expectedSize);
+    }
   }
 }

--- a/android/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
@@ -141,4 +141,39 @@ public class CompactLinkedHashMapTest extends TestCase {
       assertEquals(expectedValue, values.get(i));
     }
   }
+
+  public void testAllocArraysDefault() {
+    CompactLinkedHashMap<Integer, String> map = CompactLinkedHashMap.create();
+    assertThat(map.needsAllocArrays()).isTrue();
+    assertThat(map.entries).isNull();
+    assertThat(map.keys).isNull();
+    assertThat(map.values).isNull();
+    assertThat(map.links).isNull();
+
+    map.put(1, Integer.toString(1));
+    assertThat(map.needsAllocArrays()).isFalse();
+    assertThat(map.entries).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.keys).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.values).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.links).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactLinkedHashMap.DEFAULT_SIZE; i++) {
+      CompactLinkedHashMap<Integer, String> map = CompactLinkedHashMap.createWithExpectedSize(i);
+      assertThat(map.needsAllocArrays()).isTrue();
+      assertThat(map.entries).isNull();
+      assertThat(map.keys).isNull();
+      assertThat(map.values).isNull();
+      assertThat(map.links).isNull();
+
+      map.put(1, Integer.toString(1));
+      assertThat(map.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(map.entries).hasLength(expectedSize);
+      assertThat(map.keys).hasLength(expectedSize);
+      assertThat(map.values).hasLength(expectedSize);
+      assertThat(map.links).hasLength(expectedSize);
+    }
+  }
 }

--- a/android/guava-tests/test/com/google/common/collect/CompactLinkedHashSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/CompactLinkedHashSetTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.testing.SetTestSuiteBuilder;
 import com.google.common.collect.testing.TestStringSetGenerator;
@@ -65,7 +67,26 @@ public class CompactLinkedHashSetTest extends TestCase {
     return suite;
   }
 
-  public void testDummyMethod() {
-    // Just make sure the test runner doesn't complain about no test methods.
+  public void testAllocArraysDefault() {
+    CompactHashSet<Integer> set = CompactHashSet.create();
+    assertThat(set.needsAllocArrays()).isTrue();
+    assertThat(set.elements).isNull();
+
+    set.add(1);
+    assertThat(set.needsAllocArrays()).isFalse();
+    assertThat(set.elements).hasLength(CompactHashSet.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashSet.DEFAULT_SIZE; i++) {
+      CompactHashSet<Integer> set = CompactHashSet.createWithExpectedSize(i);
+      assertThat(set.needsAllocArrays()).isTrue();
+      assertThat(set.elements).isNull();
+
+      set.add(1);
+      assertThat(set.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(set.elements).hasLength(expectedSize);
+    }
   }
 }

--- a/android/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactHashMap.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -169,20 +170,40 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    * @param capacity the initial capacity of this {@code CompactHashMap}.
    */
   CompactHashMap(int capacity) {
-    this(capacity, DEFAULT_LOAD_FACTOR);
+    init(capacity, DEFAULT_LOAD_FACTOR);
   }
 
-  CompactHashMap(int expectedSize, float loadFactor) {
-    init(expectedSize, loadFactor);
+  /**
+   * Constructs a new instance of {@code CompactHashMap} with the specified capacity and load
+   * factor.
+   *
+   * @param capacity the initial capacity of this {@code CompactHashMap}.
+   * @param loadFactor the load factor of this {@code CompactHashMap}.
+   */
+  CompactHashMap(int capacity, float loadFactor) {
+    init(capacity, loadFactor);
   }
 
   /** Pseudoconstructor for serialization support. */
   void init(int expectedSize, float loadFactor) {
     Preconditions.checkArgument(expectedSize >= 0, "Initial capacity must be non-negative");
     Preconditions.checkArgument(loadFactor > 0, "Illegal load factor");
+    this.loadFactor = loadFactor;
+    this.threshold = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
+  }
+
+  /** Returns whether arrays need to be allocated. */
+  boolean needsAllocArrays() {
+    return table == null;
+  }
+
+  /** Handle lazy allocation of arrays. */
+  void allocArrays() {
+    Preconditions.checkState(needsAllocArrays(), "Arrays already allocated");
+
+    int expectedSize = threshold;
     int buckets = Hashing.closedTableSize(expectedSize, loadFactor);
     this.table = newTable(buckets);
-    this.loadFactor = loadFactor;
 
     this.keys = new Object[expectedSize];
     this.values = new Object[expectedSize];
@@ -233,6 +254,9 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @Override
   @NullableDecl
   public V put(@NullableDecl K key, @NullableDecl V value) {
+    if (needsAllocArrays()) {
+      allocArrays();
+    }
     long[] entries = this.entries;
     Object[] keys = this.keys;
     Object[] values = this.values;
@@ -285,7 +309,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     this.values[entryIndex] = value;
   }
 
-  /** Returns currentSize + 1, after resizing the entries storage if necessary. */
+  /** Resizes the entries storage if necessary. */
   private void resizeMeMaybe(int newSize) {
     int entriesSize = entries.length;
     if (newSize > entriesSize) {
@@ -341,6 +365,9 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   private int indexOf(@NullableDecl Object key) {
+    if (needsAllocArrays()) {
+      return -1;
+    }
     int hash = smearedHash(key);
     int next = table[hash & hashTableMask()];
     while (next != UNSET) {
@@ -370,6 +397,9 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @Override
   @NullableDecl
   public V remove(@NullableDecl Object key) {
+    if (needsAllocArrays()) {
+      return null;
+    }
     return remove(key, smearedHash(key));
   }
 
@@ -740,6 +770,9 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    * current size.
    */
   public void trimToSize() {
+    if (needsAllocArrays()) {
+      return;
+    }
     int size = this.size;
     if (size < entries.length) {
       resizeEntries(size);
@@ -763,11 +796,14 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
   @Override
   public void clear() {
+    if (needsAllocArrays()) {
+      return;
+    }
     modCount++;
     Arrays.fill(keys, 0, size, null);
     Arrays.fill(values, 0, size, null);
     Arrays.fill(table, UNSET);
-    Arrays.fill(entries, UNSET);
+    Arrays.fill(entries, 0, size, UNSET);
     this.size = 0;
   }
 
@@ -778,7 +814,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   private void writeObject(ObjectOutputStream stream) throws IOException {
     stream.defaultWriteObject();
     stream.writeInt(size);
-    for (int i = 0; i < size; i++) {
+    for (int i = firstEntryIndex(); i >= 0; i = getSuccessor(i)) {
       stream.writeObject(keys[i]);
       stream.writeObject(values[i]);
     }
@@ -787,9 +823,12 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @SuppressWarnings("unchecked")
   private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
     stream.defaultReadObject();
-    init(DEFAULT_SIZE, DEFAULT_LOAD_FACTOR);
     int elementCount = stream.readInt();
-    for (int i = elementCount; --i >= 0; ) {
+    if (elementCount < 0) {
+      throw new InvalidObjectException("Invalid size: " + elementCount);
+    }
+    init(elementCount, DEFAULT_LOAD_FACTOR);
+    for (int i = 0; i < elementCount; i++) {
       K key = (K) stream.readObject();
       V value = (V) stream.readObject();
       put(key, value);

--- a/android/guava/src/com/google/common/collect/CompactHashSet.java
+++ b/android/guava/src/com/google/common/collect/CompactHashSet.java
@@ -20,10 +20,12 @@ import static com.google.common.collect.CollectPreconditions.checkRemove;
 import static com.google.common.collect.Hashing.smearedHash;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -123,7 +125,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   private static final long HASH_MASK = ~NEXT_MASK;
 
   // TODO(user): decide default size
-  private static final int DEFAULT_SIZE = 3;
+  @VisibleForTesting static final int DEFAULT_SIZE = 3;
 
   static final int UNSET = -1;
 
@@ -182,10 +184,25 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   void init(int expectedSize, float loadFactor) {
     Preconditions.checkArgument(expectedSize >= 0, "Initial capacity must be non-negative");
     Preconditions.checkArgument(loadFactor > 0, "Illegal load factor");
+    this.loadFactor = loadFactor;
+    this.threshold = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
+  }
+
+  /** Returns whether arrays need to be allocated. */
+  boolean needsAllocArrays() {
+    return table == null;
+  }
+
+  /** Handle lazy allocation of arrays. */
+  void allocArrays() {
+    Preconditions.checkState(needsAllocArrays(), "Arrays already allocated");
+
+    int expectedSize = threshold;
     int buckets = Hashing.closedTableSize(expectedSize, loadFactor);
     this.table = newTable(buckets);
-    this.loadFactor = loadFactor;
+
     this.elements = new Object[expectedSize];
+
     this.entries = newEntries(expectedSize);
     this.threshold = Math.max(1, (int) (buckets * loadFactor));
   }
@@ -223,6 +240,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   @CanIgnoreReturnValue
   @Override
   public boolean add(@NullableDecl E object) {
+    if (needsAllocArrays()) {
+      allocArrays();
+    }
     long[] entries = this.entries;
     Object[] elements = this.elements;
     int hash = smearedHash(object);
@@ -266,7 +286,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     this.elements[entryIndex] = object;
   }
 
-  /** Returns currentSize + 1, after resizing the entries storage if necessary. */
+  /** Resizes the entries storage if necessary. */
   private void resizeMeMaybe(int newSize) {
     int entriesSize = entries.length;
     if (newSize > entriesSize) {
@@ -322,6 +342,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
 
   @Override
   public boolean contains(@NullableDecl Object object) {
+    if (needsAllocArrays()) {
+      return false;
+    }
     int hash = smearedHash(object);
     int next = table[hash & hashTableMask()];
     while (next != UNSET) {
@@ -337,6 +360,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   @CanIgnoreReturnValue
   @Override
   public boolean remove(@NullableDecl Object object) {
+    if (needsAllocArrays()) {
+      return false;
+    }
     return remove(object, smearedHash(object));
   }
 
@@ -480,12 +506,21 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
 
   @Override
   public Object[] toArray() {
+    if (needsAllocArrays()) {
+      return new Object[0];
+    }
     return Arrays.copyOf(elements, size);
   }
 
   @CanIgnoreReturnValue
   @Override
   public <T> T[] toArray(T[] a) {
+    if (needsAllocArrays()) {
+      if (a.length > 0) {
+        a[0] = null;
+      }
+      return a;
+    }
     return ObjectArrays.toArrayImpl(elements, 0, size, a);
   }
 
@@ -494,6 +529,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
    * current size.
    */
   public void trimToSize() {
+    if (needsAllocArrays()) {
+      return;
+    }
     int size = this.size;
     if (size < entries.length) {
       resizeEntries(size);
@@ -517,10 +555,13 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
 
   @Override
   public void clear() {
+    if (needsAllocArrays()) {
+      return;
+    }
     modCount++;
     Arrays.fill(elements, 0, size, null);
     Arrays.fill(table, UNSET);
-    Arrays.fill(entries, UNSET);
+    Arrays.fill(entries, 0, size, UNSET);
     this.size = 0;
   }
 
@@ -531,17 +572,20 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   private void writeObject(ObjectOutputStream stream) throws IOException {
     stream.defaultWriteObject();
     stream.writeInt(size);
-    for (E e : this) {
-      stream.writeObject(e);
+    for (int i = firstEntryIndex(); i >= 0; i = getSuccessor(i)) {
+      stream.writeObject(elements[i]);
     }
   }
 
   @SuppressWarnings("unchecked")
   private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
     stream.defaultReadObject();
-    init(DEFAULT_SIZE, DEFAULT_LOAD_FACTOR);
     int elementCount = stream.readInt();
-    for (int i = elementCount; --i >= 0; ) {
+    if (elementCount < 0) {
+      throw new InvalidObjectException("Invalid size: " + elementCount);
+    }
+    init(elementCount, DEFAULT_LOAD_FACTOR);
+    for (int i = 0; i < elementCount; i++) {
       E element = (E) stream.readObject();
       add(element);
     }

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -101,6 +101,12 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     super.init(expectedSize, loadFactor);
     firstEntry = ENDPOINT;
     lastEntry = ENDPOINT;
+  }
+
+  @Override
+  void allocArrays() {
+    super.allocArrays();
+    int expectedSize = keys.length; // allocated size may be different than initial capacity
     links = new long[expectedSize];
     Arrays.fill(links, UNSET);
   }
@@ -164,13 +170,18 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
       setSucceeds(getPredecessor(srcIndex), dstIndex);
       setSucceeds(dstIndex, getSuccessor(srcIndex));
     }
+    links[srcIndex] = UNSET;
     super.moveLastEntry(dstIndex);
   }
 
   @Override
   void resizeEntries(int newCapacity) {
     super.resizeEntries(newCapacity);
+    int oldCapacity = links.length;
     links = Arrays.copyOf(links, newCapacity);
+    if (oldCapacity < newCapacity) {
+      Arrays.fill(links, oldCapacity, newCapacity, UNSET);
+    }
   }
 
   @Override
@@ -185,8 +196,12 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
 
   @Override
   public void clear() {
-    super.clear();
+    if (needsAllocArrays()) {
+      return;
+    }
     this.firstEntry = ENDPOINT;
     this.lastEntry = ENDPOINT;
+    Arrays.fill(links, 0, size(), UNSET);
+    super.clear();
   }
 }

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashSet.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashSet.java
@@ -122,13 +122,19 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   @Override
   void init(int expectedSize, float loadFactor) {
     super.init(expectedSize, loadFactor);
+    firstEntry = ENDPOINT;
+    lastEntry = ENDPOINT;
+  }
+
+  @Override
+  void allocArrays() {
+    super.allocArrays();
+    int expectedSize = elements.length; // allocated size may be different than initial capacity
     this.predecessor = new int[expectedSize];
     this.successor = new int[expectedSize];
 
     Arrays.fill(predecessor, UNSET);
     Arrays.fill(successor, UNSET);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
   }
 
   private void succeeds(int pred, int succ) {
@@ -168,11 +174,14 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
 
   @Override
   public void clear() {
-    super.clear();
+    if (needsAllocArrays()) {
+      return;
+    }
     firstEntry = ENDPOINT;
     lastEntry = ENDPOINT;
-    Arrays.fill(predecessor, UNSET);
-    Arrays.fill(successor, UNSET);
+    Arrays.fill(predecessor, 0, size(), UNSET);
+    Arrays.fill(successor, 0, size(), UNSET);
+    super.clear();
   }
 
   @Override

--- a/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
@@ -85,4 +85,35 @@ public class CompactHashMapTest extends TestCase {
     entry.setValue("one");
     assertThat(map).containsEntry(1, "one");
   }
+
+  public void testAllocArraysDefault() {
+    CompactHashMap<Integer, String> map = CompactHashMap.create();
+    assertThat(map.needsAllocArrays()).isTrue();
+    assertThat(map.entries).isNull();
+    assertThat(map.keys).isNull();
+    assertThat(map.values).isNull();
+
+    map.put(1, "1");
+    assertThat(map.needsAllocArrays()).isFalse();
+    assertThat(map.entries).hasLength(CompactHashMap.DEFAULT_SIZE);
+    assertThat(map.keys).hasLength(CompactHashMap.DEFAULT_SIZE);
+    assertThat(map.values).hasLength(CompactHashMap.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashMap.DEFAULT_SIZE; i++) {
+      CompactHashMap<Integer, String> map = CompactHashMap.createWithExpectedSize(i);
+      assertThat(map.needsAllocArrays()).isTrue();
+      assertThat(map.entries).isNull();
+      assertThat(map.keys).isNull();
+      assertThat(map.values).isNull();
+
+      map.put(1, "1");
+      assertThat(map.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(map.entries).hasLength(expectedSize);
+      assertThat(map.keys).hasLength(expectedSize);
+      assertThat(map.values).hasLength(expectedSize);
+    }
+  }
 }

--- a/guava-tests/test/com/google/common/collect/CompactHashSetTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactHashSetTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.testing.SetTestSuiteBuilder;
 import com.google.common.collect.testing.TestStringSetGenerator;
@@ -83,7 +85,26 @@ public class CompactHashSetTest extends TestCase {
     return suite;
   }
 
-  public void testDummyMethod() {
-    // Just make sure the test runner doesn't complain about no test methods.
+  public void testAllocArraysDefault() {
+    CompactHashSet<Integer> set = CompactHashSet.create();
+    assertThat(set.needsAllocArrays()).isTrue();
+    assertThat(set.elements).isNull();
+
+    set.add(1);
+    assertThat(set.needsAllocArrays()).isFalse();
+    assertThat(set.elements).hasLength(CompactHashSet.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashSet.DEFAULT_SIZE; i++) {
+      CompactHashSet<Integer> set = CompactHashSet.createWithExpectedSize(i);
+      assertThat(set.needsAllocArrays()).isTrue();
+      assertThat(set.elements).isNull();
+
+      set.add(1);
+      assertThat(set.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(set.elements).hasLength(expectedSize);
+    }
   }
 }

--- a/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
@@ -141,4 +141,39 @@ public class CompactLinkedHashMapTest extends TestCase {
       assertEquals(expectedValue, values.get(i));
     }
   }
+
+  public void testAllocArraysDefault() {
+    CompactLinkedHashMap<Integer, String> map = CompactLinkedHashMap.create();
+    assertThat(map.needsAllocArrays()).isTrue();
+    assertThat(map.entries).isNull();
+    assertThat(map.keys).isNull();
+    assertThat(map.values).isNull();
+    assertThat(map.links).isNull();
+
+    map.put(1, Integer.toString(1));
+    assertThat(map.needsAllocArrays()).isFalse();
+    assertThat(map.entries).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.keys).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.values).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+    assertThat(map.links).hasLength(CompactLinkedHashMap.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactLinkedHashMap.DEFAULT_SIZE; i++) {
+      CompactLinkedHashMap<Integer, String> map = CompactLinkedHashMap.createWithExpectedSize(i);
+      assertThat(map.needsAllocArrays()).isTrue();
+      assertThat(map.entries).isNull();
+      assertThat(map.keys).isNull();
+      assertThat(map.values).isNull();
+      assertThat(map.links).isNull();
+
+      map.put(1, Integer.toString(1));
+      assertThat(map.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(map.entries).hasLength(expectedSize);
+      assertThat(map.keys).hasLength(expectedSize);
+      assertThat(map.values).hasLength(expectedSize);
+      assertThat(map.links).hasLength(expectedSize);
+    }
+  }
 }

--- a/guava-tests/test/com/google/common/collect/CompactLinkedHashSetTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactLinkedHashSetTest.java
@@ -16,6 +16,8 @@
 
 package com.google.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.testing.SetTestSuiteBuilder;
 import com.google.common.collect.testing.TestStringSetGenerator;
@@ -65,7 +67,26 @@ public class CompactLinkedHashSetTest extends TestCase {
     return suite;
   }
 
-  public void testDummyMethod() {
-    // Just make sure the test runner doesn't complain about no test methods.
+  public void testAllocArraysDefault() {
+    CompactHashSet<Integer> set = CompactHashSet.create();
+    assertThat(set.needsAllocArrays()).isTrue();
+    assertThat(set.elements).isNull();
+
+    set.add(1);
+    assertThat(set.needsAllocArrays()).isFalse();
+    assertThat(set.elements).hasLength(CompactHashSet.DEFAULT_SIZE);
+  }
+
+  public void testAllocArraysExpectedSize() {
+    for (int i = 0; i <= CompactHashSet.DEFAULT_SIZE; i++) {
+      CompactHashSet<Integer> set = CompactHashSet.createWithExpectedSize(i);
+      assertThat(set.needsAllocArrays()).isTrue();
+      assertThat(set.elements).isNull();
+
+      set.add(1);
+      assertThat(set.needsAllocArrays()).isFalse();
+      int expectedSize = Math.max(1, i);
+      assertThat(set.elements).hasLength(expectedSize);
+    }
   }
 }

--- a/guava/src/com/google/common/collect/CompactLinkedHashSet.java
+++ b/guava/src/com/google/common/collect/CompactLinkedHashSet.java
@@ -127,13 +127,19 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   @Override
   void init(int expectedSize, float loadFactor) {
     super.init(expectedSize, loadFactor);
+    firstEntry = ENDPOINT;
+    lastEntry = ENDPOINT;
+  }
+
+  @Override
+  void allocArrays() {
+    super.allocArrays();
+    int expectedSize = elements.length; // allocated size may be different than initial capacity
     this.predecessor = new int[expectedSize];
     this.successor = new int[expectedSize];
 
     Arrays.fill(predecessor, UNSET);
     Arrays.fill(successor, UNSET);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
   }
 
   private void succeeds(int pred, int succ) {
@@ -173,11 +179,14 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
 
   @Override
   public void clear() {
-    super.clear();
+    if (needsAllocArrays()) {
+      return;
+    }
     firstEntry = ENDPOINT;
     lastEntry = ENDPOINT;
-    Arrays.fill(predecessor, UNSET);
-    Arrays.fill(successor, UNSET);
+    Arrays.fill(predecessor, 0, size(), UNSET);
+    Arrays.fill(successor, 0, size(), UNSET);
+    super.clear();
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Lazily allocate CompactHash backing arrays on first write

Empty maps/sets are extremely common. Lazily allocating the backing arrays can
save hundreds of KB of heap and reduce load on the garbage collector.

While here:
- Use serialized size to pre-size the arrays
- Respect ordering during serialization (without using an iterator)
- Consistently mark unused links as UNSET

Memory savings before first write (bytes):
- CompactHashMap.create(): 184 -> 64
- CompactLinkedHashMap.create(): 240 -> 80
- CompactHashSet.create(): 136 -> 40
- CompactLinkedHashSet.create(): 200 -> 56
- CompactHashMap.createWithExpectedSize(0): 136 -> 64
- CompactLinkedHashMap.createWithExpectedSize(0): 168 -> 80
- CompactHashSet.createWithExpectedSize(0): 96 -> 40
- CompactLinkedHashSet.createWithExpectedSize(0): 144 -> 56

801e018184d2f5196c80e2b2168a883c093ffe5a