### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -647,6 +647,37 @@ public class ImmutableMapTest extends TestCase {
       assertMapEquals(copy, "one", 1, "two", 2, "three", 3);
       assertSame(copy, ImmutableMap.copyOf(copy));
     }
+
+    public static void hashtableTestHelper(ImmutableList<Integer> sizes) {
+      for (int size : sizes) {
+        Builder<Integer, Integer> builder = ImmutableMap.builderWithExpectedSize(size);
+        for (int i = 0; i < size; i++) {
+          Integer integer = i;
+          builder.put(integer, integer);
+        }
+        ImmutableMap<Integer, Integer> map = builder.build();
+        assertEquals(size, map.size());
+        int entries = 0;
+        for (Integer key : map.keySet()) {
+          assertEquals(entries, key.intValue());
+          assertSame(key, map.get(key));
+          entries++;
+        }
+        assertEquals(size, entries);
+      }
+    }
+
+    public void testByteArrayHashtable() {
+      hashtableTestHelper(ImmutableList.of(2, 89));
+    }
+
+    public void testShortArrayHashtable() {
+      hashtableTestHelper(ImmutableList.of(90, 22937));
+    }
+
+    public void testIntArrayHashtable() {
+      hashtableTestHelper(ImmutableList.of(22938));
+    }
   }
 
   public void testNullGet() {

--- a/android/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
@@ -70,4 +70,66 @@ public class ImmutableGraphTest {
 
     assertThat(graph2).isSameAs(graph1);
   }
+
+  @Test
+  public void immutableGraphBuilder_appliesGraphBuilderConfig() {
+    ImmutableGraph<String> emptyGraph =
+        GraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .immutable()
+            .build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableGraph.Builder doesn't change when the creating GraphBuilder changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableGraphBuilder_copiesGraphBuilder() {
+    GraphBuilder<String> graphBuilder =
+        GraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableGraph.Builder<String> immutableGraphBuilder = graphBuilder.immutable();
+
+    // Update GraphBuilder, but this shouldn't impact immutableGraphBuilder
+    graphBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableGraph<String> emptyGraph = immutableGraphBuilder.build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableGraphBuilder_addNode() {
+    ImmutableGraph<String> graph = GraphBuilder.directed().<String>immutable().addNode("A").build();
+
+    assertThat(graph.nodes()).containsExactly("A");
+    assertThat(graph.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableGraphBuilder_putEdgeFromNodes() {
+    ImmutableGraph<String> graph =
+        GraphBuilder.directed().<String>immutable().putEdge("A", "B").build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+  }
+
+  @Test
+  public void immutableGraphBuilder_putEdgeFromEndpointPair() {
+    ImmutableGraph<String> graph =
+        GraphBuilder.directed().<String>immutable().putEdge(EndpointPair.ordered("A", "B")).build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+  }
 }

--- a/android/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ImmutableGraph} and {@link ImmutableValueGraph} . */
+/** Tests for {@link ImmutableGraph}. */
 @RunWith(JUnit4.class)
 public class ImmutableGraphTest {
 
@@ -40,33 +40,9 @@ public class ImmutableGraphTest {
   }
 
   @Test
-  public void immutableValueGraph() {
-    MutableValueGraph<String, Integer> mutableValueGraph = ValueGraphBuilder.directed().build();
-    mutableValueGraph.addNode("A");
-    ImmutableValueGraph<String, Integer> immutableValueGraph =
-        ImmutableValueGraph.copyOf(mutableValueGraph);
-
-    assertThat(immutableValueGraph.asGraph()).isInstanceOf(ImmutableGraph.class);
-    assertThat(immutableValueGraph).isNotInstanceOf(MutableValueGraph.class);
-    assertThat(immutableValueGraph).isEqualTo(mutableValueGraph);
-
-    mutableValueGraph.addNode("B");
-    assertThat(immutableValueGraph).isNotEqualTo(mutableValueGraph);
-  }
-
-  @Test
   public void copyOfImmutableGraph_optimized() {
     Graph<String> graph1 = ImmutableGraph.copyOf(GraphBuilder.directed().<String>build());
     Graph<String> graph2 = ImmutableGraph.copyOf(graph1);
-
-    assertThat(graph2).isSameAs(graph1);
-  }
-
-  @Test
-  public void copyOfImmutableValueGraph_optimized() {
-    ValueGraph<String, Integer> graph1 =
-        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
-    ValueGraph<String, Integer> graph2 = ImmutableValueGraph.copyOf(graph1);
 
     assertThat(graph2).isSameAs(graph1);
   }

--- a/android/guava-tests/test/com/google/common/graph/ImmutableNetworkTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableNetworkTest.java
@@ -74,4 +74,74 @@ public class ImmutableNetworkTest {
     assertThat(network.edgesConnecting("A", "B")).containsExactly("AB");
     assertThat(network.edgesConnecting("B", "A")).containsExactly("AB");
   }
+
+  @Test
+  public void immutableNetworkBuilder_appliesNetworkBuilderConfig() {
+    ImmutableNetwork<String, Integer> emptyNetwork =
+        NetworkBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .<String, Integer>immutable()
+            .build();
+
+    assertThat(emptyNetwork.isDirected()).isTrue();
+    assertThat(emptyNetwork.allowsSelfLoops()).isTrue();
+    assertThat(emptyNetwork.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableNetwork.Builder doesn't change when the creating NetworkBuilder
+   * changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableNetworkBuilder_copiesNetworkBuilder() {
+    NetworkBuilder<String, Object> networkBuilder =
+        NetworkBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableNetwork.Builder<String, Integer> immutableNetworkBuilder =
+        networkBuilder.<String, Integer>immutable();
+
+    // Update NetworkBuilder, but this shouldn't impact immutableNetworkBuilder
+    networkBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableNetwork<String, Integer> emptyNetwork = immutableNetworkBuilder.build();
+
+    assertThat(emptyNetwork.isDirected()).isTrue();
+    assertThat(emptyNetwork.allowsSelfLoops()).isTrue();
+    assertThat(emptyNetwork.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableNetworkBuilder_addNode() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed().<String, Integer>immutable().addNode("A").build();
+
+    assertThat(network.nodes()).containsExactly("A");
+    assertThat(network.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableNetworkBuilder_putEdgeFromNodes() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed().<String, Integer>immutable().addEdge("A", "B", 10).build();
+
+    assertThat(network.nodes()).containsExactly("A", "B");
+    assertThat(network.edges()).containsExactly(10);
+    assertThat(network.incidentNodes(10)).isEqualTo(EndpointPair.ordered("A", "B"));
+  }
+
+  @Test
+  public void immutableNetworkBuilder_putEdgeFromEndpointPair() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed()
+            .<String, Integer>immutable()
+            .addEdge(EndpointPair.ordered("A", "B"), 10)
+            .build();
+
+    assertThat(network.nodes()).containsExactly("A", "B");
+    assertThat(network.edges()).containsExactly(10);
+    assertThat(network.incidentNodes(10)).isEqualTo(EndpointPair.ordered("A", "B"));
+  }
 }

--- a/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ImmutableValueGraph} . */
+@RunWith(JUnit4.class)
+public class ImmutableValueGraphTest {
+
+  @Test
+  public void immutableValueGraph() {
+    MutableValueGraph<String, Integer> mutableValueGraph = ValueGraphBuilder.directed().build();
+    mutableValueGraph.addNode("A");
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(mutableValueGraph);
+
+    assertThat(immutableValueGraph.asGraph()).isInstanceOf(ImmutableGraph.class);
+    assertThat(immutableValueGraph).isNotInstanceOf(MutableValueGraph.class);
+    assertThat(immutableValueGraph).isEqualTo(mutableValueGraph);
+
+    mutableValueGraph.addNode("B");
+    assertThat(immutableValueGraph).isNotEqualTo(mutableValueGraph);
+  }
+
+  @Test
+  public void copyOfImmutableValueGraph_optimized() {
+    ValueGraph<String, Integer> graph1 =
+        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
+    ValueGraph<String, Integer> graph2 = ImmutableValueGraph.copyOf(graph1);
+
+    assertThat(graph2).isSameAs(graph1);
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_appliesGraphBuilderConfig() {
+    ImmutableValueGraph<String, Integer> emptyGraph =
+        ValueGraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .<String, Integer>immutable()
+            .build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableValueGraph.Builder doesn't change when the creating ValueGraphBuilder
+   * changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableValueGraphBuilder_copiesGraphBuilder() {
+    ValueGraphBuilder<String, Object> graphBuilder =
+        ValueGraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableValueGraph.Builder<String, Integer> immutableValueGraphBuilder =
+        graphBuilder.<String, Integer>immutable();
+
+    // Update ValueGraphBuilder, but this shouldn't impact immutableValueGraphBuilder
+    graphBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableValueGraph<String, Integer> emptyGraph = immutableValueGraphBuilder.build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_addNode() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed().<String, Integer>immutable().addNode("A").build();
+
+    assertThat(graph.nodes()).containsExactly("A");
+    assertThat(graph.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_putEdgeFromNodes() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed()
+            .<String, Integer>immutable()
+            .putEdgeValue("A", "B", 10)
+            .build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+    assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_putEdgeFromEndpointPair() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed()
+            .<String, Integer>immutable()
+            .putEdgeValue(EndpointPair.ordered("A", "B"), 10)
+            .build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+    assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
+  }
+}

--- a/android/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
@@ -44,6 +44,11 @@ public class FluentFutureTest extends TestCase {
     assertThat(FluentFuture.from(f)).isSameAs(f);
   }
 
+  public void testFromFluentFuturePassingAsNonFluent() {
+    ListenableFuture<String> f = FluentFuture.from(SettableFuture.<String>create());
+    assertThat(FluentFuture.from(f)).isSameAs(f);
+  }
+
   public void testFromNonFluentFuture() throws Exception {
     ListenableFuture<String> f =
         new SimpleForwardingListenableFuture<String>(immediateFuture("a")) {};

--- a/android/guava/src/com/google/common/collect/RegularImmutableBiMap.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableBiMap.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 final class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
   static final RegularImmutableBiMap<Object, Object> EMPTY = new RegularImmutableBiMap<>();
 
-  private final transient int[] keyHashTable;
+  private final transient Object keyHashTable;
   @VisibleForTesting final transient Object[] alternatingKeysAndValues;
   private final transient int keyOffset; // 0 for K-to-V, 1 for V-to-K
   private final transient int size;
@@ -54,7 +54,7 @@ final class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
     int tableSize = (size >= 2) ? ImmutableSet.chooseTableSize(size) : 0;
     this.keyHashTable =
         RegularImmutableMap.createHashTable(alternatingKeysAndValues, size, tableSize, 0);
-    int[] valueHashTable =
+    Object valueHashTable =
         RegularImmutableMap.createHashTable(alternatingKeysAndValues, size, tableSize, 1);
     this.inverse =
         new RegularImmutableBiMap<V, K>(valueHashTable, alternatingKeysAndValues, size, this);
@@ -62,7 +62,7 @@ final class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
 
   /** V-to-K constructor. */
   private RegularImmutableBiMap(
-      int[] valueHashTable,
+      Object valueHashTable,
       Object[] alternatingKeysAndValues,
       int size,
       RegularImmutableBiMap<V, K> inverse) {

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -88,7 +88,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    */
   public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
     GraphBuilder<N1> castBuilder = cast();
-    return new ImmutableGraph.Builder<N1>(castBuilder);
+    return new ImmutableGraph.Builder<>(castBuilder);
   }
 
   /**

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -80,6 +80,18 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableGraph#Builder} with the properties of this {@link GraphBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
+    GraphBuilder<N1> castBuilder = cast();
+    return new ImmutableGraph.Builder<N1>(castBuilder);
+  }
+
+  /**
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -103,9 +103,9 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
    * graphs. Example:
    *
    * <pre>{@code
-   * public static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
+   * static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
    *     GraphBuilder.undirected()
-   *         .<Country> immutable()
+   *         .<Country>immutable()
    *         .putEdge(FRANCE, GERMANY)
    *         .putEdge(FRANCE, BELGIUM)
    *         .putEdge(GERMANY, BELGIUM)

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -38,6 +38,7 @@ import com.google.errorprone.annotations.Immutable;
  * @author James Sexton
  * @author Joshua O'Madadhain
  * @author Omar Darwish
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @since 20.0
  */

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -24,6 +24,7 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.graph.GraphConstants.Presence;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 /**
@@ -95,5 +96,97 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
   @Override
   protected BaseGraph<N> delegate() {
     return backingGraph;
+  }
+
+  /**
+   * A builder for creating {@link ImmutableGraph} instances, especially {@code static final}
+   * graphs. Example:
+   *
+   * <pre>{@code
+   * public static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
+   *     GraphBuilder.undirected()
+   *         .<Country> immutable()
+   *         .putEdge(FRANCE, GERMANY)
+   *         .putEdge(FRANCE, BELGIUM)
+   *         .putEdge(GERMANY, BELGIUM)
+   *         .addNode(ICELAND)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple graphs in series. Each new graph contains all the elements of the ones created before
+   * it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N> {
+
+    private final MutableGraph<N> mutableGraph;
+
+    Builder(GraphBuilder<N> graphBuilder) {
+      this.mutableGraph = graphBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> addNode(N node) {
+      mutableGraph.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code nodeU} to {@code nodeV} if one is not already present.
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> putEdge(N nodeU, N nodeV) {
+      mutableGraph.putEdge(nodeU, nodeV);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code endpoints} (in the order, if any, specified by {@code
+     * endpoints}) if one is not already present.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered and the added edge will be
+     * directed; if it is undirected, the added edge will be undirected.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered.
+     *
+     * <p>If either or both endpoints are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the graph is directed
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> putEdge(EndpointPair<N> endpoints) {
+      mutableGraph.putEdge(endpoints);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableGraph} based on the contents of this {@code Builder}.
+     */
+    public ImmutableGraph<N> build() {
+      return ImmutableGraph.copyOf(mutableGraph);
+    }
   }
 }

--- a/android/guava/src/com/google/common/graph/ImmutableNetwork.java
+++ b/android/guava/src/com/google/common/graph/ImmutableNetwork.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Map;
 
@@ -37,6 +38,7 @@ import java.util.Map;
  * @author James Sexton
  * @author Joshua O'Madadhain
  * @author Omar Darwish
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <E> Edge parameter type
  * @since 20.0
@@ -137,5 +139,116 @@ public final class ImmutableNetwork<N, E> extends ConfigurableNetwork<N, E> {
         return network.incidentNodes(edge).adjacentNode(node);
       }
     };
+  }
+
+  /**
+   * A builder for creating {@link ImmutableNetwork} instances, especially {@code static final}
+   * networks. Example:
+   *
+   * <pre>{@code
+   * static final ImmutableNetwork<City, Train> TRAIN_NETWORK =
+   *     NetworkBuilder.undirected()
+   *         .allowsParallelEdges(true)
+   *         .<City, Train>immutable()
+   *         .addEdge(PARIS, BRUSSELS, Thalys.trainNumber("1111"))
+   *         .addEdge(PARIS, BRUSSELS, RegionalTrain.trainNumber("2222"))
+   *         .addEdge(LONDON, PARIS, Eurostar.trainNumber("3333"))
+   *         .addEdge(LONDON, BRUSSELS, Eurostar.trainNumber("4444"))
+   *         .addNode(REYKJAVIK)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple networks in series. Each new network contains all the elements of the ones created
+   * before it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N, E> {
+
+    private final MutableNetwork<N, E> mutableNetwork;
+
+    Builder(NetworkBuilder<N, E> networkBuilder) {
+      this.mutableNetwork = networkBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addNode(N node) {
+      mutableNetwork.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds {@code edge} connecting {@code nodeU} to {@code nodeV}.
+     *
+     * <p>If the network is directed, {@code edge} will be directed in this network; otherwise, it
+     * will be undirected.
+     *
+     * <p><b>{@code edge} must be unique to this network</b>, just as a {@code Map} key must be. It
+     * must also be non-null.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this network, this method
+     * will silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the network.
+     *
+     * <p>If {@code edge} already connects {@code nodeU} to {@code nodeV} (in the specified order if
+     * this network {@link #isDirected()}, else in any order), then this method will have no effect.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if {@code edge} already exists in the network and does not
+     *     connect {@code nodeU} to {@code nodeV}
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsParallelEdges()} or {@link #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addEdge(N nodeU, N nodeV, E edge) {
+      mutableNetwork.addEdge(nodeU, nodeV, edge);
+      return this;
+    }
+
+    /**
+     * Adds {@code edge} connecting {@code endpoints}. In an undirected network, {@code edge} will
+     * also connect {@code nodeV} to {@code nodeU}.
+     *
+     * <p>If this network is directed, {@code edge} will be directed in this network; if it is
+     * undirected, {@code edge} will be undirected in this network.
+     *
+     * <p>If this network is directed, {@code endpoints} must be ordered.
+     *
+     * <p><b>{@code edge} must be unique to this network</b>, just as a {@code Map} key must be. It
+     * must also be non-null.
+     *
+     * <p>If either or both endpoints are not already present in this network, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the network.
+     *
+     * <p>If {@code edge} already connects an endpoint pair equal to {@code endpoints}, then this
+     * method will have no effect.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if {@code edge} already exists in the network and connects
+     *     some other endpoint pair that is not equal to {@code endpoints}
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsParallelEdges()} or {@link #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the network is directed
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addEdge(EndpointPair<N> endpoints, E edge) {
+      mutableNetwork.addEdge(endpoints, edge);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableNetwork} based on the contents of this {@code
+     * Builder}.
+     */
+    public ImmutableNetwork<N, E> build() {
+      return ImmutableNetwork.copyOf(mutableNetwork);
+    }
   }
 }

--- a/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 /**
@@ -34,6 +35,7 @@ import com.google.errorprone.annotations.Immutable;
  * provided by this class.
  *
  * @author James Sexton
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  * @since 20.0
@@ -95,5 +97,103 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
             graph.predecessors(node), Maps.asMap(graph.successors(node), successorNodeToValueFn))
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), successorNodeToValueFn));
+  }
+
+  /**
+   * A builder for creating {@link ImmutableValueGraph} instances, especially {@code static final}
+   * graphs. Example:
+   *
+   * <pre>{@code
+   * static final ImmutableValueGraph<City, Distance> CITY_ROAD_DISTANCE_GRAPH =
+   *     ValueGraphBuilder.undirected()
+   *         .<City, Distance>immutable()
+   *         .putEdgeValue(PARIS, BERLIN, kilometers(1060))
+   *         .putEdgeValue(PARIS, BRUSSELS, kilometers(317))
+   *         .putEdgeValue(BERLIN, BRUSSELS, kilometers(764))
+   *         .addNode(REYKJAVIK)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple graphs in series. Each new graph contains all the elements of the ones created before
+   * it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N, V> {
+
+    private final MutableValueGraph<N, V> mutableValueGraph;
+
+    Builder(ValueGraphBuilder<N, V> graphBuilder) {
+      this.mutableValueGraph = graphBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> addNode(N node) {
+      mutableValueGraph.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code nodeU} to {@code nodeV} if one is not already present, and
+     * sets a value for that edge to {@code value} (overwriting the existing value, if any).
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>Values do not have to be unique. However, values must be non-null.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> putEdgeValue(N nodeU, N nodeV, V value) {
+      mutableValueGraph.putEdgeValue(nodeU, nodeV, value);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code endpoints} if one is not already present, and sets a value for
+     * that edge to {@code value} (overwriting the existing value, if any).
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered.
+     *
+     * <p>Values do not have to be unique. However, values must be non-null.
+     *
+     * <p>If either or both endpoints are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the graph is directed
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> putEdgeValue(EndpointPair<N> endpoints, V value) {
+      mutableValueGraph.putEdgeValue(endpoints, value);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableValueGraph} based on the contents of this {@code
+     * Builder}.
+     */
+    public ImmutableValueGraph<N, V> build() {
+      return ImmutableValueGraph.copyOf(mutableValueGraph);
+    }
   }
 }

--- a/android/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/android/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -92,6 +92,18 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableNetwork#Builder} with the properties of this {@link NetworkBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableNetwork}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N, E1 extends E> ImmutableNetwork.Builder<N1, E1> immutable() {
+    NetworkBuilder<N1, E1> castBuilder = cast();
+    return new ImmutableNetwork.Builder<>(castBuilder);
+  }
+
+  /**
    * Specifies whether the network will allow parallel edges. Attempting to add a parallel edge to a
    * network that does not allow them will throw an {@link UnsupportedOperationException}.
    */

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -85,6 +85,19 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableValueGraph#Builder} with the properties of this {@link
+   * ValueGraphBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N, V1 extends V> ImmutableValueGraph.Builder<N1, V1> immutable() {
+    ValueGraphBuilder<N1, V1> castBuilder = cast();
+    return new ImmutableValueGraph.Builder<>(castBuilder);
+  }
+
+  /**
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -412,6 +412,31 @@ public final class HttpHeaders {
   public static final String PING_TO = "Ping-To";
 
   /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * Purpose}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String PURPOSE = "Purpose";
+  /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * X-Purpose}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String X_PURPOSE = "X-Purpose";
+  /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * X-Moz}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String X_MOZ = "X-Moz";
+
+  /**
    * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Dest}</a> header
    * field name.
    *

--- a/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -14,6 +14,8 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -124,6 +126,17 @@ public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecializat
     return future instanceof FluentFuture
         ? (FluentFuture<V>) future
         : new ForwardingFluentFuture<V>(future);
+  }
+
+  /**
+   * Simply returns its argument.
+   *
+   * @deprecated no need to use this
+   * @since NEXT
+   */
+  @Deprecated
+  public static <V> FluentFuture<V> from(FluentFuture<V> future) {
+    return checkNotNull(future);
   }
 
   /**

--- a/guava-gwt/test/com/google/common/util/concurrent/FluentFutureTest_gwt.java
+++ b/guava-gwt/test/com/google/common/util/concurrent/FluentFutureTest_gwt.java
@@ -38,6 +38,11 @@ public void testFromFluentFuture() throws Exception {
   testCase.testFromFluentFuture();
 }
 
+public void testFromFluentFuturePassingAsNonFluent() throws Exception {
+  com.google.common.util.concurrent.FluentFutureTest testCase = new com.google.common.util.concurrent.FluentFutureTest();
+  testCase.testFromFluentFuturePassingAsNonFluent();
+}
+
 public void testFromNonFluentFuture() throws Exception {
   com.google.common.util.concurrent.FluentFutureTest testCase = new com.google.common.util.concurrent.FluentFutureTest();
   testCase.testFromNonFluentFuture();

--- a/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
@@ -70,4 +70,66 @@ public class ImmutableGraphTest {
 
     assertThat(graph2).isSameAs(graph1);
   }
+
+  @Test
+  public void immutableGraphBuilder_appliesGraphBuilderConfig() {
+    ImmutableGraph<String> emptyGraph =
+        GraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .immutable()
+            .build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableGraph.Builder doesn't change when the creating GraphBuilder changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableGraphBuilder_copiesGraphBuilder() {
+    GraphBuilder<String> graphBuilder =
+        GraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableGraph.Builder<String> immutableGraphBuilder = graphBuilder.immutable();
+
+    // Update GraphBuilder, but this shouldn't impact immutableGraphBuilder
+    graphBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableGraph<String> emptyGraph = immutableGraphBuilder.build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableGraphBuilder_addNode() {
+    ImmutableGraph<String> graph = GraphBuilder.directed().<String>immutable().addNode("A").build();
+
+    assertThat(graph.nodes()).containsExactly("A");
+    assertThat(graph.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableGraphBuilder_putEdgeFromNodes() {
+    ImmutableGraph<String> graph =
+        GraphBuilder.directed().<String>immutable().putEdge("A", "B").build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+  }
+
+  @Test
+  public void immutableGraphBuilder_putEdgeFromEndpointPair() {
+    ImmutableGraph<String> graph =
+        GraphBuilder.directed().<String>immutable().putEdge(EndpointPair.ordered("A", "B")).build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+  }
 }

--- a/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ImmutableGraph} and {@link ImmutableValueGraph} . */
+/** Tests for {@link ImmutableGraph}. */
 @RunWith(JUnit4.class)
 public class ImmutableGraphTest {
 
@@ -40,33 +40,9 @@ public class ImmutableGraphTest {
   }
 
   @Test
-  public void immutableValueGraph() {
-    MutableValueGraph<String, Integer> mutableValueGraph = ValueGraphBuilder.directed().build();
-    mutableValueGraph.addNode("A");
-    ImmutableValueGraph<String, Integer> immutableValueGraph =
-        ImmutableValueGraph.copyOf(mutableValueGraph);
-
-    assertThat(immutableValueGraph.asGraph()).isInstanceOf(ImmutableGraph.class);
-    assertThat(immutableValueGraph).isNotInstanceOf(MutableValueGraph.class);
-    assertThat(immutableValueGraph).isEqualTo(mutableValueGraph);
-
-    mutableValueGraph.addNode("B");
-    assertThat(immutableValueGraph).isNotEqualTo(mutableValueGraph);
-  }
-
-  @Test
   public void copyOfImmutableGraph_optimized() {
     Graph<String> graph1 = ImmutableGraph.copyOf(GraphBuilder.directed().<String>build());
     Graph<String> graph2 = ImmutableGraph.copyOf(graph1);
-
-    assertThat(graph2).isSameAs(graph1);
-  }
-
-  @Test
-  public void copyOfImmutableValueGraph_optimized() {
-    ValueGraph<String, Integer> graph1 =
-        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
-    ValueGraph<String, Integer> graph2 = ImmutableValueGraph.copyOf(graph1);
 
     assertThat(graph2).isSameAs(graph1);
   }

--- a/guava-tests/test/com/google/common/graph/ImmutableNetworkTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableNetworkTest.java
@@ -74,4 +74,74 @@ public class ImmutableNetworkTest {
     assertThat(network.edgesConnecting("A", "B")).containsExactly("AB");
     assertThat(network.edgesConnecting("B", "A")).containsExactly("AB");
   }
+
+  @Test
+  public void immutableNetworkBuilder_appliesNetworkBuilderConfig() {
+    ImmutableNetwork<String, Integer> emptyNetwork =
+        NetworkBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .<String, Integer>immutable()
+            .build();
+
+    assertThat(emptyNetwork.isDirected()).isTrue();
+    assertThat(emptyNetwork.allowsSelfLoops()).isTrue();
+    assertThat(emptyNetwork.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableNetwork.Builder doesn't change when the creating NetworkBuilder
+   * changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableNetworkBuilder_copiesNetworkBuilder() {
+    NetworkBuilder<String, Object> networkBuilder =
+        NetworkBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableNetwork.Builder<String, Integer> immutableNetworkBuilder =
+        networkBuilder.<String, Integer>immutable();
+
+    // Update NetworkBuilder, but this shouldn't impact immutableNetworkBuilder
+    networkBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableNetwork<String, Integer> emptyNetwork = immutableNetworkBuilder.build();
+
+    assertThat(emptyNetwork.isDirected()).isTrue();
+    assertThat(emptyNetwork.allowsSelfLoops()).isTrue();
+    assertThat(emptyNetwork.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableNetworkBuilder_addNode() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed().<String, Integer>immutable().addNode("A").build();
+
+    assertThat(network.nodes()).containsExactly("A");
+    assertThat(network.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableNetworkBuilder_putEdgeFromNodes() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed().<String, Integer>immutable().addEdge("A", "B", 10).build();
+
+    assertThat(network.nodes()).containsExactly("A", "B");
+    assertThat(network.edges()).containsExactly(10);
+    assertThat(network.incidentNodes(10)).isEqualTo(EndpointPair.ordered("A", "B"));
+  }
+
+  @Test
+  public void immutableNetworkBuilder_putEdgeFromEndpointPair() {
+    ImmutableNetwork<String, Integer> network =
+        NetworkBuilder.directed()
+            .<String, Integer>immutable()
+            .addEdge(EndpointPair.ordered("A", "B"), 10)
+            .build();
+
+    assertThat(network.nodes()).containsExactly("A", "B");
+    assertThat(network.edges()).containsExactly(10);
+    assertThat(network.incidentNodes(10)).isEqualTo(EndpointPair.ordered("A", "B"));
+  }
 }

--- a/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ImmutableValueGraph} . */
+@RunWith(JUnit4.class)
+public class ImmutableValueGraphTest {
+
+  @Test
+  public void immutableValueGraph() {
+    MutableValueGraph<String, Integer> mutableValueGraph = ValueGraphBuilder.directed().build();
+    mutableValueGraph.addNode("A");
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(mutableValueGraph);
+
+    assertThat(immutableValueGraph.asGraph()).isInstanceOf(ImmutableGraph.class);
+    assertThat(immutableValueGraph).isNotInstanceOf(MutableValueGraph.class);
+    assertThat(immutableValueGraph).isEqualTo(mutableValueGraph);
+
+    mutableValueGraph.addNode("B");
+    assertThat(immutableValueGraph).isNotEqualTo(mutableValueGraph);
+  }
+
+  @Test
+  public void copyOfImmutableValueGraph_optimized() {
+    ValueGraph<String, Integer> graph1 =
+        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
+    ValueGraph<String, Integer> graph2 = ImmutableValueGraph.copyOf(graph1);
+
+    assertThat(graph2).isSameAs(graph1);
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_appliesGraphBuilderConfig() {
+    ImmutableValueGraph<String, Integer> emptyGraph =
+        ValueGraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .nodeOrder(ElementOrder.<String>natural())
+            .<String, Integer>immutable()
+            .build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  /**
+   * Tests that the ImmutableValueGraph.Builder doesn't change when the creating ValueGraphBuilder
+   * changes.
+   */
+  @Test
+  @SuppressWarnings("CheckReturnValue")
+  public void immutableValueGraphBuilder_copiesGraphBuilder() {
+    ValueGraphBuilder<String, Object> graphBuilder =
+        ValueGraphBuilder.directed()
+            .allowsSelfLoops(true)
+            .<String>nodeOrder(ElementOrder.<String>natural());
+    ImmutableValueGraph.Builder<String, Integer> immutableValueGraphBuilder =
+        graphBuilder.<String, Integer>immutable();
+
+    // Update ValueGraphBuilder, but this shouldn't impact immutableValueGraphBuilder
+    graphBuilder.allowsSelfLoops(false).nodeOrder(ElementOrder.<String>unordered());
+
+    ImmutableValueGraph<String, Integer> emptyGraph = immutableValueGraphBuilder.build();
+
+    assertThat(emptyGraph.isDirected()).isTrue();
+    assertThat(emptyGraph.allowsSelfLoops()).isTrue();
+    assertThat(emptyGraph.nodeOrder()).isEqualTo(ElementOrder.<String>natural());
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_addNode() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed().<String, Integer>immutable().addNode("A").build();
+
+    assertThat(graph.nodes()).containsExactly("A");
+    assertThat(graph.edges()).isEmpty();
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_putEdgeFromNodes() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed()
+            .<String, Integer>immutable()
+            .putEdgeValue("A", "B", 10)
+            .build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+    assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_putEdgeFromEndpointPair() {
+    ImmutableValueGraph<String, Integer> graph =
+        ValueGraphBuilder.directed()
+            .<String, Integer>immutable()
+            .putEdgeValue(EndpointPair.ordered("A", "B"), 10)
+            .build();
+
+    assertThat(graph.nodes()).containsExactly("A", "B");
+    assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
+    assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
+  }
+}

--- a/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FluentFutureTest.java
@@ -44,6 +44,11 @@ public class FluentFutureTest extends TestCase {
     assertThat(FluentFuture.from(f)).isSameAs(f);
   }
 
+  public void testFromFluentFuturePassingAsNonFluent() {
+    ListenableFuture<String> f = FluentFuture.from(SettableFuture.<String>create());
+    assertThat(FluentFuture.from(f)).isSameAs(f);
+  }
+
   public void testFromNonFluentFuture() throws Exception {
     ListenableFuture<String> f =
         new SimpleForwardingListenableFuture<String>(immediateFuture("a")) {};

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -88,7 +88,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    */
   public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
     GraphBuilder<N1> castBuilder = cast();
-    return new ImmutableGraph.Builder<N1>(castBuilder);
+    return new ImmutableGraph.Builder<>(castBuilder);
   }
 
   /**

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -80,6 +80,18 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableGraph#Builder} with the properties of this {@link GraphBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
+    GraphBuilder<N1> castBuilder = cast();
+    return new ImmutableGraph.Builder<N1>(castBuilder);
+  }
+
+  /**
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -103,9 +103,9 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
    * graphs. Example:
    *
    * <pre>{@code
-   * public static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
+   * static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
    *     GraphBuilder.undirected()
-   *         .<Country> immutable()
+   *         .<Country>immutable()
    *         .putEdge(FRANCE, GERMANY)
    *         .putEdge(FRANCE, BELGIUM)
    *         .putEdge(GERMANY, BELGIUM)

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -38,6 +38,7 @@ import com.google.errorprone.annotations.Immutable;
  * @author James Sexton
  * @author Joshua O'Madadhain
  * @author Omar Darwish
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @since 20.0
  */

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -24,6 +24,7 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.graph.GraphConstants.Presence;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 /**
@@ -95,5 +96,97 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
   @Override
   protected BaseGraph<N> delegate() {
     return backingGraph;
+  }
+
+  /**
+   * A builder for creating {@link ImmutableGraph} instances, especially {@code static final}
+   * graphs. Example:
+   *
+   * <pre>{@code
+   * public static final ImmutableGraph<Country> COUNTRY_ADJACENCY_GRAPH =
+   *     GraphBuilder.undirected()
+   *         .<Country> immutable()
+   *         .putEdge(FRANCE, GERMANY)
+   *         .putEdge(FRANCE, BELGIUM)
+   *         .putEdge(GERMANY, BELGIUM)
+   *         .addNode(ICELAND)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple graphs in series. Each new graph contains all the elements of the ones created before
+   * it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N> {
+
+    private final MutableGraph<N> mutableGraph;
+
+    Builder(GraphBuilder<N> graphBuilder) {
+      this.mutableGraph = graphBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> addNode(N node) {
+      mutableGraph.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code nodeU} to {@code nodeV} if one is not already present.
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> putEdge(N nodeU, N nodeV) {
+      mutableGraph.putEdge(nodeU, nodeV);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code endpoints} (in the order, if any, specified by {@code
+     * endpoints}) if one is not already present.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered and the added edge will be
+     * directed; if it is undirected, the added edge will be undirected.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered.
+     *
+     * <p>If either or both endpoints are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the graph is directed
+     */
+    @CanIgnoreReturnValue
+    public Builder<N> putEdge(EndpointPair<N> endpoints) {
+      mutableGraph.putEdge(endpoints);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableGraph} based on the contents of this {@code Builder}.
+     */
+    public ImmutableGraph<N> build() {
+      return ImmutableGraph.copyOf(mutableGraph);
+    }
   }
 }

--- a/guava/src/com/google/common/graph/ImmutableNetwork.java
+++ b/guava/src/com/google/common/graph/ImmutableNetwork.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Map;
 
@@ -37,6 +38,7 @@ import java.util.Map;
  * @author James Sexton
  * @author Joshua O'Madadhain
  * @author Omar Darwish
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <E> Edge parameter type
  * @since 20.0
@@ -137,5 +139,116 @@ public final class ImmutableNetwork<N, E> extends ConfigurableNetwork<N, E> {
         return network.incidentNodes(edge).adjacentNode(node);
       }
     };
+  }
+
+  /**
+   * A builder for creating {@link ImmutableNetwork} instances, especially {@code static final}
+   * networks. Example:
+   *
+   * <pre>{@code
+   * static final ImmutableNetwork<City, Train> TRAIN_NETWORK =
+   *     NetworkBuilder.undirected()
+   *         .allowsParallelEdges(true)
+   *         .<City, Train>immutable()
+   *         .addEdge(PARIS, BRUSSELS, Thalys.trainNumber("1111"))
+   *         .addEdge(PARIS, BRUSSELS, RegionalTrain.trainNumber("2222"))
+   *         .addEdge(LONDON, PARIS, Eurostar.trainNumber("3333"))
+   *         .addEdge(LONDON, BRUSSELS, Eurostar.trainNumber("4444"))
+   *         .addNode(REYKJAVIK)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple networks in series. Each new network contains all the elements of the ones created
+   * before it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N, E> {
+
+    private final MutableNetwork<N, E> mutableNetwork;
+
+    Builder(NetworkBuilder<N, E> networkBuilder) {
+      this.mutableNetwork = networkBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addNode(N node) {
+      mutableNetwork.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds {@code edge} connecting {@code nodeU} to {@code nodeV}.
+     *
+     * <p>If the network is directed, {@code edge} will be directed in this network; otherwise, it
+     * will be undirected.
+     *
+     * <p><b>{@code edge} must be unique to this network</b>, just as a {@code Map} key must be. It
+     * must also be non-null.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this network, this method
+     * will silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the network.
+     *
+     * <p>If {@code edge} already connects {@code nodeU} to {@code nodeV} (in the specified order if
+     * this network {@link #isDirected()}, else in any order), then this method will have no effect.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if {@code edge} already exists in the network and does not
+     *     connect {@code nodeU} to {@code nodeV}
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsParallelEdges()} or {@link #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addEdge(N nodeU, N nodeV, E edge) {
+      mutableNetwork.addEdge(nodeU, nodeV, edge);
+      return this;
+    }
+
+    /**
+     * Adds {@code edge} connecting {@code endpoints}. In an undirected network, {@code edge} will
+     * also connect {@code nodeV} to {@code nodeU}.
+     *
+     * <p>If this network is directed, {@code edge} will be directed in this network; if it is
+     * undirected, {@code edge} will be undirected in this network.
+     *
+     * <p>If this network is directed, {@code endpoints} must be ordered.
+     *
+     * <p><b>{@code edge} must be unique to this network</b>, just as a {@code Map} key must be. It
+     * must also be non-null.
+     *
+     * <p>If either or both endpoints are not already present in this network, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the network.
+     *
+     * <p>If {@code edge} already connects an endpoint pair equal to {@code endpoints}, then this
+     * method will have no effect.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if {@code edge} already exists in the network and connects
+     *     some other endpoint pair that is not equal to {@code endpoints}
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsParallelEdges()} or {@link #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the network is directed
+     */
+    @CanIgnoreReturnValue
+    public ImmutableNetwork.Builder<N, E> addEdge(EndpointPair<N> endpoints, E edge) {
+      mutableNetwork.addEdge(endpoints, edge);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableNetwork} based on the contents of this {@code
+     * Builder}.
+     */
+    public ImmutableNetwork<N, E> build() {
+      return ImmutableNetwork.copyOf(mutableNetwork);
+    }
   }
 }

--- a/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 
 /**
@@ -34,6 +35,7 @@ import com.google.errorprone.annotations.Immutable;
  * provided by this class.
  *
  * @author James Sexton
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  * @since 20.0
@@ -95,5 +97,103 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
             graph.predecessors(node), Maps.asMap(graph.successors(node), successorNodeToValueFn))
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), successorNodeToValueFn));
+  }
+
+  /**
+   * A builder for creating {@link ImmutableValueGraph} instances, especially {@code static final}
+   * graphs. Example:
+   *
+   * <pre>{@code
+   * static final ImmutableValueGraph<City, Distance> CITY_ROAD_DISTANCE_GRAPH =
+   *     ValueGraphBuilder.undirected()
+   *         .<City, Distance>immutable()
+   *         .putEdgeValue(PARIS, BERLIN, kilometers(1060))
+   *         .putEdgeValue(PARIS, BRUSSELS, kilometers(317))
+   *         .putEdgeValue(BERLIN, BRUSSELS, kilometers(764))
+   *         .addNode(REYKJAVIK)
+   *         .build();
+   * }</pre>
+   *
+   * <p>Builder instances can be reused; it is safe to call {@link #build} multiple times to build
+   * multiple graphs in series. Each new graph contains all the elements of the ones created before
+   * it.
+   *
+   * @since NEXT
+   */
+  public static class Builder<N, V> {
+
+    private final MutableValueGraph<N, V> mutableValueGraph;
+
+    Builder(ValueGraphBuilder<N, V> graphBuilder) {
+      this.mutableValueGraph = graphBuilder.build();
+    }
+
+    /**
+     * Adds {@code node} if it is not already present.
+     *
+     * <p><b>Nodes must be unique</b>, just as {@code Map} keys must be. They must also be non-null.
+     *
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> addNode(N node) {
+      mutableValueGraph.addNode(node);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code nodeU} to {@code nodeV} if one is not already present, and
+     * sets a value for that edge to {@code value} (overwriting the existing value, if any).
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>Values do not have to be unique. However, values must be non-null.
+     *
+     * <p>If {@code nodeU} and {@code nodeV} are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} {@code nodeU} and {@code nodeV} to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> putEdgeValue(N nodeU, N nodeV, V value) {
+      mutableValueGraph.putEdgeValue(nodeU, nodeV, value);
+      return this;
+    }
+
+    /**
+     * Adds an edge connecting {@code endpoints} if one is not already present, and sets a value for
+     * that edge to {@code value} (overwriting the existing value, if any).
+     *
+     * <p>If the graph is directed, the resultant edge will be directed; otherwise, it will be
+     * undirected.
+     *
+     * <p>If this graph is directed, {@code endpoints} must be ordered.
+     *
+     * <p>Values do not have to be unique. However, values must be non-null.
+     *
+     * <p>If either or both endpoints are not already present in this graph, this method will
+     * silently {@link #addNode(Object) add} each missing endpoint to the graph.
+     *
+     * @return this {@code Builder} object
+     * @throws IllegalArgumentException if the introduction of the edge would violate {@link
+     *     #allowsSelfLoops()}
+     * @throws IllegalArgumentException if the endpoints are unordered and the graph is directed
+     */
+    @CanIgnoreReturnValue
+    public ImmutableValueGraph.Builder<N, V> putEdgeValue(EndpointPair<N> endpoints, V value) {
+      mutableValueGraph.putEdgeValue(endpoints, value);
+      return this;
+    }
+
+    /**
+     * Returns a newly-created {@code ImmutableValueGraph} based on the contents of this {@code
+     * Builder}.
+     */
+    public ImmutableValueGraph<N, V> build() {
+      return ImmutableValueGraph.copyOf(mutableValueGraph);
+    }
   }
 }

--- a/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -92,6 +92,18 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableNetwork#Builder} with the properties of this {@link NetworkBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableNetwork}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N, E1 extends E> ImmutableNetwork.Builder<N1, E1> immutable() {
+    NetworkBuilder<N1, E1> castBuilder = cast();
+    return new ImmutableNetwork.Builder<>(castBuilder);
+  }
+
+  /**
    * Specifies whether the network will allow parallel edges. Attempting to add a parallel edge to a
    * network that does not allow them will throw an {@link UnsupportedOperationException}.
    */

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -85,6 +85,19 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   }
 
   /**
+   * Returns an {@link ImmutableValueGraph#Builder} with the properties of this {@link
+   * ValueGraphBuilder}.
+   *
+   * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.
+   *
+   * @since NEXT
+   */
+  public <N1 extends N, V1 extends V> ImmutableValueGraph.Builder<N1, V1> immutable() {
+    ValueGraphBuilder<N1, V1> castBuilder = cast();
+    return new ImmutableValueGraph.Builder<>(castBuilder);
+  }
+
+  /**
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -412,6 +412,31 @@ public final class HttpHeaders {
   public static final String PING_TO = "Ping-To";
 
   /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * Purpose}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String PURPOSE = "Purpose";
+  /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * X-Purpose}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String X_PURPOSE = "X-Purpose";
+  /**
+   * The HTTP <a
+   * href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F">{@code
+   * X-Moz}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String X_MOZ = "X-Moz";
+
+  /**
    * The HTTP <a href="https://mikewest.github.io/sec-metadata/">{@code Sec-Fetch-Dest}</a> header
    * field name.
    *

--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -14,6 +14,8 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -124,6 +126,17 @@ public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecializat
     return future instanceof FluentFuture
         ? (FluentFuture<V>) future
         : new ForwardingFluentFuture<V>(future);
+  }
+
+  /**
+   * Simply returns its argument.
+   *
+   * @deprecated no need to use this
+   * @since NEXT
+   */
+  @Deprecated
+  public static <V> FluentFuture<V> from(FluentFuture<V> future) {
+    return checkNotNull(future);
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add (unimplemented) API for GrapbBuilder.immutable() and ImmutableGraph.Builder.

50eddd03e92dc2855a3ae05c3b8d93de18e6bddd

-------

<p> Adds constants for prefetch headers.

Of note, X-Purpose is NOT just a google specific header as previously defined.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ#As_a_server_admin.2C_can_I_distinguish_prefetch_requests_from_normal_requests.3F

https://developers.google.com/web/updates/2018/07/nostate-prefetch

RELNOTES=Adds constants for prefetch headers.

966879ff982425a4418341c9ccbe9a7249bb0a4d

-------

<p> Implement GraphBuilder.immutable().

RELNOTES=`graph`: Added `GraphBuilder.immutable()` for building immutable graphs in a fluent way

7998dc473efbfa7ec7d57ece8b4c527fa9e11b9b

-------

<p> Add FluentFuture.from(FluentFuture) factory method.

This follows the steps of FluentIterable.from(FluentIterable) and other
“migration aid” methods that are deprecated from inception and are just here to
point out code that is no longer needed.

RELNOTES=Added deprecated `FluentFuture.from(FluentFuture)` to point out redundant code.

2d060028e9d99f798a29fd1ec09c844f4fc58a1d

-------

<p> Use byte[]/short[]/int[] for hashtable depending on size

The hashtable is stored as an Object and cast to the correct type using
instanceof checks.

Memory:
byte[] sizes (2-89): 12-41% better (average: 32% better)
short[] sizes (90-22937): 20-29% better (average: 24% better)
int[] sizes (22938+): unchanged

Runtime on a Pixel 2:
createAndPopulate: 9% better to 6% worse (average: 4.3% better)
get: 1% better to 8% worse (average: 3.5% worse)
iterateWithKeySetAndGet: 9% better to 13% worse (average: 3.2% worse)
iterateWithEntrySet: unchanged (doesn't use hashtable)

Effects on ImmutableMapProGuard:
59105 bytes => 60369 bytes (+2.1%)
21 classes => 21 classes (0%)
200 methods => 201 methods (+0.5%)

Effects on ImmutableBiMapProGuard:
68893 bytes => 70235 bytes (+1.9%)
25 classes => 25 classes (0%)
232 methods => 233 methods (+0.4%)

b1a11396bd731ddcd1efd60850b0aa004c9f874b

-------

<p> Add ValueGraphBuilder.immutable().

RELNOTES=`graph`: Added `ValueGraphBuilder.immutable()` for building immutable value graphs in a fluent way

79e0a573fc00db17f0916426ce2107d3bf63d481

-------

<p> Remove unnecessary Type parameter

6f0b66d172a9532aaa82dac8a1add496c916ad97

-------

<p> Add NetworkBuilder.immutable().

RELNOTES=`graph`: Added `NetworkBuilder.immutable()` for building immutable networks in a fluent way

a812af75ee14d8cb01a1a180b2c369c2f16311a3