### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactHashMap.java
@@ -96,10 +96,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     return new CompactHashMap<>(expectedSize);
   }
 
-  private static final int MAXIMUM_CAPACITY = 1 << 30;
-
-  // TODO(user): decide, and inline, load factor. 0.75?
-  static final float DEFAULT_LOAD_FACTOR = 1.0f;
+  private static final float LOAD_FACTOR = 1.0f;
 
   /** Bitmask that selects the low 32 bits. */
   private static final long NEXT_MASK = (1L << 32) - 1;
@@ -143,9 +140,6 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    */
   @VisibleForTesting @MonotonicNonNullDecl transient Object[] values;
 
-  /** The load factor. */
-  transient float loadFactor;
-
   /**
    * Keeps track of modifications of this set, to make it possible to throw
    * ConcurrentModificationException in the iterator. Note that we choose not to make this volatile,
@@ -153,15 +147,12 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    */
   transient int modCount;
 
-  /** When we have this many elements, resize the hashtable. */
-  private transient int threshold;
-
   /** The number of elements contained in the set. */
   private transient int size;
 
   /** Constructs a new empty instance of {@code CompactHashMap}. */
   CompactHashMap() {
-    init(DEFAULT_SIZE, DEFAULT_LOAD_FACTOR);
+    init(DEFAULT_SIZE);
   }
 
   /**
@@ -169,27 +160,14 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    *
    * @param capacity the initial capacity of this {@code CompactHashMap}.
    */
-  CompactHashMap(int capacity) {
-    init(capacity, DEFAULT_LOAD_FACTOR);
-  }
-
-  /**
-   * Constructs a new instance of {@code CompactHashMap} with the specified capacity and load
-   * factor.
-   *
-   * @param capacity the initial capacity of this {@code CompactHashMap}.
-   * @param loadFactor the load factor of this {@code CompactHashMap}.
-   */
-  CompactHashMap(int capacity, float loadFactor) {
-    init(capacity, loadFactor);
+  CompactHashMap(int expectedSize) {
+    init(expectedSize);
   }
 
   /** Pseudoconstructor for serialization support. */
-  void init(int expectedSize, float loadFactor) {
+  void init(int expectedSize) {
     Preconditions.checkArgument(expectedSize >= 0, "Initial capacity must be non-negative");
-    Preconditions.checkArgument(loadFactor > 0, "Illegal load factor");
-    this.loadFactor = loadFactor;
-    this.threshold = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
+    this.modCount = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
   }
 
   /** Returns whether arrays need to be allocated. */
@@ -201,15 +179,13 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   void allocArrays() {
     Preconditions.checkState(needsAllocArrays(), "Arrays already allocated");
 
-    int expectedSize = threshold;
-    int buckets = Hashing.closedTableSize(expectedSize, loadFactor);
+    int expectedSize = modCount;
+    int buckets = Hashing.closedTableSize(expectedSize, LOAD_FACTOR);
     this.table = newTable(buckets);
 
+    this.entries = newEntries(expectedSize);
     this.keys = new Object[expectedSize];
     this.values = new Object[expectedSize];
-
-    this.entries = newEntries(expectedSize);
-    this.threshold = Math.max(1, (int) (buckets * loadFactor));
   }
 
   private static int[] newTable(int size) {
@@ -265,7 +241,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     int tableIndex = hash & hashTableMask();
     int newEntryIndex = this.size; // current size, and pointer to the entry to be appended
     int next = table[tableIndex];
-    if (next == UNSET) {
+    if (next == UNSET) { // uninitialized bucket
       table[tableIndex] = newEntryIndex;
     } else {
       int last;
@@ -293,8 +269,9 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     resizeMeMaybe(newSize);
     insertEntry(newEntryIndex, key, value, hash);
     this.size = newSize;
-    if (newEntryIndex >= threshold) {
-      resizeTable(2 * table.length);
+    int oldCapacity = table.length;
+    if (Hashing.needsResizing(newEntryIndex, oldCapacity, LOAD_FACTOR)) {
+      resizeTable(2 * oldCapacity);
     }
     modCount++;
     return null;
@@ -340,13 +317,6 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   private void resizeTable(int newCapacity) { // newCapacity always a power of two
-    int[] oldTable = table;
-    int oldCapacity = oldTable.length;
-    if (oldCapacity >= MAXIMUM_CAPACITY) {
-      threshold = Integer.MAX_VALUE;
-      return;
-    }
-    int newThreshold = 1 + (int) (newCapacity * loadFactor);
     int[] newTable = newTable(newCapacity);
     long[] entries = this.entries;
 
@@ -360,7 +330,6 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
       entries[i] = ((long) hash << 32) | (NEXT_MASK & next);
     }
 
-    this.threshold = newThreshold;
     this.table = newTable;
   }
 
@@ -412,25 +381,23 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     }
     int last = UNSET;
     do {
-      if (getHash(entries[next]) == hash) {
-        if (Objects.equal(key, keys[next])) {
-          @SuppressWarnings("unchecked") // values only contains Vs
-          @NullableDecl
-          V oldValue = (V) values[next];
+      if (getHash(entries[next]) == hash && Objects.equal(key, keys[next])) {
+        @SuppressWarnings("unchecked") // values only contains Vs
+        @NullableDecl
+        V oldValue = (V) values[next];
 
-          if (last == UNSET) {
-            // we need to update the root link from table[]
-            table[tableIndex] = getNext(entries[next]);
-          } else {
-            // we need to update the link from the chain
-            entries[last] = swapNext(entries[last], getNext(entries[next]));
-          }
-
-          moveLastEntry(next);
-          size--;
-          modCount++;
-          return oldValue;
+        if (last == UNSET) {
+          // we need to update the root link from table[]
+          table[tableIndex] = getNext(entries[next]);
+        } else {
+          // we need to update the link from the chain
+          entries[last] = swapNext(entries[last], getNext(entries[next]));
         }
+
+        moveLastEntry(next);
+        size--;
+        modCount++;
+        return oldValue;
       }
       last = next;
       next = getNext(entries[next]);
@@ -777,18 +744,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     if (size < entries.length) {
       resizeEntries(size);
     }
-    // size / loadFactor gives the table size of the appropriate load factor,
-    // but that may not be a power of two. We floor it to a power of two by
-    // keeping its highest bit. But the smaller table may have a load factor
-    // larger than what we want; then we want to go to the next power of 2 if we can
-    int minimumTableSize = Math.max(1, Integer.highestOneBit((int) (size / loadFactor)));
-    if (minimumTableSize < MAXIMUM_CAPACITY) {
-      double load = (double) size / minimumTableSize;
-      if (load > loadFactor) {
-        minimumTableSize <<= 1; // increase to next power if possible
-      }
-    }
-
+    int minimumTableSize = Hashing.closedTableSize(size, LOAD_FACTOR);
     if (minimumTableSize < table.length) {
       resizeTable(minimumTableSize);
     }
@@ -827,7 +783,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     if (elementCount < 0) {
       throw new InvalidObjectException("Invalid size: " + elementCount);
     }
-    init(elementCount, DEFAULT_LOAD_FACTOR);
+    init(elementCount);
     for (int i = 0; i < elementCount; i++) {
       K key = (K) stream.readObject();
       V value = (V) stream.readObject();

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.common.collect;
 
 import com.google.common.annotations.GwtIncompatible;
@@ -51,7 +52,7 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
 
   /**
    * Creates a {@code CompactLinkedHashMap} instance, with a high enough "initial capacity" that it
-   * <i>should</i> hold {@code expectedSize} elements without growth.
+   * <i>should</i> hold {@code expectedSize} elements without rebuilding internal data structures.
    *
    * @param expectedSize the number of elements you expect to add to the returned set
    * @return a new, empty {@code CompactLinkedHashMap} with enough capacity to hold {@code
@@ -88,26 +89,26 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
   }
 
   CompactLinkedHashMap(int expectedSize) {
-    this(expectedSize, DEFAULT_LOAD_FACTOR, false);
+    this(expectedSize, false);
   }
 
-  CompactLinkedHashMap(int expectedSize, float loadFactor, boolean accessOrder) {
-    super(expectedSize, loadFactor);
+  CompactLinkedHashMap(int expectedSize, boolean accessOrder) {
+    super(expectedSize);
     this.accessOrder = accessOrder;
   }
 
   @Override
-  void init(int expectedSize, float loadFactor) {
-    super.init(expectedSize, loadFactor);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
+  void init(int expectedSize) {
+    super.init(expectedSize);
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
   }
 
   @Override
   void allocArrays() {
     super.allocArrays();
     int expectedSize = keys.length; // allocated size may be different than initial capacity
-    links = new long[expectedSize];
+    this.links = new long[expectedSize];
     Arrays.fill(links, UNSET);
   }
 
@@ -136,6 +137,7 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     } else {
       setSuccessor(pred, succ);
     }
+
     if (succ == ENDPOINT) {
       lastEntry = pred;
     } else {
@@ -165,13 +167,14 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
   @Override
   void moveLastEntry(int dstIndex) {
     int srcIndex = size() - 1;
+    super.moveLastEntry(dstIndex);
+
     setSucceeds(getPredecessor(dstIndex), getSuccessor(dstIndex));
     if (dstIndex < srcIndex) {
       setSucceeds(getPredecessor(srcIndex), dstIndex);
       setSucceeds(dstIndex, getSuccessor(srcIndex));
     }
     links[srcIndex] = UNSET;
-    super.moveLastEntry(dstIndex);
   }
 
   @Override

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashSet.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashSet.java
@@ -48,7 +48,7 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
 
   /** Creates an empty {@code CompactLinkedHashSet} instance. */
   public static <E> CompactLinkedHashSet<E> create() {
-    return new CompactLinkedHashSet<E>();
+    return new CompactLinkedHashSet<>();
   }
 
   /**
@@ -87,7 +87,7 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
    * @throws IllegalArgumentException if {@code expectedSize} is negative
    */
   public static <E> CompactLinkedHashSet<E> createWithExpectedSize(int expectedSize) {
-    return new CompactLinkedHashSet<E>(expectedSize);
+    return new CompactLinkedHashSet<>(expectedSize);
   }
 
   private static final int ENDPOINT = -2;
@@ -108,7 +108,10 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
    */
   @MonotonicNonNullDecl private transient int[] successor;
 
+  /** Pointer to the first node in the linked list, or {@code ENDPOINT} if there are no entries. */
   private transient int firstEntry;
+
+  /** Pointer to the last node in the linked list, or {@code ENDPOINT} if there are no entries. */
   private transient int lastEntry;
 
   CompactLinkedHashSet() {
@@ -120,10 +123,10 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   }
 
   @Override
-  void init(int expectedSize, float loadFactor) {
-    super.init(expectedSize, loadFactor);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
+  void init(int expectedSize) {
+    super.init(expectedSize);
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
   }
 
   @Override
@@ -132,56 +135,60 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
     int expectedSize = elements.length; // allocated size may be different than initial capacity
     this.predecessor = new int[expectedSize];
     this.successor = new int[expectedSize];
-
     Arrays.fill(predecessor, UNSET);
     Arrays.fill(successor, UNSET);
   }
 
-  private void succeeds(int pred, int succ) {
+  private int getPredecessor(int entry) {
+    return predecessor[entry];
+  }
+
+  @Override
+  int getSuccessor(int entry) {
+    return successor[entry];
+  }
+
+  private void setSuccessor(int entry, int succ) {
+    successor[entry] = succ;
+  }
+
+  private void setPredecessor(int entry, int pred) {
+    predecessor[entry] = pred;
+  }
+
+  private void setSucceeds(int pred, int succ) {
     if (pred == ENDPOINT) {
       firstEntry = succ;
     } else {
-      successor[pred] = succ;
+      setSuccessor(pred, succ);
     }
 
     if (succ == ENDPOINT) {
       lastEntry = pred;
     } else {
-      predecessor[succ] = pred;
+      setPredecessor(succ, pred);
     }
   }
 
   @Override
   void insertEntry(int entryIndex, E object, int hash) {
     super.insertEntry(entryIndex, object, hash);
-    succeeds(lastEntry, entryIndex);
-    succeeds(entryIndex, ENDPOINT);
+    setSucceeds(lastEntry, entryIndex);
+    setSucceeds(entryIndex, ENDPOINT);
   }
 
   @Override
-  void moveEntry(int dstIndex) {
+  void moveLastEntry(int dstIndex) {
     int srcIndex = size() - 1;
-    super.moveEntry(dstIndex);
+    super.moveLastEntry(dstIndex);
 
-    succeeds(predecessor[dstIndex], successor[dstIndex]);
-    if (srcIndex != dstIndex) {
-      succeeds(predecessor[srcIndex], dstIndex);
-      succeeds(dstIndex, successor[srcIndex]);
+    setSucceeds(getPredecessor(dstIndex), getSuccessor(dstIndex));
+    if (dstIndex < srcIndex) {
+      setSucceeds(getPredecessor(srcIndex), dstIndex);
+      setSucceeds(dstIndex, getSuccessor(srcIndex));
     }
     predecessor[srcIndex] = UNSET;
     successor[srcIndex] = UNSET;
-  }
-
-  @Override
-  public void clear() {
-    if (needsAllocArrays()) {
-      return;
-    }
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
-    Arrays.fill(predecessor, 0, size(), UNSET);
-    Arrays.fill(successor, 0, size(), UNSET);
-    super.clear();
   }
 
   @Override
@@ -190,11 +197,20 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
     int oldCapacity = predecessor.length;
     predecessor = Arrays.copyOf(predecessor, newCapacity);
     successor = Arrays.copyOf(successor, newCapacity);
-
     if (oldCapacity < newCapacity) {
       Arrays.fill(predecessor, oldCapacity, newCapacity, UNSET);
       Arrays.fill(successor, oldCapacity, newCapacity, UNSET);
     }
+  }
+
+  @Override
+  int firstEntryIndex() {
+    return firstEntry;
+  }
+
+  @Override
+  int adjustAfterRemove(int indexBeforeRemove, int indexRemoved) {
+    return (indexBeforeRemove >= size()) ? indexRemoved : indexBeforeRemove;
   }
 
   @Override
@@ -208,17 +224,14 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   }
 
   @Override
-  int firstEntryIndex() {
-    return firstEntry;
-  }
-
-  @Override
-  int adjustAfterRemove(int indexBeforeRemove, int indexRemoved) {
-    return (indexBeforeRemove == size()) ? indexRemoved : indexBeforeRemove;
-  }
-
-  @Override
-  int getSuccessor(int entryIndex) {
-    return successor[entryIndex];
+  public void clear() {
+    if (needsAllocArrays()) {
+      return;
+    }
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
+    Arrays.fill(predecessor, 0, size(), UNSET);
+    Arrays.fill(successor, 0, size(), UNSET);
+    super.clear();
   }
 }

--- a/guava/src/com/google/common/collect/CompactHashSet.java
+++ b/guava/src/com/google/common/collect/CompactHashSet.java
@@ -75,7 +75,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
 
   /** Creates an empty {@code CompactHashSet} instance. */
   public static <E> CompactHashSet<E> create() {
-    return new CompactHashSet<E>();
+    return new CompactHashSet<>();
   }
 
   /**
@@ -114,13 +114,10 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
    * @throws IllegalArgumentException if {@code expectedSize} is negative
    */
   public static <E> CompactHashSet<E> createWithExpectedSize(int expectedSize) {
-    return new CompactHashSet<E>(expectedSize);
+    return new CompactHashSet<>(expectedSize);
   }
 
-  private static final int MAXIMUM_CAPACITY = 1 << 30;
-
-  // TODO(user): decide, and inline, load factor. 0.75?
-  private static final float DEFAULT_LOAD_FACTOR = 1.0f;
+  private static final float LOAD_FACTOR = 1.0f;
 
   /** Bitmask that selects the low 32 bits. */
   private static final long NEXT_MASK = (1L << 32) - 1;
@@ -131,10 +128,11 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   // TODO(user): decide default size
   @VisibleForTesting static final int DEFAULT_SIZE = 3;
 
+  // used to indicate blank table entries
   static final int UNSET = -1;
 
   /**
-   * The hashtable. Its values are indexes to both the elements and entries arrays.
+   * The hashtable. Its values are indexes to the elements and entries arrays.
    *
    * <p>Currently, the UNSET value means "null pointer", and any non negative value x is the actual
    * index.
@@ -151,11 +149,11 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
    */
   private transient long @MonotonicNonNull [] entries;
 
-  /** The elements contained in the set, in the range of [0, size()). */
+  /**
+   * The elements contained in the set, in the range of [0, size()). The elements in [size(),
+   * elements.length) are all {@code null}.
+   */
   transient Object @MonotonicNonNull [] elements;
-
-  /** The load factor. */
-  transient float loadFactor;
 
   /**
    * Keeps track of modifications of this set, to make it possible to throw
@@ -164,15 +162,12 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
    */
   transient int modCount;
 
-  /** When we have this many elements, resize the hashtable. */
-  private transient int threshold;
-
   /** The number of elements contained in the set. */
   private transient int size;
 
   /** Constructs a new empty instance of {@code CompactHashSet}. */
   CompactHashSet() {
-    init(DEFAULT_SIZE, DEFAULT_LOAD_FACTOR);
+    init(DEFAULT_SIZE);
   }
 
   /**
@@ -181,15 +176,13 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
    * @param expectedSize the initial capacity of this {@code CompactHashSet}.
    */
   CompactHashSet(int expectedSize) {
-    init(expectedSize, DEFAULT_LOAD_FACTOR);
+    init(expectedSize);
   }
 
   /** Pseudoconstructor for serialization support. */
-  void init(int expectedSize, float loadFactor) {
+  void init(int expectedSize) {
     Preconditions.checkArgument(expectedSize >= 0, "Initial capacity must be non-negative");
-    Preconditions.checkArgument(loadFactor > 0, "Illegal load factor");
-    this.loadFactor = loadFactor;
-    this.threshold = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
+    this.modCount = Math.max(1, expectedSize); // Save expectedSize for use in allocArrays()
   }
 
   /** Returns whether arrays need to be allocated. */
@@ -201,14 +194,12 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   void allocArrays() {
     Preconditions.checkState(needsAllocArrays(), "Arrays already allocated");
 
-    int expectedSize = threshold;
-    int buckets = Hashing.closedTableSize(expectedSize, loadFactor);
+    int expectedSize = modCount;
+    int buckets = Hashing.closedTableSize(expectedSize, LOAD_FACTOR);
     this.table = newTable(buckets);
 
-    this.elements = new Object[expectedSize];
-
     this.entries = newEntries(expectedSize);
-    this.threshold = Math.max(1, (int) (buckets * loadFactor));
+    this.elements = new Object[expectedSize];
   }
 
   private static int[] newTable(int size) {
@@ -221,6 +212,10 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     long[] array = new long[size];
     Arrays.fill(array, UNSET);
     return array;
+  }
+
+  private int hashTableMask() {
+    return table.length - 1;
   }
 
   private static int getHash(long entry) {
@@ -237,10 +232,6 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     return (HASH_MASK & entry) | (NEXT_MASK & newNext);
   }
 
-  private int hashTableMask() {
-    return table.length - 1;
-  }
-
   @CanIgnoreReturnValue
   @Override
   public boolean add(@Nullable E object) {
@@ -249,6 +240,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     }
     long[] entries = this.entries;
     Object[] elements = this.elements;
+
     int hash = smearedHash(object);
     int tableIndex = hash & hashTableMask();
     int newEntryIndex = this.size; // current size, and pointer to the entry to be appended
@@ -275,8 +267,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     resizeMeMaybe(newSize);
     insertEntry(newEntryIndex, object, hash);
     this.size = newSize;
-    if (newEntryIndex >= threshold) {
-      resizeTable(2 * table.length);
+    int oldCapacity = table.length;
+    if (Hashing.needsResizing(newEntryIndex, oldCapacity, LOAD_FACTOR)) {
+      resizeTable(2 * oldCapacity);
     }
     modCount++;
     return true;
@@ -311,22 +304,15 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   void resizeEntries(int newCapacity) {
     this.elements = Arrays.copyOf(elements, newCapacity);
     long[] entries = this.entries;
-    int oldSize = entries.length;
+    int oldCapacity = entries.length;
     entries = Arrays.copyOf(entries, newCapacity);
-    if (newCapacity > oldSize) {
-      Arrays.fill(entries, oldSize, newCapacity, UNSET);
+    if (newCapacity > oldCapacity) {
+      Arrays.fill(entries, oldCapacity, newCapacity, UNSET);
     }
     this.entries = entries;
   }
 
   private void resizeTable(int newCapacity) { // newCapacity always a power of two
-    int[] oldTable = table;
-    int oldCapacity = oldTable.length;
-    if (oldCapacity >= MAXIMUM_CAPACITY) {
-      threshold = Integer.MAX_VALUE;
-      return;
-    }
-    int newThreshold = 1 + (int) (newCapacity * loadFactor);
     int[] newTable = newTable(newCapacity);
     long[] entries = this.entries;
 
@@ -340,7 +326,6 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
       entries[i] = ((long) hash << 32) | (NEXT_MASK & next);
     }
 
-    this.threshold = newThreshold;
     this.table = newTable;
   }
 
@@ -388,7 +373,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
           entries[last] = swapNext(entries[last], getNext(entries[next]));
         }
 
-        moveEntry(next);
+        moveLastEntry(next);
         size--;
         modCount++;
         return true;
@@ -402,7 +387,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   /**
    * Moves the last entry in the entry array into {@code dstIndex}, and nulls out its old position.
    */
-  void moveEntry(int dstIndex) {
+  void moveLastEntry(int dstIndex) {
     int srcIndex = size() - 1;
     if (dstIndex < srcIndex) {
       // move last entry to deleted spot
@@ -459,12 +444,12 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   public Iterator<E> iterator() {
     return new Iterator<E>() {
       int expectedModCount = modCount;
-      int index = firstEntryIndex();
+      int currentIndex = firstEntryIndex();
       int indexToRemove = -1;
 
       @Override
       public boolean hasNext() {
-        return index >= 0;
+        return currentIndex >= 0;
       }
 
       @Override
@@ -474,9 +459,9 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
         if (!hasNext()) {
           throw new NoSuchElementException();
         }
-        indexToRemove = index;
-        E result = (E) elements[index];
-        index = getSuccessor(index);
+        indexToRemove = currentIndex;
+        E result = (E) elements[currentIndex];
+        currentIndex = getSuccessor(currentIndex);
         return result;
       }
 
@@ -486,7 +471,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
         checkRemove(indexToRemove >= 0);
         expectedModCount++;
         CompactHashSet.this.remove(elements[indexToRemove], getHash(entries[indexToRemove]));
-        index = adjustAfterRemove(index, indexToRemove);
+        currentIndex = adjustAfterRemove(currentIndex, indexToRemove);
         indexToRemove = -1;
       }
 
@@ -509,7 +494,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
   @Override
   public void forEach(Consumer<? super E> action) {
     checkNotNull(action);
-    for (int i = 0; i < size; i++) {
+    for (int i = firstEntryIndex(); i >= 0; i = getSuccessor(i)) {
       action.accept((E) elements[i]);
     }
   }
@@ -556,18 +541,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     if (size < entries.length) {
       resizeEntries(size);
     }
-    // size / loadFactor gives the table size of the appropriate load factor,
-    // but that may not be a power of two. We floor it to a power of two by
-    // keeping its highest bit. But the smaller table may have a load factor
-    // larger than what we want; then we want to go to the next power of 2 if we can
-    int minimumTableSize = Math.max(1, Integer.highestOneBit((int) (size / loadFactor)));
-    if (minimumTableSize < MAXIMUM_CAPACITY) {
-      double load = (double) size / minimumTableSize;
-      if (load > loadFactor) {
-        minimumTableSize <<= 1; // increase to next power if possible
-      }
-    }
-
+    int minimumTableSize = Hashing.closedTableSize(size, LOAD_FACTOR);
     if (minimumTableSize < table.length) {
       resizeTable(minimumTableSize);
     }
@@ -604,7 +578,7 @@ class CompactHashSet<E> extends AbstractSet<E> implements Serializable {
     if (elementCount < 0) {
       throw new InvalidObjectException("Invalid size: " + elementCount);
     }
-    init(elementCount, DEFAULT_LOAD_FACTOR);
+    init(elementCount);
     for (int i = 0; i < elementCount; i++) {
       E element = (E) stream.readObject();
       add(element);

--- a/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.common.collect;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+package com.google.common.collect;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
@@ -25,8 +24,6 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -60,7 +57,7 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
 
   /**
    * Creates a {@code CompactLinkedHashMap} instance, with a high enough "initial capacity" that it
-   * <i>should</i> hold {@code expectedSize} elements without growth.
+   * <i>should</i> hold {@code expectedSize} elements without rebuilding internal data structures.
    *
    * @param expectedSize the number of elements you expect to add to the returned set
    * @return a new, empty {@code CompactLinkedHashMap} with enough capacity to hold {@code
@@ -97,26 +94,26 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
   }
 
   CompactLinkedHashMap(int expectedSize) {
-    this(expectedSize, DEFAULT_LOAD_FACTOR, false);
+    this(expectedSize, false);
   }
 
-  CompactLinkedHashMap(int expectedSize, float loadFactor, boolean accessOrder) {
-    super(expectedSize, loadFactor);
+  CompactLinkedHashMap(int expectedSize, boolean accessOrder) {
+    super(expectedSize);
     this.accessOrder = accessOrder;
   }
 
   @Override
-  void init(int expectedSize, float loadFactor) {
-    super.init(expectedSize, loadFactor);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
+  void init(int expectedSize) {
+    super.init(expectedSize);
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
   }
 
   @Override
   void allocArrays() {
     super.allocArrays();
     int expectedSize = keys.length; // allocated size may be different than initial capacity
-    links = new long[expectedSize];
+    this.links = new long[expectedSize];
     Arrays.fill(links, UNSET);
   }
 
@@ -145,6 +142,7 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     } else {
       setSuccessor(pred, succ);
     }
+
     if (succ == ENDPOINT) {
       lastEntry = pred;
     } else {
@@ -174,13 +172,14 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
   @Override
   void moveLastEntry(int dstIndex) {
     int srcIndex = size() - 1;
+    super.moveLastEntry(dstIndex);
+
     setSucceeds(getPredecessor(dstIndex), getSuccessor(dstIndex));
     if (dstIndex < srcIndex) {
       setSucceeds(getPredecessor(srcIndex), dstIndex);
       setSucceeds(dstIndex, getSuccessor(srcIndex));
     }
     links[srcIndex] = UNSET;
-    super.moveLastEntry(dstIndex);
   }
 
   @Override
@@ -201,14 +200,6 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
   @Override
   int adjustAfterRemove(int indexBeforeRemove, int indexRemoved) {
     return (indexBeforeRemove >= size()) ? indexRemoved : indexBeforeRemove;
-  }
-
-  @Override
-  public void forEach(BiConsumer<? super K, ? super V> action) {
-    checkNotNull(action);
-    for (int i = firstEntry; i != ENDPOINT; i = getSuccessor(i)) {
-      action.accept((K) keys[i], (V) values[i]);
-    }
   }
 
   @Override
@@ -241,14 +232,6 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
       public Spliterator<K> spliterator() {
         return Spliterators.spliterator(this, Spliterator.ORDERED | Spliterator.DISTINCT);
       }
-
-      @Override
-      public void forEach(Consumer<? super K> action) {
-        checkNotNull(action);
-        for (int i = firstEntry; i != ENDPOINT; i = getSuccessor(i)) {
-          action.accept((K) keys[i]);
-        }
-      }
     }
     return new KeySetImpl();
   }
@@ -270,14 +253,6 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
       @Override
       public Spliterator<V> spliterator() {
         return Spliterators.spliterator(this, Spliterator.ORDERED);
-      }
-
-      @Override
-      public void forEach(Consumer<? super V> action) {
-        checkNotNull(action);
-        for (int i = firstEntry; i != ENDPOINT; i = getSuccessor(i)) {
-          action.accept((V) values[i]);
-        }
       }
     }
     return new ValuesImpl();

--- a/guava/src/com/google/common/collect/CompactLinkedHashSet.java
+++ b/guava/src/com/google/common/collect/CompactLinkedHashSet.java
@@ -16,15 +16,12 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.GwtIncompatible;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -53,7 +50,7 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
 
   /** Creates an empty {@code CompactLinkedHashSet} instance. */
   public static <E> CompactLinkedHashSet<E> create() {
-    return new CompactLinkedHashSet<E>();
+    return new CompactLinkedHashSet<>();
   }
 
   /**
@@ -92,7 +89,7 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
    * @throws IllegalArgumentException if {@code expectedSize} is negative
    */
   public static <E> CompactLinkedHashSet<E> createWithExpectedSize(int expectedSize) {
-    return new CompactLinkedHashSet<E>(expectedSize);
+    return new CompactLinkedHashSet<>(expectedSize);
   }
 
   private static final int ENDPOINT = -2;
@@ -113,7 +110,10 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
    */
   private transient int @MonotonicNonNull [] successor;
 
+  /** Pointer to the first node in the linked list, or {@code ENDPOINT} if there are no entries. */
   private transient int firstEntry;
+
+  /** Pointer to the last node in the linked list, or {@code ENDPOINT} if there are no entries. */
   private transient int lastEntry;
 
   CompactLinkedHashSet() {
@@ -125,10 +125,10 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   }
 
   @Override
-  void init(int expectedSize, float loadFactor) {
-    super.init(expectedSize, loadFactor);
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
+  void init(int expectedSize) {
+    super.init(expectedSize);
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
   }
 
   @Override
@@ -137,56 +137,60 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
     int expectedSize = elements.length; // allocated size may be different than initial capacity
     this.predecessor = new int[expectedSize];
     this.successor = new int[expectedSize];
-
     Arrays.fill(predecessor, UNSET);
     Arrays.fill(successor, UNSET);
   }
 
-  private void succeeds(int pred, int succ) {
+  private int getPredecessor(int entry) {
+    return predecessor[entry];
+  }
+
+  @Override
+  int getSuccessor(int entry) {
+    return successor[entry];
+  }
+
+  private void setSuccessor(int entry, int succ) {
+    successor[entry] = succ;
+  }
+
+  private void setPredecessor(int entry, int pred) {
+    predecessor[entry] = pred;
+  }
+
+  private void setSucceeds(int pred, int succ) {
     if (pred == ENDPOINT) {
       firstEntry = succ;
     } else {
-      successor[pred] = succ;
+      setSuccessor(pred, succ);
     }
 
     if (succ == ENDPOINT) {
       lastEntry = pred;
     } else {
-      predecessor[succ] = pred;
+      setPredecessor(succ, pred);
     }
   }
 
   @Override
   void insertEntry(int entryIndex, E object, int hash) {
     super.insertEntry(entryIndex, object, hash);
-    succeeds(lastEntry, entryIndex);
-    succeeds(entryIndex, ENDPOINT);
+    setSucceeds(lastEntry, entryIndex);
+    setSucceeds(entryIndex, ENDPOINT);
   }
 
   @Override
-  void moveEntry(int dstIndex) {
+  void moveLastEntry(int dstIndex) {
     int srcIndex = size() - 1;
-    super.moveEntry(dstIndex);
+    super.moveLastEntry(dstIndex);
 
-    succeeds(predecessor[dstIndex], successor[dstIndex]);
-    if (srcIndex != dstIndex) {
-      succeeds(predecessor[srcIndex], dstIndex);
-      succeeds(dstIndex, successor[srcIndex]);
+    setSucceeds(getPredecessor(dstIndex), getSuccessor(dstIndex));
+    if (dstIndex < srcIndex) {
+      setSucceeds(getPredecessor(srcIndex), dstIndex);
+      setSucceeds(dstIndex, getSuccessor(srcIndex));
     }
     predecessor[srcIndex] = UNSET;
     successor[srcIndex] = UNSET;
-  }
-
-  @Override
-  public void clear() {
-    if (needsAllocArrays()) {
-      return;
-    }
-    firstEntry = ENDPOINT;
-    lastEntry = ENDPOINT;
-    Arrays.fill(predecessor, 0, size(), UNSET);
-    Arrays.fill(successor, 0, size(), UNSET);
-    super.clear();
   }
 
   @Override
@@ -195,11 +199,20 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
     int oldCapacity = predecessor.length;
     predecessor = Arrays.copyOf(predecessor, newCapacity);
     successor = Arrays.copyOf(successor, newCapacity);
-
     if (oldCapacity < newCapacity) {
       Arrays.fill(predecessor, oldCapacity, newCapacity, UNSET);
       Arrays.fill(successor, oldCapacity, newCapacity, UNSET);
     }
+  }
+
+  @Override
+  int firstEntryIndex() {
+    return firstEntry;
+  }
+
+  @Override
+  int adjustAfterRemove(int indexBeforeRemove, int indexRemoved) {
+    return (indexBeforeRemove >= size()) ? indexRemoved : indexBeforeRemove;
   }
 
   @Override
@@ -213,30 +226,19 @@ class CompactLinkedHashSet<E> extends CompactHashSet<E> {
   }
 
   @Override
-  int firstEntryIndex() {
-    return firstEntry;
-  }
-
-  @Override
-  int adjustAfterRemove(int indexBeforeRemove, int indexRemoved) {
-    return (indexBeforeRemove == size()) ? indexRemoved : indexBeforeRemove;
-  }
-
-  @Override
-  int getSuccessor(int entryIndex) {
-    return successor[entryIndex];
-  }
-
-  @Override
   public Spliterator<E> spliterator() {
     return Spliterators.spliterator(this, Spliterator.ORDERED | Spliterator.DISTINCT);
   }
 
   @Override
-  public void forEach(Consumer<? super E> action) {
-    checkNotNull(action);
-    for (int i = firstEntry; i != ENDPOINT; i = successor[i]) {
-      action.accept((E) elements[i]);
+  public void clear() {
+    if (needsAllocArrays()) {
+      return;
     }
+    this.firstEntry = ENDPOINT;
+    this.lastEntry = ENDPOINT;
+    Arrays.fill(predecessor, 0, size(), UNSET);
+    Arrays.fill(successor, 0, size(), UNSET);
+    super.clear();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove unused configuration of load factor

This allows removal of loadFactor/threshold which saves 8 bytes per object.

While here:
- Reduce diff between Map/Set classes
- Make base forEach() work for Linked classes

Shallow object size (bytes):
- CompactHashMap: 64 -> 56
- CompactLinkedHashMap: 80 -> 72
- CompactHashSet: 40 -> 32
- CompactLinkedHashSet: 56 -> 48

062afc318cc7f60f6d681d6a3fa6cdc4f437a2d7