### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -492,4 +492,39 @@ public final class HttpHeaders {
    * @since 25.1
    */
   public static final String SEC_REFERRED_TOKEN_BINDING_ID = "Sec-Referred-Token-Binding-ID";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Accept}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_ACCEPT = "Sec-Websocket-Accept";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Extensions}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_EXTENSIONS = "Sec-Websocket-Extensions";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Key}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_KEY = "Sec-Websocket-Key";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Protocol}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_PROTOCOL = "Sec-Websocket-Protocol";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Versions}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_VERSIONS = "Sec-Websocket-Versions";
 }

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -492,4 +492,39 @@ public final class HttpHeaders {
    * @since 25.1
    */
   public static final String SEC_REFERRED_TOKEN_BINDING_ID = "Sec-Referred-Token-Binding-ID";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Accept}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_ACCEPT = "Sec-Websocket-Accept";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Extensions}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_EXTENSIONS = "Sec-Websocket-Extensions";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Key}</a> header
+   * field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_KEY = "Sec-Websocket-Key";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Protocol}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_PROTOCOL = "Sec-Websocket-Protocol";
+  /**
+   * The HTTP <a href="https://tools.ietf.org/html/rfc6455">{@code Sec-WebSocket-Versions}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_WEBSOCKET_VERSIONS = "Sec-Websocket-Versions";
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add websocket headers to HTTP header listings.

This adds five headers, as defined in RFC 6455: Sec-WebSocket-Accept,
Sec-WebSocket-Extensions, Sec-WebSocket-Key, Sec-WebSocket-Protocol, and
Sec-WebSocket-Versions.

This also changes the C++ per-header unit test so that it can recognize the
alternate capitalization of WebSocket, instead of adding five special cases. The
Go and Java versions use the "Websocket" capitalization instead.

78fe31027ec67c0648667582e40d49351757cfe9