### PR TITLE
Rejuvenate logging statement levels

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
@@ -173,12 +173,12 @@ public abstract class FeatureSpecificTestSuiteBuilder<
   public TestSuite createTestSuite() {
     checkCanCreate();
 
-    logger.fine(" Testing: " + name);
-    logger.fine("Features: " + formatFeatureSet(features));
+    logger.finest(" Testing: " + name);
+    logger.finest("Features: " + formatFeatureSet(features));
 
     FeatureUtil.addImpliedFeatures(features);
 
-    logger.fine("Expanded: " + formatFeatureSet(features));
+    logger.finest("Expanded: " + formatFeatureSet(features));
 
     // Class parameters must be raw.
     List<Class<? extends AbstractTester>> testers = getTesters();
@@ -219,7 +219,7 @@ public abstract class FeatureSpecificTestSuiteBuilder<
       return true;
     }
     if (suppressedTests.contains(method)) {
-      logger.finer(Platform.format("%s: excluding because it was explicitly suppressed.", test));
+      logger.finest(Platform.format("%s: excluding because it was explicitly suppressed.", test));
       return false;
     }
     final TesterRequirements requirements;

--- a/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
@@ -61,7 +61,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     Set<Feature<?>> features = Helpers.copyToSet(getFeatures());
     List<Class<? extends AbstractTester>> testers = getTesters();
 
-    logger.fine(" Testing: " + name);
+    logger.finest(" Testing: " + name);
 
     // Split out all the specified sizes.
     Set<Feature<?>> sizesToTest = Helpers.<Feature<?>>copyToSet(CollectionSize.values());
@@ -72,7 +72,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     sizesToTest.retainAll(
         Arrays.asList(CollectionSize.ZERO, CollectionSize.ONE, CollectionSize.SEVERAL));
 
-    logger.fine("   Sizes: " + formatFeatureSet(sizesToTest));
+    logger.finest("   Sizes: " + formatFeatureSet(sizesToTest));
 
     if (sizesToTest.isEmpty()) {
       throw new IllegalStateException(

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -42,6 +42,8 @@ public class TestLogHandlerTest extends TestCase {
 
     ExampleClassUnderTest.logger.setUseParentHandlers(false); // optional
 
+    ExampleClassUnderTest.logger.setLevel(Level.ALL); // log all messages.
+
     stack.addTearDown(
         new TearDown() {
           @Override

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -56,7 +56,7 @@ public class TestLogHandlerTest extends TestCase {
     assertTrue(handler.getStoredLogRecords().isEmpty());
     ExampleClassUnderTest.foo();
     LogRecord record = handler.getStoredLogRecords().get(0);
-    assertEquals(Level.INFO, record.getLevel());
+    assertEquals(Level.FINEST, record.getLevel());
     assertEquals("message", record.getMessage());
     assertSame(EXCEPTION, record.getThrown());
   }

--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -93,7 +93,7 @@ public class TestLogHandlerTest extends TestCase {
     static final Logger logger = Logger.getLogger(ExampleClassUnderTest.class.getName());
 
     static void foo() {
-      logger.log(Level.INFO, "message", EXCEPTION);
+      logger.log(Level.FINEST, "message", EXCEPTION);
     }
   }
 }

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -679,7 +679,7 @@ public final class ServiceManager {
           // N.B. if we miss the STARTING event then we may never record a startup time.
           stopwatch.stop();
           if (!(service instanceof NoOpService)) {
-            logger.log(Level.FINE, "Started {0} in {1}.", new Object[] {service, stopwatch});
+            logger.log(Level.FINEST, "Started {0} in {1}.", new Object[] {service, stopwatch});
           }
         }
         // Queue our listeners
@@ -771,7 +771,7 @@ public final class ServiceManager {
       if (state != null) {
         state.transitionService(service, NEW, STARTING);
         if (!(service instanceof NoOpService)) {
-          logger.log(Level.FINE, "Starting {0}.", service);
+          logger.log(Level.FINEST, "Starting {0}.", service);
         }
       }
     }
@@ -798,7 +798,7 @@ public final class ServiceManager {
       if (state != null) {
         if (!(service instanceof NoOpService)) {
           logger.log(
-              Level.FINE,
+              Level.FINEST,
               "Service {0} has terminated. Previous state was: {1}",
               new Object[] {service, from});
         }


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | type FQN | enclosing method | DOI value
-- | -- | -- | -- | -- | --
logger.log(Level.FINE,"Service   {0} has terminated. Previous state was: {1}",new Object[]{service,from}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | terminated(com.google.common.util.concurrent.Service.State) | 0
logger.log(Level.FINE,"Starting   {0}.",service) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceListener | starting() | 0
logger.log(Level.FINE,"Started {0}   in {1}.",new Object[]{service,stopwatch}) | FINE | FINEST | com.google.common.util.concurrent.ServiceManager$ServiceManagerState | transitionService(com.google.common.util.concurrent.Service,com.google.common.util.concurrent.Service.State,com.google.common.util.concurrent.Service.State) | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Expanded: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.log(Level.INFO,"message",EXCEPTION) | INFO | FINEST | com.google.common.testing.TestLogHandlerTest$ExampleClassUnderTest | foo() | 0
logger.fine(" Testing: " +   name) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.fine("   Sizes: " +   formatFeatureSet(sizesToTest)) | FINE | FINEST | com.google.common.collect.testing.PerCollectionSizeTestSuiteBuilder | createTestSuite() | 0
logger.fine("Features: " +   formatFeatureSet(features)) | FINE | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | createTestSuite() | 0
logger.finer(Platform.format("%s:   excluding because it was explicitly suppressed.",test)) | FINER | FINEST | com.google.common.collect.testing.FeatureSpecificTestSuiteBuilder | matches(junit.framework.Test) | 0



##  Manual Change 
This pull request contains one manual change where we changed (please see below) adjusted a test case to reflect our change. This is not part of the output of our tool but simply a necessary change to make the test pass.

```diff
diff --git a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
index 678f1ea4b..9ca57fab7 100644
--- a/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
+++ b/guava-testlib/test/com/google/common/testing/TestLogHandlerTest.java
@@ -56,7 +56,7 @@ public class TestLogHandlerTest extends TestCase {
     assertTrue(handler.getStoredLogRecords().isEmpty());
     ExampleClassUnderTest.foo();
     LogRecord record = handler.getStoredLogRecords().get(0);
-    assertEquals(Level.INFO, record.getLevel());
+    assertEquals(Level.FINEST, record.getLevel());
     assertEquals("message", record.getMessage());
     assertSame(EXCEPTION, record.getThrown());
   }
```

## Bug Fix

We found a bug in the same test case where only log messages having level `INFO` or above are tested. Now, all levels are tested. This was also a manual fix.

## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).
- The number of commits evaluated: 1000 (setting 3).

Head: 74fc49f

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
guava | [0.0, 0.8812485) | FINEST
guava | [0.8812485, 1.762497) | FINER
guava | [1.762497, 2.6437454) | FINE
guava | [2.6437454, 3.524994) | INFO
guava-gwt | [0.0, 0.30324998) | FINEST
guava-gwt | [0.30324998, 0.60649997) | FINER
guava-gwt | [0.60649997, 0.90975) | FINE
guava-gwt | [0.90975, 1.2129999) | INFO
guava-testlib | [0.0, 2.8239996) | FINEST
guava-testlib | [2.8239996, 5.6479993) | FINER
guava-testlib | [5.6479993, 8.471999) | FINE
guava-testlib | [8.471999, 11.295999) | INFO
guava-tests | [0.0, 1.4872494) | FINEST
guava-tests | [1.4872494, 2.9744987) | FINER
guava-tests | [2.9744987, 4.461748) | FINE
guava-tests | [4.461748, 5.9489975) | INFO

## Notes

This supersedes https://github.com/google/guava/pull/3413 to workaround CLA bot issue. 