### PR TITLE
Upgrade maven-gpg-plugin to 1.6

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -332,7 +332,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.1</version>
+              <version>1.6</version>
               <executions>
                 <execution>
                   <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.1</version>
+              <version>1.6</version>
               <executions>
                 <execution>
                   <id>sign-artifacts</id>


### PR DESCRIPTION
Latest maven-gpg-plugin version has been at 1.6 since [2015](https://blog.soebes.de/blog/2015/01/20/apache-maven-gpg-plugin-version-1-dot-6-released/). Bumping up to this latest version from version 1.1, released in 2010.
Versions bypassed:

- [1.5](http://mail-archives.apache.org/mod_mbox/maven-announce/201402.mbox/%3CCA+nPnMxvcd8wEJOeVP5DTS4HHCrC-0V4Kyk1Dv0QAuacGuzRBg@mail.gmail.com%3E)
- 1.4 (unable to find release notes)
- 1.3 (unable to find release notes)
- 1.2 (unable to find release notes)