### PR TITLE
Upgrade Maven Javadoc Plugin to 3.1.0

### DIFF
--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal,com.google.thirdparty.publicsuffix,com.oracle,com.sun,java,javax,jdk,org,sun</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal.*,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk.*,org.*,sun.*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal:*,com.google.thirdparty.publicsuffix:*,com.oracle:*,com.sun:*,java:*,javax:*,jdk.:,org:*,sun:*</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal:com.google.common.base.internal.*,com.google.thirdparty.publicsuffix,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk,jdk.*,org.*,sun.*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal.*,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk.*,org.*,sun.*</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal:*,com.google.thirdparty.publicsuffix:*,com.oracle:*,com.sun:*,java:*,javax:*,jdk.:,org:*,sun:*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -15,7 +15,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal,com.google.thirdparty.publicsuffix,com.oracle,com.sun,java,javax,jdk,org,sun</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal.*,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk.*,org.*,sun.*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal:*,com.google.thirdparty.publicsuffix:*,com.oracle:*,com.sun:*,java:*,javax:*,jdk.:,org:*,sun:*</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal:com.google.common.base.internal.*,com.google.thirdparty.publicsuffix,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk,jdk.*,org.*,sun.*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -128,7 +128,7 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal.*,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk.*,org.*,sun.*</excludePackageNames>
+          <excludePackageNames>com.google.common.base.internal:*,com.google.thirdparty.publicsuffix:*,com.oracle:*,com.sun:*,java:*,javax:*,jdk.:,org:*,sun:*</excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>


### PR DESCRIPTION
Upgrade Maven Javadoc Plugin from 3.0.1 to [3.1.0](https://blog.soebes.de/blog/2019/03/04/apache-maven-javadoc-plugin-version-3-dot-1.0-released/)
Additionally added wildcard syntax to the list of excluded package names due to failing without it after the upgrade

Comment from @njhill in PR #3370 notes a javadoc plugin issue with JDK 11 that should be resolved in this most recent version.