### PR TITLE
Fixed double slicing ByteSource

### DIFF
--- a/guava-tests/test/com/google/common/io/ByteSourceTest.java
+++ b/guava-tests/test/com/google/common/io/ByteSourceTest.java
@@ -221,6 +221,25 @@ public class ByteSourceTest extends IoTestCase {
   }
 
   /**
+   * Tests that slice() works correctly when the source is sliced two times, when the second slice
+   * starts at an offset greater than the length of the previous slice.
+   */
+  public void testSlice_slicingAfterSlicing() throws IOException {
+    // Source of length 10
+    ByteSource source = new TestByteSource(newPreFilledByteArray(10));
+
+    // Slice the source twice
+    ByteSource doubleSlice = source.slice(0, 3).slice(4,3);
+
+    // Open a stream to the slice
+    InputStream in = doubleSlice.openStream();
+
+    // The result should be empty because the second slice starts at an offset greater than
+    // the length of the first slice.
+    assertEquals(-1, in.read());
+  }
+
+  /**
    * Tests that the default slice() behavior is correct when the source is sliced starting at an
    * offset that is greater than the current length of the source, a stream is then opened to that
    * source, and finally additional bytes are appended to the source before the stream is read.

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -527,6 +527,7 @@ public abstract class ByteSource {
     public ByteSource slice(long offset, long length) {
       checkArgument(offset >= 0, "offset (%s) may not be negative", offset);
       checkArgument(length >= 0, "length (%s) may not be negative", length);
+      offset = Math.min(offset, this.length);
       long maxLength = this.length - offset;
       return ByteSource.this.slice(this.offset + offset, Math.min(length, maxLength));
     }


### PR DESCRIPTION
Fixes #3501

However, there is still a problem in this method. If `this.offset + this.length > Long.MAX_VALUE`, it will overflow. These are 4 possible approaches:

1. Leave is as it is.
2. Disallow offset + length > Long.MAX_VALUE on slices by adding checks.
3. Allow offsets larger than Long.MAX_VALUE.
4. Assume that no ByteSource has that much elements, and if the offset would overflow, return an empty source.