### PR TITLE
change keyToKeyList from HashMap to LinkedHashMap

### DIFF
--- a/guava/src/com/google/common/collect/LinkedListMultimap.java
+++ b/guava/src/com/google/common/collect/LinkedListMultimap.java
@@ -195,7 +195,7 @@ public class LinkedListMultimap<K, V> extends AbstractMultimap<K, V>
   }
 
   private LinkedListMultimap(int expectedKeys) {
-    keyToKeyList = Platform.newHashMapWithExpectedSize(expectedKeys);
+    keyToKeyList = Platform.newLinkedHashMapWithExpectedSize(expectedKeys);
   }
 
   private LinkedListMultimap(Multimap<? extends K, ? extends V> multimap) {


### PR DESCRIPTION
in  constructor method ,keyToKeyList was set as HashMap ,keyToKeyList should keep insertion-order   .
like in readObject()  method do : keyToKeyList = Maps.newLinkedHashMap();