### PR TITLE
Add java.util.UUID to ArbitraryInstances

### DIFF
--- a/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -127,6 +127,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.UUID;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -214,6 +215,7 @@ public final class ArbitraryInstances {
           .put(OptionalInt.class, OptionalInt.empty())
           .put(OptionalLong.class, OptionalLong.empty())
           .put(OptionalDouble.class, OptionalDouble.empty())
+          .put(UUID.class, UUID.randomUUID())
           // common.base
           .put(CharMatcher.class, CharMatcher.none())
           .put(Joiner.class, Joiner.on(','))

--- a/guava-testlib/test/com/google/common/testing/ArbitraryInstancesTest.java
+++ b/guava-testlib/test/com/google/common/testing/ArbitraryInstancesTest.java
@@ -113,6 +113,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -171,6 +172,7 @@ public class ArbitraryInstancesTest extends TestCase {
     assertEquals(OptionalInt.empty(), ArbitraryInstances.get(OptionalInt.class));
     assertEquals(OptionalLong.empty(), ArbitraryInstances.get(OptionalLong.class));
     assertEquals(OptionalDouble.empty(), ArbitraryInstances.get(OptionalDouble.class));
+    assertNotNull(ArbitraryInstances.get(UUID.class));
   }
 
   public void testGet_collections() {


### PR DESCRIPTION
I hope this counts as a trivial change. This adds `java.util.UUID` to `ArbitratyInstances` - I have recently been working on a project where we used `UUID` and `NullPointerTester` and we've often had to set a default manually, this should avoid that.