### PR TITLE
Update checker-qual to 2.8.0, because it is now OSGi compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>2.5.2</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
Update checker-qual to 2.8.0, because it is now OSGi compatible. Prior to this fix, an OSGi application that uses Guava would encounter OSGi compatibility failures.

See also https://github.com/typetools/checker-framework/pull/2281