### PR TITLE
ArrayTable - Implement eraseRow and eraseColumn

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ArrayTableTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ArrayTableTest.java
@@ -452,6 +452,54 @@ public class ArrayTableTest extends AbstractTableTest {
     assertNull(table.erase("bar", null));
   }
 
+  public void testEraseRow() {
+    ArrayTable<String, Integer, Character> table =
+            create("foo", 1, 'a', "foo", 2, 'b', "foo", 3, 'c', "bar", 1, 'd', "bar", 2, 'e', "bar", 3, 'f');
+    assertEquals((Character) 'a', table.get("foo", 1));
+    assertEquals((Character) 'b', table.get("foo", 2));
+    assertEquals((Character) 'c', table.get("foo", 3));
+    table.eraseRow("foo");
+    assertNull(table.get("foo", 1));
+    assertNull(table.get("foo", 2));
+    assertNull(table.get("foo", 3));
+    assertTrue(table.containsRow("foo"));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'd', table.get("bar", 1));
+    assertEquals((Character) 'e', table.get("bar", 2));
+    assertEquals((Character) 'f', table.get("bar", 3));
+    table.eraseRow("bar");
+    assertNull(table.get("bar", 1));
+    assertNull(table.get("bar", 2));
+    assertNull(table.get("bar", 3));
+    assertEquals(9, table.size());
+  }
+
+  public void testEraseColumn() {
+    ArrayTable<String, Integer, Character> table =
+            create("foo", 1, 'a', "foo", 2, 'b', "foo", 3, 'c', "bar", 1, 'd', "bar", 2, 'e', "bar", 3, 'f');
+    assertEquals((Character) 'a', table.get("foo", 1));
+    assertEquals((Character) 'd', table.get("bar", 1));
+    table.eraseColumn(1);
+    assertNull(table.get("foo", 1));
+    assertNull(table.get("bar", 1));
+    assertTrue(table.containsColumn(1));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'b', table.get("foo", 2));
+    assertEquals((Character) 'e', table.get("bar", 2));
+    table.eraseColumn(2);
+    assertNull(table.get("foo", 2));
+    assertNull(table.get("bar", 2));
+    assertTrue(table.containsColumn(2));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'c', table.get("foo", 3));
+    assertEquals((Character) 'f', table.get("bar", 3));
+    table.eraseColumn(3);
+    assertNull(table.get("foo", 3));
+    assertNull(table.get("bar", 3));
+    assertTrue(table.containsColumn(3));
+    assertEquals(9, table.size());
+  }
+
   @GwtIncompatible // ArrayTable.toArray(Class)
   public void testToArray() {
     ArrayTable<String, Integer, Character> table =

--- a/android/guava/src/com/google/common/collect/ArrayTable.java
+++ b/android/guava/src/com/google/common/collect/ArrayTable.java
@@ -120,8 +120,8 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
    */
   public static <R, C, V> ArrayTable<R, C, V> create(Table<R, C, V> table) {
     return (table instanceof ArrayTable<?, ?, ?>)
-        ? new ArrayTable<R, C, V>((ArrayTable<R, C, V>) table)
-        : new ArrayTable<R, C, V>(table);
+        ? new ArrayTable<>((ArrayTable<R, C, V>) table)
+        : new ArrayTable<>(table);
   }
 
   private final ImmutableList<R> rowList;
@@ -141,7 +141,7 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
      * TODO(jlevy): Support only one of rowKey / columnKey being empty? If we
      * do, when columnKeys is empty but rowKeys isn't, rowKeyList() can contain
      * elements but rowKeySet() will be empty and containsRow() won't
-     * acknolwedge them.
+     * acknowledge them.
      */
     rowKeyToIndex = Maps.indexMap(rowList);
     columnKeyToIndex = Maps.indexMap(columnList);
@@ -497,7 +497,39 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
     return set(rowIndex, columnIndex, null);
   }
 
-  // TODO(jlevy): Add eraseRow and eraseColumn methods?
+  /**
+   * Associates the value {@code null} with the entire row for the specified key, assuming key is valid. If
+   * key is null or isn't among the keys provided during construction, this method has no effect.
+   *
+   * @param rowKey row key of row to be erased
+   * @since NEXT
+   */
+  public void eraseRow(@NullableDecl Object rowKey) {
+    Integer rowIndex = rowKeyToIndex.get(rowKey);
+    if (rowIndex == null) {
+      return;
+    }
+    checkElementIndex(rowIndex, rowList.size());
+    Arrays.fill(array[rowIndex], null);
+  }
+
+  /**
+   * Associates the value {@code null} with the entire column for the specified key, assuming key is valid. If
+   * key is null or isn't among the keys provided during construction, this method has no effect.
+   *
+   * @param columnKey column key of column to be erased
+   * @since NEXT
+   */
+  public void eraseColumn(@NullableDecl Object columnKey) {
+    Integer columnIndex = columnKeyToIndex.get(columnKey);
+    if (columnIndex == null) {
+      return;
+    }
+    checkElementIndex(columnIndex, columnList.size());
+    for (int i = 0; i < rowList.size(); i++) {
+      set(i, columnIndex, null);
+    }
+  }
 
   @Override
   public int size() {

--- a/guava-gwt/test/com/google/common/collect/ArrayTableTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/ArrayTableTest_gwt.java
@@ -180,6 +180,18 @@ public void testEraseAll() throws Exception {
   testCase.testEraseAll();
 }
 
+public void testEraseRow() throws Exception {
+    com.google.common.collect.ArrayTableTest testCase = new com.google.common.collect.ArrayTableTest();
+    testCase.setUp();
+    testCase.testEraseRow();
+  }
+
+public void testEraseColumn() throws Exception {
+    com.google.common.collect.ArrayTableTest testCase = new com.google.common.collect.ArrayTableTest();
+    testCase.setUp();
+    testCase.testEraseColumn();
+  }
+
 public void testGet() throws Exception {
   com.google.common.collect.ArrayTableTest testCase = new com.google.common.collect.ArrayTableTest();
   testCase.setUp();

--- a/guava-tests/test/com/google/common/collect/ArrayTableTest.java
+++ b/guava-tests/test/com/google/common/collect/ArrayTableTest.java
@@ -217,7 +217,7 @@ public class ArrayTableTest extends AbstractTableTest {
 
   public void testCreateEmptyRowsXColumns() {
     ArrayTable<String, String, Character> table =
-        ArrayTable.create(Arrays.<String>asList(), Arrays.<String>asList());
+        ArrayTable.create(Arrays.asList(), Arrays.asList());
     assertThat(table).isEmpty();
     assertThat(table).hasSize(0);
     assertThat(table.columnKeyList()).isEmpty();
@@ -234,7 +234,7 @@ public class ArrayTableTest extends AbstractTableTest {
   @GwtIncompatible // toArray
   public void testEmptyToArry() {
     ArrayTable<String, String, Character> table =
-        ArrayTable.create(Arrays.<String>asList(), Arrays.<String>asList());
+        ArrayTable.create(Arrays.asList(), Arrays.asList());
     assertThat(table.toArray(Character.class)).asList().isEmpty();
   }
 
@@ -279,7 +279,7 @@ public class ArrayTableTest extends AbstractTableTest {
 
   public void testCreateCopyEmptyArrayTable() {
     Table<String, Integer, Character> original =
-        ArrayTable.create(Arrays.<String>asList(), Arrays.<Integer>asList());
+        ArrayTable.create(Arrays.asList(), Arrays.asList());
     ArrayTable<String, Integer, Character> copy = ArrayTable.create(original);
     assertThat(copy).isEqualTo(original);
     assertThat(copy).isEmpty();
@@ -450,6 +450,54 @@ public class ArrayTableTest extends AbstractTableTest {
     assertNull(table.erase("bar", 5));
     assertNull(table.erase(null, 1));
     assertNull(table.erase("bar", null));
+  }
+
+  public void testEraseRow() {
+    ArrayTable<String, Integer, Character> table =
+            create("foo", 1, 'a', "foo", 2, 'b', "foo", 3, 'c', "bar", 1, 'd', "bar", 2, 'e', "bar", 3, 'f');
+    assertEquals((Character) 'a', table.get("foo", 1));
+    assertEquals((Character) 'b', table.get("foo", 2));
+    assertEquals((Character) 'c', table.get("foo", 3));
+    table.eraseRow("foo");
+    assertNull(table.get("foo", 1));
+    assertNull(table.get("foo", 2));
+    assertNull(table.get("foo", 3));
+    assertTrue(table.containsRow("foo"));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'd', table.get("bar", 1));
+    assertEquals((Character) 'e', table.get("bar", 2));
+    assertEquals((Character) 'f', table.get("bar", 3));
+    table.eraseRow("bar");
+    assertNull(table.get("bar", 1));
+    assertNull(table.get("bar", 2));
+    assertNull(table.get("bar", 3));
+    assertEquals(9, table.size());
+  }
+
+  public void testEraseColumn() {
+      ArrayTable<String, Integer, Character> table =
+              create("foo", 1, 'a', "foo", 2, 'b', "foo", 3, 'c', "bar", 1, 'd', "bar", 2, 'e', "bar", 3, 'f');
+    assertEquals((Character) 'a', table.get("foo", 1));
+    assertEquals((Character) 'd', table.get("bar", 1));
+    table.eraseColumn(1);
+    assertNull(table.get("foo", 1));
+    assertNull(table.get("bar", 1));
+    assertTrue(table.containsColumn(1));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'b', table.get("foo", 2));
+    assertEquals((Character) 'e', table.get("bar", 2));
+    table.eraseColumn(2);
+    assertNull(table.get("foo", 2));
+    assertNull(table.get("bar", 2));
+    assertTrue(table.containsColumn(2));
+    assertEquals(9, table.size());
+    assertEquals((Character) 'c', table.get("foo", 3));
+    assertEquals((Character) 'f', table.get("bar", 3));
+    table.eraseColumn(3);
+    assertNull(table.get("foo", 3));
+    assertNull(table.get("bar", 3));
+    assertTrue(table.containsColumn(3));
+    assertEquals(9, table.size());
   }
 
   @GwtIncompatible // ArrayTable.toArray(Class)

--- a/guava/src/com/google/common/collect/ArrayTable.java
+++ b/guava/src/com/google/common/collect/ArrayTable.java
@@ -121,8 +121,8 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
    */
   public static <R, C, V> ArrayTable<R, C, V> create(Table<R, C, V> table) {
     return (table instanceof ArrayTable<?, ?, ?>)
-        ? new ArrayTable<R, C, V>((ArrayTable<R, C, V>) table)
-        : new ArrayTable<R, C, V>(table);
+        ? new ArrayTable<>((ArrayTable<R, C, V>) table)
+        : new ArrayTable<>(table);
   }
 
   private final ImmutableList<R> rowList;
@@ -142,7 +142,7 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
      * TODO(jlevy): Support only one of rowKey / columnKey being empty? If we
      * do, when columnKeys is empty but rowKeys isn't, rowKeyList() can contain
      * elements but rowKeySet() will be empty and containsRow() won't
-     * acknolwedge them.
+     * acknowledge them.
      */
     rowKeyToIndex = Maps.indexMap(rowList);
     columnKeyToIndex = Maps.indexMap(columnList);
@@ -501,7 +501,39 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
     return set(rowIndex, columnIndex, null);
   }
 
-  // TODO(jlevy): Add eraseRow and eraseColumn methods?
+  /**
+   * Associates the value {@code null} with the entire row for the specified key, assuming key is valid. If
+   * key is null or isn't among the keys provided during construction, this method has no effect.
+   *
+   * @param rowKey row key of row to be erased
+   * @since NEXT
+   */
+  public void eraseRow(@Nullable Object rowKey) {
+    Integer rowIndex = rowKeyToIndex.get(rowKey);
+    if (rowIndex == null) {
+      return;
+    }
+    checkElementIndex(rowIndex, rowList.size());
+    Arrays.fill(array[rowIndex], null);
+  }
+
+  /**
+   * Associates the value {@code null} with the entire column for the specified key, assuming key is valid. If
+   * key is null or isn't among the keys provided during construction, this method has no effect.
+   *
+   * @param columnKey column key of column to be erased
+   * @since NEXT
+   */
+  public void eraseColumn(@Nullable Object columnKey) {
+    Integer columnIndex = columnKeyToIndex.get(columnKey);
+    if (columnIndex == null) {
+      return;
+    }
+    checkElementIndex(columnIndex, columnList.size());
+    for (int i = 0; i < rowList.size(); i++) {
+      set(i, columnIndex, null);
+    }
+  }
 
   @Override
   public int size() {
@@ -583,7 +615,7 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
   public Map<R, V> column(C columnKey) {
     checkNotNull(columnKey);
     Integer columnIndex = columnKeyToIndex.get(columnKey);
-    return (columnIndex == null) ? ImmutableMap.<R, V>of() : new Column(columnIndex);
+    return (columnIndex == null) ? ImmutableMap.of() : new Column(columnIndex);
   }
 
   private class Column extends ArrayMap<R, V> {
@@ -671,7 +703,7 @@ public final class ArrayTable<R, C, V> extends AbstractTable<R, C, V> implements
   public Map<C, V> row(R rowKey) {
     checkNotNull(rowKey);
     Integer rowIndex = rowKeyToIndex.get(rowKey);
-    return (rowIndex == null) ? ImmutableMap.<C, V>of() : new Row(rowIndex);
+    return (rowIndex == null) ? ImmutableMap.of() : new Row(rowIndex);
   }
 
   private class Row extends ArrayMap<C, V> {


### PR DESCRIPTION
Work completed fulfills a //TODO left in the ArrayTable class:
`// TODO(jlevy): Add eraseRow and eraseColumn methods?`

- Added new eraseRow and eraseColumn functions to the ArrayTable class. 
- Added test cases for the two new functions.
- Minor code clean up and a spelling fix in the ArrayTable and ArrayTableTest classes.