### PR TITLE
RFC1123 Compliant InternetDomainName Test Cases

### DIFF
--- a/android/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
+++ b/android/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
@@ -63,6 +63,8 @@ public final class InternetDomainNameTest extends TestCase {
           "f_a",
           "foo.net.us\uFF61ocm",
           "woo.com.",
+          "8server.shop",
+          "123.cn",
           "a" + DELTA + "b.com",
           ALMOST_TOO_MANY_LEVELS,
           ALMOST_TOO_LONG);

--- a/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
+++ b/guava-tests/test/com/google/common/net/InternetDomainNameTest.java
@@ -63,6 +63,8 @@ public final class InternetDomainNameTest extends TestCase {
           "f_a",
           "foo.net.us\uFF61ocm",
           "woo.com.",
+          "8server.shop",
+          "123.cn",
           "a" + DELTA + "b.com",
           ALMOST_TOO_MANY_LEVELS,
           ALMOST_TOO_LONG);


### PR DESCRIPTION
RFC1123 compliant InternetDomainName test cases

Add tests to prove URLs with leading digits are valid and containing only digits are valid.
#1872 was resolved at some point from 2014 to now without the issue getting closed. This PR adds test cases proving this issue can be closed. 

Some sample real domains from related to these tests would be [www.9gag.com](https://www.9gag.com/) and [www.9292.nl](https://www.9292.nl/)