### PR TITLE
Replace maven prerequisites with the enforcer plugin

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -29,9 +29,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <prerequisites>
-    <maven>3.0.3</maven>
-  </prerequisites>
   <scm>
     <connection>scm:git:https://github.com/google/guava.git</connection>
     <developerConnection>scm:git:git@github.com:google/guava.git</developerConnection>
@@ -82,6 +79,28 @@
       </testResource>
     </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.0.5</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>1.7.0</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
@@ -202,6 +221,11 @@
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
             <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN</argLine>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M2</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <prerequisites>
-    <maven>3.0.3</maven>
-  </prerequisites>
   <scm>
     <connection>scm:git:https://github.com/google/guava.git</connection>
     <developerConnection>scm:git:git@github.com:google/guava.git</developerConnection>
@@ -83,6 +80,28 @@
       </testResource>
     </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.0.5</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>1.8.0</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
@@ -198,6 +217,11 @@
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
             <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN</argLine>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
As of [Maven version 3.5](https://maven.apache.org/docs/3.5.0/release-notes.html) the prerequisites tag was deprecated.

Adds minimum required maven and java version into the parent poms which gets inherited by all children. The deprecated prerequisites tag does not get inherited by children ([reference](https://maven.apache.org/enforcer/maven-enforcer-plugin/faq.html))

Additionally bump the minimum maven version requirement from 3.0.3 to [3.0.5](https://maven.apache.org/docs/3.5.0/release-notes.html) to prevent the [vulnerable](https://www.cvedetails.com/cve/CVE-2013-0253/) version 3.0.4 ever being used.

Sample error messages when invalid versions are used:
- Using Java 8 when minimum requirement of Java 11+ is defined:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) @ guava-parent ---
[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.8.0-212 is not in the allowed range 1.11.0.
```
- Using Maven 3.3.9 when minimum requirement of Maven 3.6+ is defined:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) @ guava-parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.3.9 is not in the allowed range 3.6.
```
In both cases the build with fail.

Update specific Java version can be specified, for example the following would require Java 8 update 211:
`<version>1.8.0-211</version>`