### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -3717,6 +3717,10 @@ public class FuturesTest extends TestCase {
   // Simulate a timeout that fires before the call the SES.schedule returns but the future is
   // already completed.
 
+  // This test covers a bug where an Error thrown from a callback could cause the TimeoutFuture to
+  // never complete when timing out.  Notably, nothing would get logged since the Error would get
+  // stuck in the ScheduledFuture inside of TimeoutFuture and nothing ever calls get on it.
+
   private static final Executor REJECTING_EXECUTOR =
       new Executor() {
         @Override

--- a/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -46,7 +46,6 @@ import static com.google.common.util.concurrent.TestPlatform.clearInterrupt;
 import static com.google.common.util.concurrent.TestPlatform.getDoneFromTimeoutOverload;
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
-import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -128,7 +128,11 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal,com.google.thirdparty.publicsuffix,com.oracle,com.sun,java,javax,jdk,org,sun</excludePackageNames>
+          <!-- excludePackageNames requires specification of packages separately from "all subpackages".
+               https://issues.apache.org/jira/browse/MJAVADOC-584 -->
+          <excludePackageNames>
+            com.google.common.base.internal,com.google.common.base.internal.*,com.google.thirdparty.publicsuffix,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk,jdk.*,org.*,sun.*
+          </excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/android/guava/src/com/google/common/base/Functions.java
+++ b/android/guava/src/com/google/common/base/Functions.java
@@ -122,7 +122,7 @@ public final class Functions {
    * set. See also {@link #forMap(Map)}, which throws an exception in this case.
    *
    * <p><b>Java 8 users:</b> you can just write the lambda expression {@code k ->
-   * map.getWithDefault(k, defaultValue)} instead.
+   * map.getOrDefault(k, defaultValue)} instead.
    *
    * @param map source map that determines the function behavior
    * @param defaultValue the value to return for inputs that aren't map keys

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -92,7 +92,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableGraph#Builder} with the properties of this {@link GraphBuilder}.
+   * Returns an {@link ImmutableGraph.Builder} with the properties of this {@link GraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
    *

--- a/android/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/android/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -104,7 +104,7 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableNetwork#Builder} with the properties of this {@link NetworkBuilder}.
+   * Returns an {@link ImmutableNetwork.Builder} with the properties of this {@link NetworkBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableNetwork}.
    *

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -97,7 +97,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableValueGraph#Builder} with the properties of this {@link
+   * Returns an {@link ImmutableValueGraph.Builder} with the properties of this {@link
    * ValueGraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -74,6 +74,13 @@ public final class HttpHeaders {
   /** The HTTP {@code Cookie} header field name. */
   public static final String COOKIE = "Cookie";
   /**
+   * The HTTP <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header">{@code
+   * Cross-Origin-Resource-Policy}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String CROSS_ORIGIN_RESOURCE_POLICY = "Cross-Origin-Resource-Policy";
+  /**
    * The HTTP <a href="https://tools.ietf.org/html/rfc8470">{@code Early-Data}</a> header field
    * name.
    *

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -426,6 +426,14 @@ public final class MediaType {
    */
   public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
+  /**
+   * Media type for the <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Format</a>, a
+   * geospatial data interchange format based on JSON.
+   *
+   * @since NEXT
+   */
+  public static final MediaType GEO_JSON = createConstant(APPLICATION_TYPE, "geo+json");
+
   public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /** Implementations of {@code Futures.immediate*}. */
-@GwtCompatible(emulated = true)
+@GwtCompatible
 abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
 

--- a/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -92,7 +92,6 @@ import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
 // would mean a maximum rate of "1MB/s", which might be small in some cases.
 @Beta
 @GwtIncompatible
-@SuppressWarnings("GoodTime") // lots of violations; how should we model a rate? b/119435646
 public abstract class RateLimiter {
   /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
@@ -159,6 +158,7 @@ public abstract class RateLimiter {
    * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero or {@code
    *     warmupPeriod} is negative
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static RateLimiter create(double permitsPerSecond, long warmupPeriod, TimeUnit unit) {
     checkArgument(warmupPeriod >= 0, "warmupPeriod must not be negative: %s", warmupPeriod);
     return create(
@@ -300,6 +300,7 @@ public abstract class RateLimiter {
    * @return {@code true} if the permit was acquired, {@code false} otherwise
    * @throws IllegalArgumentException if the requested number of permits is negative or zero
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean tryAcquire(long timeout, TimeUnit unit) {
     return tryAcquire(1, timeout, unit);
   }
@@ -342,6 +343,7 @@ public abstract class RateLimiter {
    * @return {@code true} if the permits were acquired, {@code false} otherwise
    * @throws IllegalArgumentException if the requested number of permits is negative or zero
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean tryAcquire(int permits, long timeout, TimeUnit unit) {
     long timeoutMicros = max(unit.toMicros(timeout), 0);
     checkPermits(permits);

--- a/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -92,7 +92,7 @@ import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
 // would mean a maximum rate of "1MB/s", which might be small in some cases.
 @Beta
 @GwtIncompatible
-@SuppressWarnings("GoodTime") // lots of violations - also how should we model a rate?
+@SuppressWarnings("GoodTime") // lots of violations; how should we model a rate? b/119435646
 public abstract class RateLimiter {
   /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -25,7 +25,7 @@
   <inceptionYear>2010</inceptionYear>
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -15,7 +15,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>
   <issueManagement>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -16,6 +16,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>

--- a/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -3717,6 +3717,10 @@ public class FuturesTest extends TestCase {
   // Simulate a timeout that fires before the call the SES.schedule returns but the future is
   // already completed.
 
+  // This test covers a bug where an Error thrown from a callback could cause the TimeoutFuture to
+  // never complete when timing out.  Notably, nothing would get logged since the Error would get
+  // stuck in the ScheduledFuture inside of TimeoutFuture and nothing ever calls get on it.
+
   private static final Executor REJECTING_EXECUTOR =
       new Executor() {
         @Override

--- a/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -46,7 +46,6 @@ import static com.google.common.util.concurrent.TestPlatform.clearInterrupt;
 import static com.google.common.util.concurrent.TestPlatform.getDoneFromTimeoutOverload;
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
-import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;

--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -601,7 +601,7 @@ public class RateLimiterTest extends TestCase {
   }
 
   private static final ImmutableSet<String> NOT_WORKING_ON_MOCKS =
-      ImmutableSet.of("latestPermitAgeSec", "setRate", "getAvailablePermits");
+      ImmutableSet.of("latestPermitAgeSec", "latestPermitAge", "setRate", "getAvailablePermits");
 
   // We would use ArbitraryInstances, but it returns 0, invalid for many RateLimiter methods.
   private static final ImmutableClassToInstanceMap<Object> PARAMETER_VALUES =

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -128,7 +128,11 @@
           <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/jdk-sources</sourcepath>
 
           <!-- Passing `-subpackages com.google.common` breaks things, so we explicitly exclude everything else instead. -->
-          <excludePackageNames>com.google.common.base.internal,com.google.thirdparty.publicsuffix,com.oracle,com.sun,java,javax,jdk,org,sun</excludePackageNames>
+          <!-- excludePackageNames requires specification of packages separately from "all subpackages".
+               https://issues.apache.org/jira/browse/MJAVADOC-584 -->
+          <excludePackageNames>
+            com.google.common.base.internal,com.google.common.base.internal.*,com.google.thirdparty.publicsuffix,com.google.thirdparty.publicsuffix.*,com.oracle.*,com.sun.*,java.*,javax.*,jdk,jdk.*,org.*,sun.*
+          </excludePackageNames>
 
           <!-- TODO(cpovirk): Move this to the parent after making the package-list files available there. -->
           <!-- We add the link ourselves, both so that we can choose Java 9 over the version that -source suggests and so that we can solve the JSR305 problem described below. -->

--- a/guava/src/com/google/common/base/Functions.java
+++ b/guava/src/com/google/common/base/Functions.java
@@ -121,7 +121,7 @@ public final class Functions {
    * set. See also {@link #forMap(Map)}, which throws an exception in this case.
    *
    * <p><b>Java 8 users:</b> you can just write the lambda expression {@code k ->
-   * map.getWithDefault(k, defaultValue)} instead.
+   * map.getOrDefault(k, defaultValue)} instead.
    *
    * @param map source map that determines the function behavior
    * @param defaultValue the value to return for inputs that aren't map keys

--- a/guava/src/com/google/common/collect/Streams.java
+++ b/guava/src/com/google/common/collect/Streams.java
@@ -218,7 +218,7 @@ public final class Streams {
   }
 
   /**
-   * Returns a stream in which each element is the result of passing the corresponding elementY of
+   * Returns a stream in which each element is the result of passing the corresponding element of
    * each of {@code streamA} and {@code streamB} to {@code function}.
    *
    * <p>For example:

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -92,7 +92,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableGraph#Builder} with the properties of this {@link GraphBuilder}.
+   * Returns an {@link ImmutableGraph.Builder} with the properties of this {@link GraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
    *

--- a/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -104,7 +104,7 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableNetwork#Builder} with the properties of this {@link NetworkBuilder}.
+   * Returns an {@link ImmutableNetwork.Builder} with the properties of this {@link NetworkBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableNetwork}.
    *

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -97,7 +97,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   }
 
   /**
-   * Returns an {@link ImmutableValueGraph#Builder} with the properties of this {@link
+   * Returns an {@link ImmutableValueGraph.Builder} with the properties of this {@link
    * ValueGraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -74,6 +74,13 @@ public final class HttpHeaders {
   /** The HTTP {@code Cookie} header field name. */
   public static final String COOKIE = "Cookie";
   /**
+   * The HTTP <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header">{@code
+   * Cross-Origin-Resource-Policy}</a> header field name.
+   *
+   * @since NEXT
+   */
+  public static final String CROSS_ORIGIN_RESOURCE_POLICY = "Cross-Origin-Resource-Policy";
+  /**
    * The HTTP <a href="https://tools.ietf.org/html/rfc8470">{@code Early-Data}</a> header field
    * name.
    *

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -426,6 +426,14 @@ public final class MediaType {
    */
   public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
+  /**
+   * Media type for the <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Format</a>, a
+   * geospatial data interchange format based on JSON.
+   *
+   * @since NEXT
+   */
+  public static final MediaType GEO_JSON = createConstant(APPLICATION_TYPE, "geo+json");
+
   public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -16,6 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import com.google.common.annotations.Beta;
@@ -24,6 +25,7 @@ import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.j2objc.annotations.WeakOuter;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -120,6 +122,20 @@ public abstract class AbstractScheduledService implements Service {
      * @param initialDelay the time to delay first execution
      * @param delay the delay between the termination of one execution and the commencement of the
      *     next
+     * @since NEXT
+     */
+    public static Scheduler newFixedDelaySchedule(Duration initialDelay, Duration delay) {
+      return newFixedDelaySchedule(
+          saturatedToNanos(initialDelay), saturatedToNanos(delay), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Returns a {@link Scheduler} that schedules the task using the {@link
+     * ScheduledExecutorService#scheduleWithFixedDelay} method.
+     *
+     * @param initialDelay the time to delay first execution
+     * @param delay the delay between the termination of one execution and the commencement of the
+     *     next
      * @param unit the time unit of the initialDelay and delay parameters
      */
     @SuppressWarnings("GoodTime") // should accept a java.time.Duration
@@ -134,6 +150,19 @@ public abstract class AbstractScheduledService implements Service {
           return executor.scheduleWithFixedDelay(task, initialDelay, delay, unit);
         }
       };
+    }
+
+    /**
+     * Returns a {@link Scheduler} that schedules the task using the {@link
+     * ScheduledExecutorService#scheduleAtFixedRate} method.
+     *
+     * @param initialDelay the time to delay first execution
+     * @param period the period between successive executions of the task
+     * @since NEXT
+     */
+    public static Scheduler newFixedRateSchedule(Duration initialDelay, Duration period) {
+      return newFixedRateSchedule(
+          saturatedToNanos(initialDelay), saturatedToNanos(period), TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Implementations of {@code Futures.immediate*}. */
-@GwtCompatible(emulated = true)
+@GwtCompatible
 abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
 

--- a/guava/src/com/google/common/util/concurrent/Internal.java
+++ b/guava/src/com/google/common/util/concurrent/Internal.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.time.Duration;
+
+/** This class is for {@code com.google.common.util.concurrent} use only! */
+@GwtIncompatible // java.time.Duration
+final class Internal {
+
+  /**
+   * Returns the number of nanoseconds of the given duration without throwing or overflowing.
+   *
+   * <p>Instead of throwing {@link ArithmeticException}, this method silently saturates to either
+   * {@link Long#MAX_VALUE} or {@link Long#MIN_VALUE}. This behavior can be useful when decomposing
+   * a duration in order to call a legacy API which requires a {@code long, TimeUnit} pair.
+   */
+  static long saturatedToNanos(Duration duration) {
+    // Using a try/catch seems lazy, but the catch block will rarely get invoked (except for
+    // durations longer than approximately +/- 292 years).
+    try {
+      return duration.toNanos();
+    } catch (ArithmeticException tooBig) {
+      return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
+    }
+  }
+
+  private Internal() {}
+}

--- a/guava/src/com/google/common/util/concurrent/Monitor.java
+++ b/guava/src/com/google/common/util/concurrent/Monitor.java
@@ -15,11 +15,13 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.j2objc.annotations.Weak;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -385,6 +387,16 @@ public final class Monitor {
    * Enters this monitor. Blocks at most the given time.
    *
    * @return whether the monitor was entered
+   * @since NEXT
+   */
+  public boolean enter(Duration time) {
+    return enter(saturatedToNanos(time), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Enters this monitor. Blocks at most the given time.
+   *
+   * @return whether the monitor was entered
    */
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean enter(long time, TimeUnit unit) {
@@ -418,6 +430,17 @@ public final class Monitor {
    */
   public void enterInterruptibly() throws InterruptedException {
     lock.lockInterruptibly();
+  }
+
+  /**
+   * Enters this monitor. Blocks at most the given time, and may be interrupted.
+   *
+   * @return whether the monitor was entered
+   * @throws InterruptedException if interrupted while waiting
+   * @since NEXT
+   */
+  public boolean enterInterruptibly(Duration time) throws InterruptedException {
+    return enterInterruptibly(saturatedToNanos(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -466,6 +489,19 @@ public final class Monitor {
         leave();
       }
     }
+  }
+
+  /**
+   * Enters this monitor when the guard is satisfied. Blocks at most the given time, including both
+   * the time to acquire the lock and the time to wait for the guard to be satisfied, and may be
+   * interrupted.
+   *
+   * @return whether the monitor was entered, which guarantees that the guard is now satisfied
+   * @throws InterruptedException if interrupted while waiting
+   * @since NEXT
+   */
+  public boolean enterWhen(Guard guard, Duration time) throws InterruptedException {
+    return enterWhen(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -548,6 +584,17 @@ public final class Monitor {
         leave();
       }
     }
+  }
+
+  /**
+   * Enters this monitor when the guard is satisfied. Blocks at most the given time, including both
+   * the time to acquire the lock and the time to wait for the guard to be satisfied.
+   *
+   * @return whether the monitor was entered, which guarantees that the guard is now satisfied
+   * @since NEXT
+   */
+  public boolean enterWhenUninterruptibly(Guard guard, Duration time) {
+    return enterWhenUninterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -645,6 +692,17 @@ public final class Monitor {
    * lock, but does not wait for the guard to be satisfied.
    *
    * @return whether the monitor was entered, which guarantees that the guard is now satisfied
+   * @since NEXT
+   */
+  public boolean enterIf(Guard guard, Duration time) {
+    return enterIf(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Enters this monitor if the guard is satisfied. Blocks at most the given time acquiring the
+   * lock, but does not wait for the guard to be satisfied.
+   *
+   * @return whether the monitor was entered, which guarantees that the guard is now satisfied
    */
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean enterIf(Guard guard, long time, TimeUnit unit) {
@@ -687,6 +745,17 @@ public final class Monitor {
         lock.unlock();
       }
     }
+  }
+
+  /**
+   * Enters this monitor if the guard is satisfied. Blocks at most the given time acquiring the
+   * lock, but does not wait for the guard to be satisfied, and may be interrupted.
+   *
+   * @return whether the monitor was entered, which guarantees that the guard is now satisfied
+   * @since NEXT
+   */
+  public boolean enterIfInterruptibly(Guard guard, Duration time) throws InterruptedException {
+    return enterIfInterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -764,6 +833,18 @@ public final class Monitor {
    *
    * @return whether the guard is now satisfied
    * @throws InterruptedException if interrupted while waiting
+   * @since NEXT
+   */
+  public boolean waitFor(Guard guard, Duration time) throws InterruptedException {
+    return waitFor(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Waits for the guard to be satisfied. Waits at most the given time, and may be interrupted. May
+   * be called only by a thread currently occupying this monitor.
+   *
+   * @return whether the guard is now satisfied
+   * @throws InterruptedException if interrupted while waiting
    */
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean waitFor(Guard guard, long time, TimeUnit unit) throws InterruptedException {
@@ -791,6 +872,17 @@ public final class Monitor {
     if (!guard.isSatisfied()) {
       awaitUninterruptibly(guard, true);
     }
+  }
+
+  /**
+   * Waits for the guard to be satisfied. Waits at most the given time. May be called only by a
+   * thread currently occupying this monitor.
+   *
+   * @return whether the guard is now satisfied
+   * @since NEXT
+   */
+  public boolean waitForUninterruptibly(Guard guard, Duration time) {
+    return waitForUninterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -16,6 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -29,6 +30,7 @@ import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwar
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -114,6 +116,27 @@ public final class MoreExecutors {
    * @param executor the executor to modify to make sure it exits when the application is finished
    * @param terminationTimeout how long to wait for the executor to finish before terminating the
    *     JVM
+   * @return an unmodifiable version of the input which will not hang the JVM
+   * @since NEXT
+   */
+  @Beta
+  @GwtIncompatible // java.time.Duration
+  public static ScheduledExecutorService getExitingScheduledExecutorService(
+      ScheduledThreadPoolExecutor executor, Duration terminationTimeout) {
+    return getExitingScheduledExecutorService(
+        executor, saturatedToNanos(terminationTimeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Converts the given ScheduledThreadPoolExecutor into a ScheduledExecutorService that exits when
+   * the application is complete. It does so by using daemon threads and adding a shutdown hook to
+   * wait for their completion.
+   *
+   * <p>This is mainly for fixed thread pools. See {@link Executors#newScheduledThreadPool(int)}.
+   *
+   * @param executor the executor to modify to make sure it exits when the application is finished
+   * @param terminationTimeout how long to wait for the executor to finish before terminating the
+   *     JVM
    * @param timeUnit unit of time for the time parameter
    * @return an unmodifiable version of the input which will not hang the JVM
    */
@@ -144,6 +167,23 @@ public final class MoreExecutors {
   public static ScheduledExecutorService getExitingScheduledExecutorService(
       ScheduledThreadPoolExecutor executor) {
     return new Application().getExitingScheduledExecutorService(executor);
+  }
+
+  /**
+   * Add a shutdown hook to wait for thread completion in the given {@link ExecutorService service}.
+   * This is useful if the given service uses daemon threads, and we want to keep the JVM from
+   * exiting immediately on shutdown, instead giving these daemon threads a chance to terminate
+   * normally.
+   *
+   * @param service ExecutorService which uses daemon threads
+   * @param terminationTimeout how long to wait for the executor to finish before terminating the
+   *     JVM
+   * @since NEXT
+   */
+  @Beta
+  @GwtIncompatible // java.time.Duration
+  public static void addDelayedShutdownHook(ExecutorService service, Duration terminationTimeout) {
+    addDelayedShutdownHook(service, saturatedToNanos(terminationTimeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -639,6 +679,20 @@ public final class MoreExecutors {
    * An implementation of {@link ExecutorService#invokeAny} for {@link ListeningExecutorService}
    * implementations.
    */
+  @GwtIncompatible static <T> T invokeAnyImpl(
+      ListeningExecutorService executorService,
+      Collection<? extends Callable<T>> tasks,
+      boolean timed,
+      Duration timeout)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return invokeAnyImpl(
+        executorService, tasks, timed, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * An implementation of {@link ExecutorService#invokeAny} for {@link ListeningExecutorService}
+   * implementations.
+   */
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   @GwtIncompatible static <T> T invokeAnyImpl(
       ListeningExecutorService executorService,
@@ -902,6 +956,36 @@ public final class MoreExecutors {
         return Callables.threadRenaming(command, nameSupplier);
       }
     };
+  }
+
+  /**
+   * Shuts down the given executor service gradually, first disabling new submissions and later, if
+   * necessary, cancelling remaining tasks.
+   *
+   * <p>The method takes the following steps:
+   *
+   * <ol>
+   *   <li>calls {@link ExecutorService#shutdown()}, disabling acceptance of new submitted tasks.
+   *   <li>awaits executor service termination for half of the specified timeout.
+   *   <li>if the timeout expires, it calls {@link ExecutorService#shutdownNow()}, cancelling
+   *       pending tasks and interrupting running tasks.
+   *   <li>awaits executor service termination for the other half of the specified timeout.
+   * </ol>
+   *
+   * <p>If, at any step of the process, the calling thread is interrupted, the method calls {@link
+   * ExecutorService#shutdownNow()} and returns.
+   *
+   * @param service the {@code ExecutorService} to shut down
+   * @param timeout the maximum time to wait for the {@code ExecutorService} to terminate
+   * @return {@code true} if the {@code ExecutorService} was terminated successfully, {@code false}
+   *     if the call timed out or was interrupted
+   * @since NEXT
+   */
+  @Beta
+  @CanIgnoreReturnValue
+  @GwtIncompatible // java.time.Duration
+  public static boolean shutdownAndAwaitTermination(ExecutorService service, Duration timeout) {
+    return shutdownAndAwaitTermination(service, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -92,7 +92,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 // would mean a maximum rate of "1MB/s", which might be small in some cases.
 @Beta
 @GwtIncompatible
-@SuppressWarnings("GoodTime") // lots of violations; how should we model a rate? b/119435646
 public abstract class RateLimiter {
   /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
@@ -159,6 +158,7 @@ public abstract class RateLimiter {
    * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero or {@code
    *     warmupPeriod} is negative
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public static RateLimiter create(double permitsPerSecond, long warmupPeriod, TimeUnit unit) {
     checkArgument(warmupPeriod >= 0, "warmupPeriod must not be negative: %s", warmupPeriod);
     return create(
@@ -300,6 +300,7 @@ public abstract class RateLimiter {
    * @return {@code true} if the permit was acquired, {@code false} otherwise
    * @throws IllegalArgumentException if the requested number of permits is negative or zero
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean tryAcquire(long timeout, TimeUnit unit) {
     return tryAcquire(1, timeout, unit);
   }
@@ -342,6 +343,7 @@ public abstract class RateLimiter {
    * @return {@code true} if the permits were acquired, {@code false} otherwise
    * @throws IllegalArgumentException if the requested number of permits is negative or zero
    */
+  @SuppressWarnings("GoodTime") // should accept a java.time.Duration
   public boolean tryAcquire(int permits, long timeout, TimeUnit unit) {
     long timeoutMicros = max(unit.toMicros(timeout), 0);
     checkPermits(permits);

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -16,6 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -27,6 +28,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.SmoothRateLimiter.SmoothBursty;
 import com.google.common.util.concurrent.SmoothRateLimiter.SmoothWarmingUp;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -132,6 +134,34 @@ public abstract class RateLimiter {
     RateLimiter rateLimiter = new SmoothBursty(stopwatch, 1.0 /* maxBurstSeconds */);
     rateLimiter.setRate(permitsPerSecond);
     return rateLimiter;
+  }
+
+  /**
+   * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
+   * second" (commonly referred to as <i>QPS</i>, queries per second), and a <i>warmup period</i>,
+   * during which the {@code RateLimiter} smoothly ramps up its rate, until it reaches its maximum
+   * rate at the end of the period (as long as there are enough requests to saturate it). Similarly,
+   * if the {@code RateLimiter} is left <i>unused</i> for a duration of {@code warmupPeriod}, it
+   * will gradually return to its "cold" state, i.e. it will go through the same warming up process
+   * as when it was first created.
+   *
+   * <p>The returned {@code RateLimiter} is intended for cases where the resource that actually
+   * fulfills the requests (e.g., a remote server) needs "warmup" time, rather than being
+   * immediately accessed at the stable (maximum) rate.
+   *
+   * <p>The returned {@code RateLimiter} starts in a "cold" state (i.e. the warmup period will
+   * follow), and if it is left unused for long enough, it will return to that state.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
+   *     permits become available per second
+   * @param warmupPeriod the duration of the period where the {@code RateLimiter} ramps up its rate,
+   *     before reaching its stable (maximum) rate
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero or {@code
+   *     warmupPeriod} is negative
+   * @since NEXT
+   */
+  public static RateLimiter create(double permitsPerSecond, Duration warmupPeriod) {
+    return create(permitsPerSecond, saturatedToNanos(warmupPeriod), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -293,6 +323,22 @@ public abstract class RateLimiter {
    * specified {@code timeout}, or returns {@code false} immediately (without waiting) if the permit
    * would not have been granted before the timeout expired.
    *
+   * <p>This method is equivalent to {@code tryAcquire(1, timeout)}.
+   *
+   * @param timeout the maximum time to wait for the permit. Negative values are treated as zero.
+   * @return {@code true} if the permit was acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   * @since NEXT
+   */
+  public boolean tryAcquire(Duration timeout) {
+    return tryAcquire(1, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Acquires a permit from this {@code RateLimiter} if it can be obtained without exceeding the
+   * specified {@code timeout}, or returns {@code false} immediately (without waiting) if the permit
+   * would not have been granted before the timeout expired.
+   *
    * <p>This method is equivalent to {@code tryAcquire(1, timeout, unit)}.
    *
    * @param timeout the maximum time to wait for the permit. Negative values are treated as zero.
@@ -330,6 +376,21 @@ public abstract class RateLimiter {
    */
   public boolean tryAcquire() {
     return tryAcquire(1, 0, MICROSECONDS);
+  }
+
+  /**
+   * Acquires the given number of permits from this {@code RateLimiter} if it can be obtained
+   * without exceeding the specified {@code timeout}, or returns {@code false} immediately (without
+   * waiting) if the permits would not have been granted before the timeout expired.
+   *
+   * @param permits the number of permits to acquire
+   * @param timeout the maximum time to wait for the permits. Negative values are treated as zero.
+   * @return {@code true} if the permits were acquired, {@code false} otherwise
+   * @throws IllegalArgumentException if the requested number of permits is negative or zero
+   * @since NEXT
+   */
+  public boolean tryAcquire(int permits, Duration timeout) {
+    return tryAcquire(permits, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -92,7 +92,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 // would mean a maximum rate of "1MB/s", which might be small in some cases.
 @Beta
 @GwtIncompatible
-@SuppressWarnings("GoodTime") // lots of violations - also how should we model a rate?
+@SuppressWarnings("GoodTime") // lots of violations; how should we model a rate? b/119435646
 public abstract class RateLimiter {
   /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per

--- a/guava/src/com/google/common/util/concurrent/Service.java
+++ b/guava/src/com/google/common/util/concurrent/Service.java
@@ -14,9 +14,12 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -99,6 +102,21 @@ public interface Service {
    * than the given time.
    *
    * @param timeout the maximum time to wait
+   * @throws TimeoutException if the service has not reached the given state within the deadline
+   * @throws IllegalStateException if the service reaches a state from which it is not possible to
+   *     enter the {@link State#RUNNING RUNNING} state. e.g. if the {@code state} is {@code
+   *     State#TERMINATED} when this method is called then this will throw an IllegalStateException.
+   * @since NEXT
+   */
+  default void awaitRunning(Duration timeout) throws TimeoutException {
+    awaitRunning(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Waits for the {@link Service} to reach the {@linkplain State#RUNNING running state} for no more
+   * than the given time.
+   *
+   * @param timeout the maximum time to wait
    * @param unit the time unit of the timeout argument
    * @throws TimeoutException if the service has not reached the given state within the deadline
    * @throws IllegalStateException if the service reaches a state from which it is not possible to
@@ -116,6 +134,19 @@ public interface Service {
    * @since 15.0
    */
   void awaitTerminated();
+
+  /**
+   * Waits for the {@link Service} to reach a terminal state (either {@link Service.State#TERMINATED
+   * terminated} or {@link Service.State#FAILED failed}) for no more than the given time.
+   *
+   * @param timeout the maximum time to wait
+   * @throws TimeoutException if the service has not reached the given state within the deadline
+   * @throws IllegalStateException if the service {@linkplain State#FAILED fails}.
+   * @since NEXT
+   */
+  default void awaitTerminated(Duration timeout) throws TimeoutException {
+    awaitTerminated(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
 
   /**
    * Waits for the {@link Service} to reach a terminal state (either {@link Service.State#TERMINATED

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Predicates.not;
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.Service.State.FAILED;
 import static com.google.common.util.concurrent.Service.State.NEW;
@@ -54,6 +55,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.j2objc.annotations.WeakOuter;
 import java.lang.ref.WeakReference;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -320,6 +322,21 @@ public final class ServiceManager {
    * reached the {@linkplain State#RUNNING running} state.
    *
    * @param timeout the maximum time to wait
+   * @throws TimeoutException if not all of the services have finished starting within the deadline
+   * @throws IllegalStateException if the service manager reaches a state from which it cannot
+   *     become {@linkplain #isHealthy() healthy}.
+   * @since NEXT
+   */
+  public void awaitHealthy(Duration timeout) throws TimeoutException {
+    awaitHealthy(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Waits for the {@link ServiceManager} to become {@linkplain #isHealthy() healthy} for no more
+   * than the given time. The manager will become healthy after all the component services have
+   * reached the {@linkplain State#RUNNING running} state.
+   *
+   * @param timeout the maximum time to wait
    * @param unit the time unit of the timeout argument
    * @throws TimeoutException if not all of the services have finished starting within the deadline
    * @throws IllegalStateException if the service manager reaches a state from which it cannot
@@ -351,6 +368,19 @@ public final class ServiceManager {
    */
   public void awaitStopped() {
     state.awaitStopped();
+  }
+
+  /**
+   * Waits for the all the services to reach a terminal state for no more than the given time. After
+   * this method returns all services will either be {@linkplain Service.State#TERMINATED
+   * terminated} or {@linkplain Service.State#FAILED failed}.
+   *
+   * @param timeout the maximum time to wait
+   * @throws TimeoutException if not all of the services have stopped within the deadline
+   * @since NEXT
+   */
+  public void awaitStopped(Duration timeout) throws TimeoutException {
+    awaitStopped(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -14,12 +14,15 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.util.concurrent.Internal.saturatedToNanos;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -67,6 +70,19 @@ public final class Uninterruptibles {
   /**
    * Invokes {@code latch.}{@link CountDownLatch#await(long, TimeUnit) await(timeout, unit)}
    * uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @CanIgnoreReturnValue // TODO(cpovirk): Consider being more strict.
+  @GwtIncompatible // concurrency
+  @Beta
+  public static boolean awaitUninterruptibly(CountDownLatch latch, Duration timeout) {
+    return awaitUninterruptibly(latch, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Invokes {@code latch.}{@link CountDownLatch#await(long, TimeUnit) await(timeout, unit)}
+   * uninterruptibly.
    */
   @CanIgnoreReturnValue // TODO(cpovirk): Consider being more strict.
   @GwtIncompatible // concurrency
@@ -91,6 +107,18 @@ public final class Uninterruptibles {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  /**
+   * Invokes {@code condition.}{@link Condition#await(long, TimeUnit) await(timeout, unit)}
+   * uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @GwtIncompatible // concurrency
+  @Beta
+  public static boolean awaitUninterruptibly(Condition condition, Duration timeout) {
+    return awaitUninterruptibly(condition, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -140,6 +168,18 @@ public final class Uninterruptibles {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  /**
+   * Invokes {@code unit.}{@link TimeUnit#timedJoin(Thread, long) timedJoin(toJoin, timeout)}
+   * uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @GwtIncompatible // concurrency
+  @Beta
+  public static void joinUninterruptibly(Thread toJoin, Duration timeout) {
+    joinUninterruptibly(toJoin, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -204,6 +244,33 @@ public final class Uninterruptibles {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  /**
+   * Invokes {@code future.}{@link Future#get(long, TimeUnit) get(timeout, unit)} uninterruptibly.
+   *
+   * <p>Similar methods:
+   *
+   * <ul>
+   *   <li>To retrieve a result from a {@code Future} that is already done, use {@link
+   *       Futures#getDone Futures.getDone}.
+   *   <li>To treat {@link InterruptedException} uniformly with other exceptions, use {@link
+   *       Futures#getChecked(Future, Class, long, TimeUnit) Futures.getChecked}.
+   *   <li>To get uninterruptibility and remove checked exceptions, use {@link
+   *       Futures#getUnchecked}.
+   * </ul>
+   *
+   * @throws ExecutionException if the computation threw an exception
+   * @throws CancellationException if the computation was cancelled
+   * @throws TimeoutException if the wait timed out
+   * @since NEXT
+   */
+  @CanIgnoreReturnValue
+  @GwtIncompatible // java.time.Duration
+  @Beta
+  public static <V> V getUninterruptibly(Future<V> future, Duration timeout)
+      throws ExecutionException, TimeoutException {
+    return getUninterruptibly(future, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -297,6 +364,18 @@ public final class Uninterruptibles {
   }
 
   // TODO(user): Support Sleeper somehow (wrapper or interface method)?
+  /**
+   * Invokes {@code unit.}{@link TimeUnit#sleep(long) sleep(sleepFor)} uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @GwtIncompatible // concurrency
+  @Beta
+  public static void sleepUninterruptibly(Duration sleepFor) {
+    sleepUninterruptibly(saturatedToNanos(sleepFor), TimeUnit.NANOSECONDS);
+  }
+
+  // TODO(user): Support Sleeper somehow (wrapper or interface method)?
   /** Invokes {@code unit.}{@link TimeUnit#sleep(long) sleep(sleepFor)} uninterruptibly. */
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
@@ -326,6 +405,18 @@ public final class Uninterruptibles {
    * Invokes {@code semaphore.}{@link Semaphore#tryAcquire(int, long, TimeUnit) tryAcquire(1,
    * timeout, unit)} uninterruptibly.
    *
+   * @since NEXT
+   */
+  @GwtIncompatible // concurrency
+  @Beta
+  public static boolean tryAcquireUninterruptibly(Semaphore semaphore, Duration timeout) {
+    return tryAcquireUninterruptibly(semaphore, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Invokes {@code semaphore.}{@link Semaphore#tryAcquire(int, long, TimeUnit) tryAcquire(1,
+   * timeout, unit)} uninterruptibly.
+   *
    * @since 18.0
    */
   @GwtIncompatible // concurrency
@@ -333,6 +424,20 @@ public final class Uninterruptibles {
   public static boolean tryAcquireUninterruptibly(
       Semaphore semaphore, long timeout, TimeUnit unit) {
     return tryAcquireUninterruptibly(semaphore, 1, timeout, unit);
+  }
+
+  /**
+   * Invokes {@code semaphore.}{@link Semaphore#tryAcquire(int, long, TimeUnit) tryAcquire(permits,
+   * timeout, unit)} uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @GwtIncompatible // concurrency
+  @Beta
+  public static boolean tryAcquireUninterruptibly(
+      Semaphore semaphore, int permits, Duration timeout) {
+    return tryAcquireUninterruptibly(
+        semaphore, permits, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <inceptionYear>2010</inceptionYear>
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a link back to the goodtime rate bug.

5750fb6c05d0f8b32060f56b0a94a12a52c89260

-------

<p> Copy Durations.saturatedToNanos(Duration) to package-private c.g.c.u.c.Internal so it can be used by the concurrent package (and in Guava).

#goodtime

568cbb67101fdb56436e75467a23de8d027b1089

-------

<p> Tighten the GoodTime suppression locations in RateLimiter.

#goodtime

0df55a98cf54e2c3ccf1c1180ad4a20419d69a55

-------

<p> Add Duration-based overloads to Uninterruptibles.

#goodtime

RELNOTES=Add Duration-based overloads to Uninterruptibles.

e194e7578e5e8fea2edddd5a9544ebdeac961141

-------

<p> Always complete TimeoutFuture, even if toString() throws

6c09c1732c040050752b5a087a1070ebf899ae9f

-------

<p> Add Duration-based overloads to MoreExecutors.

#goodtime

RELNOTES=Add Duration-based overloads to MoreExecutors.

e2da132822d1e62d000564e51816c789dc823998

-------

<p> Add Duration-based overloads to FluentFuture.

#goodtime

RELNOTES=Add Duration-based overloads to FluentFuture.

7f5390dcb99c6930facb2a91cca056a25b8581a4

-------

<p> Add Duration-based overloads to Futures.

#goodtime

RELNOTES=Add Duration-based overloads to Futures.

070e07da83e8320f2c368709cb773f08a383797f

-------

<p> Add Duration-based overloads to AbstractScheduledService.

#goodtime

RELNOTES=Add Duration-based overloads to AbstractScheduledService.

e7a7a1f0c4962231d73f72d101deeaa2c2b0144c

-------

<p> Add Duration-based overloads to Service.

#goodtime

RELNOTES=Add Duration-based overloads to Service.

76718f4617a2d4daea00a578f808cae59c5cdc59

-------

<p> Add Duration-based overloads to ServiceManager.

#goodtime

RELNOTES=Add Duration-based overloads to ServiceManager.

6c6edfa0b24148d5665a8e31a1811df7045b9460

-------

<p> Remove CheckedFuture utilities from util.concurrent.Futures.

d3dcc67f6da3cbd5be687e2cddec6fb13a68dd8b

-------

<p> Add Duration-based overloads to RateLimiter.

#goodtime

RELNOTES=Add Duration-based overloads to RateLimiter.

7aee4f5c283e501c854ae06aaa201fc5328ebe4f

-------

<p> Add Duration-based overload to Monitor.

#goodtime

RELNOTES=Add Duration-based overload to Monitor.

ac540c41979ade6931d9d604eff1e6223e247a9a

-------

<p> Define project build source encoding as UTF-8

Closes https://github.com/google/guava/pull/3465

196dd9edd4a8d7caa2f5f073268fab759d91b3e2

-------

<p> Fix "Apache License, Version 2.0" spelling

There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.

Closes https://github.com/google/guava/pull/3471

eb8695c81d20d83871ddd105954bd5ac3528de71

-------

<p> Fix Streams.zip documentation typo.

8cc9e91bafa0b90360b6972fca23f9d4f8dd3f65

-------

<p> Add MediaType for "application/geo+json".

via https://github.com/google/guava/pull/3243

RELNOTES=Add MediaType for "application/geo+json".

b47e9ba4e2efa318a0cc44cd9acdb1c215d41c42

-------

<p> Upgrade maven-javadoc-plugin to 3.1.0.

Fixes https://github.com/google/guava/pull/3478.

34b7a1eff5091a14ed3a325a5966c9c43b219754

-------

<p> Add Cross-Origin-Resource-Policy header name constants.

Details https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header

RELNOTES=Add Cross-Origin-Resource-Policy header to library.

161241d58e93dfdba5a9021d2ee8dc64e3cd3937

-------

<p> Fix Javadoc links.

Fixes https://github.com/google/guava/pull/3481

86be2d13b5677207cbc49bfb4431142b119647e6

-------

<p> Update documentation to refer correct method name.

https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#getOrDefault-java.lang.Object-V-

RELNOTES=N/A

a6f7253500de9a6a88c56e94858759c437dee20b