### PR TITLE
Upgrade maven dependency plugin - security upgrade

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -174,7 +174,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Maven dependency plugin has a dependency on plexus-archiver.
Plexus-archiver is vulnerable to the Zip Slip vulnerability in versions prior to 3.4.1 & 3.6.0 ([reference](https://maven.apache.org/security-plexus-archiver.html)).
Maven-dependency-plugin version [3.1.1](https://blogs.apache.org/maven/entry/apache-maven-dependency-plugin-version1) upgrades to plexus-archiver [3.6.0](https://github.com/codehaus-plexus/plexus-archiver/blob/master/ReleaseNotes.md#plexus-archiver-360)
Versions bypassed:
- [3.0.0](https://blog.soebes.de/blog/2016/12/16/apache-maven-dependency-plugin-version-3-dot-0-0-released/)
- [3.0.1](https://blog.soebes.de/blog/2017/05/16/apache-maven-dependency-plugin-version-3-dot-0-1-released/)
- [3.0.2](https://blog.soebes.de/blog/2017/09/19/apache-maven-dependency-plugin-version-3-dot-0-2-released/)
- [3.1.0](https://blogs.apache.org/maven/entry/apache-maven-dependency-plugin-version)
