### PR TITLE
Upgrade animal sniffer version to 1.18

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -14,7 +14,7 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
-    <animal.sniffer.version>1.17</animal.sniffer.version>
+    <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
-    <animal.sniffer.version>1.17</animal.sniffer.version>
+    <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
   </properties>


### PR DESCRIPTION
Version [1.18](https://github.com/mojohaus/animal-sniffer/milestone/5?closed=1) resolves a JDK8 compatibility issue, resource leak and ends support for JDK 7