### PR TITLE
Initialize uninterruptibles with current interrupt state of thread

### DIFF
--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -47,7 +47,7 @@ public final class Uninterruptibles {
   /** Invokes {@code latch.}{@link CountDownLatch#await() await()} uninterruptibly. */
   @GwtIncompatible // concurrency
   public static void awaitUninterruptibly(CountDownLatch latch) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       while (true) {
         try {
@@ -72,7 +72,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static boolean awaitUninterruptibly(CountDownLatch latch, long timeout, TimeUnit unit) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(timeout);
       long end = System.nanoTime() + remainingNanos;
@@ -102,7 +102,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static boolean awaitUninterruptibly(Condition condition, long timeout, TimeUnit unit) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(timeout);
       long end = System.nanoTime() + remainingNanos;
@@ -125,7 +125,7 @@ public final class Uninterruptibles {
   /** Invokes {@code toJoin.}{@link Thread#join() join()} uninterruptibly. */
   @GwtIncompatible // concurrency
   public static void joinUninterruptibly(Thread toJoin) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       while (true) {
         try {
@@ -150,7 +150,7 @@ public final class Uninterruptibles {
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static void joinUninterruptibly(Thread toJoin, long timeout, TimeUnit unit) {
     Preconditions.checkNotNull(toJoin);
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(timeout);
       long end = System.nanoTime() + remainingNanos;
@@ -190,7 +190,7 @@ public final class Uninterruptibles {
    */
   @CanIgnoreReturnValue
   public static <V> V getUninterruptibly(Future<V> future) throws ExecutionException {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       while (true) {
         try {
@@ -229,7 +229,7 @@ public final class Uninterruptibles {
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static <V> V getUninterruptibly(Future<V> future, long timeout, TimeUnit unit)
       throws ExecutionException, TimeoutException {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(timeout);
       long end = System.nanoTime() + remainingNanos;
@@ -253,7 +253,7 @@ public final class Uninterruptibles {
   /** Invokes {@code queue.}{@link BlockingQueue#take() take()} uninterruptibly. */
   @GwtIncompatible // concurrency
   public static <E> E takeUninterruptibly(BlockingQueue<E> queue) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       while (true) {
         try {
@@ -279,7 +279,7 @@ public final class Uninterruptibles {
    */
   @GwtIncompatible // concurrency
   public static <E> void putUninterruptibly(BlockingQueue<E> queue, E element) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       while (true) {
         try {
@@ -301,7 +301,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static void sleepUninterruptibly(long sleepFor, TimeUnit unit) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(sleepFor);
       long end = System.nanoTime() + remainingNanos;
@@ -345,7 +345,7 @@ public final class Uninterruptibles {
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static boolean tryAcquireUninterruptibly(
       Semaphore semaphore, int permits, long timeout, TimeUnit unit) {
-    boolean interrupted = false;
+    boolean interrupted = Thread.interrupted();
     try {
       long remainingNanos = unit.toNanos(timeout);
       long end = System.nanoTime() + remainingNanos;


### PR DESCRIPTION
If a thread comes into Uninterruptibles already in an interrupted state, the first call to the target action will immediately fail with InterruptedException.  Initialize the 'interrupted' flag with the current state of the thread so that the first attempt can complete (assuming the thread is not interrupted again immediately after the initialization).