### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/android/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -371,7 +371,14 @@ public final class ArbitraryInstances {
     constructor.setAccessible(true); // accessibility check is too slow
     try {
       return constructor.newInstance();
-    } catch (InstantiationException | IllegalAccessException impossible) {
+      /*
+       * Do not merge the 2 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+       * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (InstantiationException impossible) {
+      throw new AssertionError(impossible);
+    } catch (IllegalAccessException impossible) {
       throw new AssertionError(impossible);
     } catch (InvocationTargetException e) {
       logger.log(Level.WARNING, "Exception while invoking default constructor.", e.getCause());

--- a/android/guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
+++ b/android/guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
@@ -508,7 +508,14 @@ class FreshValueGenerator {
       @SuppressWarnings("unchecked") // getAvailableCurrencies() returns Set<Currency>.
       Set<Currency> currencies = (Set<Currency>) method.invoke(null);
       return pickInstance(currencies, Currency.getInstance(Locale.US));
-    } catch (NoSuchMethodException | InvocationTargetException notJava7) {
+      /*
+       * Do not merge the 2 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+       * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (NoSuchMethodException notJava7) {
+      return preJava7FreshCurrency();
+    } catch (InvocationTargetException notJava7) {
       return preJava7FreshCurrency();
     } catch (IllegalAccessException impossible) {
       throw new AssertionError(impossible);

--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
@@ -234,21 +234,21 @@ public class AbstractServiceTest extends TestCase {
    */
   public void testManualServiceStopMultipleTimesWhileStarting() throws Exception {
     ManualSwitchedService service = new ManualSwitchedService();
-    final AtomicInteger stopppingCount = new AtomicInteger();
+    final AtomicInteger stoppingCount = new AtomicInteger();
     service.addListener(
         new Listener() {
           @Override
           public void stopping(State from) {
-            stopppingCount.incrementAndGet();
+            stoppingCount.incrementAndGet();
           }
         },
         directExecutor());
 
     service.startAsync();
     service.stopAsync();
-    assertEquals(1, stopppingCount.get());
+    assertEquals(1, stoppingCount.get());
     service.stopAsync();
-    assertEquals(1, stopppingCount.get());
+    assertEquals(1, stoppingCount.get());
   }
 
   public void testManualServiceStopWhileNew() throws Exception {

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -107,6 +107,8 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public GraphBuilder<N> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -123,7 +125,11 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Graph#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> GraphBuilder<N1> nodeOrder(ElementOrder<N1> nodeOrder) {
     GraphBuilder<N1> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);

--- a/android/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/android/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -118,6 +118,8 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   /**
    * Specifies whether the network will allow parallel edges. Attempting to add a parallel edge to a
    * network that does not allow them will throw an {@link UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public NetworkBuilder<N, E> allowsParallelEdges(boolean allowsParallelEdges) {
     this.allowsParallelEdges = allowsParallelEdges;
@@ -128,6 +130,8 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
    * Specifies whether the network will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a network that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public NetworkBuilder<N, E> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -154,14 +158,22 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Network#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Network#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> NetworkBuilder<N1, E> nodeOrder(ElementOrder<N1> nodeOrder) {
     NetworkBuilder<N1, E> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);
     return newBuilder;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Network#edges()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Network#edges()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <E1 extends E> NetworkBuilder<N, E1> edgeOrder(ElementOrder<E1> edgeOrder) {
     NetworkBuilder<N, E1> newBuilder = cast();
     newBuilder.edgeOrder = checkNotNull(edgeOrder);

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -113,6 +113,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public ValueGraphBuilder<N, V> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -129,7 +131,11 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Graph#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> ValueGraphBuilder<N1, V> nodeOrder(ElementOrder<N1> nodeOrder) {
     ValueGraphBuilder<N1, V> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);

--- a/android/guava/src/com/google/common/reflect/Types.java
+++ b/android/guava/src/com/google/common/reflect/Types.java
@@ -591,7 +591,14 @@ final class Types {
           return (String) getTypeName.invoke(type);
         } catch (NoSuchMethodException e) {
           throw new AssertionError("Type.getTypeName should be available in Java 8");
-        } catch (InvocationTargetException | IllegalAccessException e) {
+          /*
+           * Do not merge the 2 catch blocks below. javac would infer a type of
+           * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+           * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+           */
+        } catch (InvocationTargetException e) {
+          throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
           throw new RuntimeException(e);
         }
       }

--- a/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -755,7 +755,16 @@ public final class MoreExecutors {
           Class.forName("com.google.appengine.api.ThreadManager")
               .getMethod("currentRequestThreadFactory")
               .invoke(null);
-    } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
+      /*
+       * Do not merge the 3 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of Android
+       * don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
+    } catch (NoSuchMethodException e) {
       throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
     } catch (InvocationTargetException e) {
       throw Throwables.propagate(e.getCause());

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -15,7 +15,7 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
-    <animal.sniffer.version>1.17</animal.sniffer.version>
+    <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -9,6 +9,7 @@
   <version>HEAD-android-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
+  <description>Parent for guava artifacts</description>
   <url>https://github.com/google/guava</url>
   <properties>
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
@@ -16,7 +17,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>

--- a/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -383,7 +383,14 @@ public final class ArbitraryInstances {
     constructor.setAccessible(true); // accessibility check is too slow
     try {
       return constructor.newInstance();
-    } catch (InstantiationException | IllegalAccessException impossible) {
+      /*
+       * Do not merge the 2 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+       * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (InstantiationException impossible) {
+      throw new AssertionError(impossible);
+    } catch (IllegalAccessException impossible) {
       throw new AssertionError(impossible);
     } catch (InvocationTargetException e) {
       logger.log(Level.WARNING, "Exception while invoking default constructor.", e.getCause());

--- a/guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
+++ b/guava-testlib/src/com/google/common/testing/FreshValueGenerator.java
@@ -512,7 +512,14 @@ class FreshValueGenerator {
       @SuppressWarnings("unchecked") // getAvailableCurrencies() returns Set<Currency>.
       Set<Currency> currencies = (Set<Currency>) method.invoke(null);
       return pickInstance(currencies, Currency.getInstance(Locale.US));
-    } catch (NoSuchMethodException | InvocationTargetException notJava7) {
+      /*
+       * Do not merge the 2 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+       * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (NoSuchMethodException notJava7) {
+      return preJava7FreshCurrency();
+    } catch (InvocationTargetException notJava7) {
       return preJava7FreshCurrency();
     } catch (IllegalAccessException impossible) {
       throw new AssertionError(impossible);

--- a/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
+++ b/guava-tests/test/com/google/common/cache/CacheBuilderTest.java
@@ -277,24 +277,13 @@ public class CacheBuilderTest extends TestCase {
   }
 
   @GwtIncompatible // java.time.Duration
-  public void testLargeDurations() {
+  public void testLargeDurationsAreOk() {
     java.time.Duration threeHundredYears = java.time.Duration.ofDays(365 * 300);
-    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
-    try {
-      builder.expireAfterWrite(threeHundredYears);
-      fail();
-    } catch (ArithmeticException expected) {
-    }
-    try {
-      builder.expireAfterAccess(threeHundredYears);
-      fail();
-    } catch (ArithmeticException expected) {
-    }
-    try {
-      builder.refreshAfterWrite(threeHundredYears);
-      fail();
-    } catch (ArithmeticException expected) {
-    }
+    CacheBuilder<Object, Object> builder =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(threeHundredYears)
+            .expireAfterAccess(threeHundredYears)
+            .refreshAfterWrite(threeHundredYears);
   }
 
   public void testTimeToLive_negative() {

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
@@ -234,21 +234,21 @@ public class AbstractServiceTest extends TestCase {
    */
   public void testManualServiceStopMultipleTimesWhileStarting() throws Exception {
     ManualSwitchedService service = new ManualSwitchedService();
-    final AtomicInteger stopppingCount = new AtomicInteger();
+    final AtomicInteger stoppingCount = new AtomicInteger();
     service.addListener(
         new Listener() {
           @Override
           public void stopping(State from) {
-            stopppingCount.incrementAndGet();
+            stoppingCount.incrementAndGet();
           }
         },
         directExecutor());
 
     service.startAsync();
     service.stopAsync();
-    assertEquals(1, stopppingCount.get());
+    assertEquals(1, stoppingCount.get());
     service.stopAsync();
-    assertEquals(1, stopppingCount.get());
+    assertEquals(1, stoppingCount.get());
   }
 
   public void testManualServiceStopWhileNew() throws Exception {

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -107,6 +107,8 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public GraphBuilder<N> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -123,7 +125,11 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Graph#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> GraphBuilder<N1> nodeOrder(ElementOrder<N1> nodeOrder) {
     GraphBuilder<N1> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);

--- a/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -118,6 +118,8 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
   /**
    * Specifies whether the network will allow parallel edges. Attempting to add a parallel edge to a
    * network that does not allow them will throw an {@link UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public NetworkBuilder<N, E> allowsParallelEdges(boolean allowsParallelEdges) {
     this.allowsParallelEdges = allowsParallelEdges;
@@ -128,6 +130,8 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
    * Specifies whether the network will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a network that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public NetworkBuilder<N, E> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -154,14 +158,22 @@ public final class NetworkBuilder<N, E> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Network#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Network#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> NetworkBuilder<N1, E> nodeOrder(ElementOrder<N1> nodeOrder) {
     NetworkBuilder<N1, E> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);
     return newBuilder;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Network#edges()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Network#edges()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <E1 extends E> NetworkBuilder<N, E1> edgeOrder(ElementOrder<E1> edgeOrder) {
     NetworkBuilder<N, E1> newBuilder = cast();
     newBuilder.edgeOrder = checkNotNull(edgeOrder);

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -113,6 +113,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * Specifies whether the graph will allow self-loops (edges that connect a node to itself).
    * Attempting to add a self-loop to a graph that does not allow them will throw an {@link
    * UnsupportedOperationException}.
+   *
+   * <p>The default value is {@code false}.
    */
   public ValueGraphBuilder<N, V> allowsSelfLoops(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
@@ -129,7 +131,11 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return this;
   }
 
-  /** Specifies the order of iteration for the elements of {@link Graph#nodes()}. */
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#nodes()}.
+   *
+   * <p>The default value is {@link ElementOrder#insertion() insertion order}.
+   */
   public <N1 extends N> ValueGraphBuilder<N1, V> nodeOrder(ElementOrder<N1> nodeOrder) {
     ValueGraphBuilder<N1, V> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -588,7 +588,14 @@ final class Types {
           return (String) getTypeName.invoke(type);
         } catch (NoSuchMethodException e) {
           throw new AssertionError("Type.getTypeName should be available in Java 8");
-        } catch (InvocationTargetException | IllegalAccessException e) {
+          /*
+           * Do not merge the 2 catch blocks below. javac would infer a type of
+           * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of
+           * Android don't *seem* to mind, but there might be edge cases of which we're unaware.)
+           */
+        } catch (InvocationTargetException e) {
+          throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
           throw new RuntimeException(e);
         }
       }

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -830,7 +830,16 @@ public final class MoreExecutors {
           Class.forName("com.google.appengine.api.ThreadManager")
               .getMethod("currentRequestThreadFactory")
               .invoke(null);
-    } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
+      /*
+       * Do not merge the 3 catch blocks below. javac would infer a type of
+       * ReflectiveOperationException, which Animal Sniffer would reject. (Old versions of Android
+       * don't *seem* to mind, but there might be edge cases of which we're unaware.)
+       */
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
+    } catch (NoSuchMethodException e) {
       throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
     } catch (InvocationTargetException e) {
       throw Throwables.propagate(e.getCause());

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>0.44</truth.version>
-    <animal.sniffer.version>1.17</animal.sniffer.version>
+    <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
   <version>HEAD-jre-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
+  <description>Parent for guava artifacts</description>
   <url>https://github.com/google/guava</url>
   <properties>
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
@@ -16,7 +17,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>    
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add missing description tags to guava-parent poms.

We were previously apparently inheriting them from sonatype-oss-parent, until we removed that. Releases don't work without a description. "Invalid POM: /com/google/guava/guava-parent/28.0-android/guava-parent-28.0-android.pom: Project description missing"

6123f09d9a4892852c566bdd8631b34471f50121

-------

<p> Fix typo in 'stoppingCount' variable name

Fixes #3500

9122cefee6b5e4d74e55045c69396d8489ec8859

-------

<p> Split catch() blocks so that javac doesn't generate a reference to their common supertype, ReflectiveOperationException.

ReflectiveOperationException isn't available on the old versions of Android that we support.

As far as we know, there is no actual problem with these references because no methods are called on them. However, the new version of Animal Sniffer we're updating to will flag them anyway, and I think that avoiding them is the safe thing to do.

Prepares for #3497

e86764ed2c5831e91a746b1c48b900e0d5d09c3c

-------

<p> Upgrade animal sniffer version to 1.18

Fixes #3497

3e3c1f93c579c1d3ef03820da4f786ce3385d0ce

-------

<p> Document default values of builder setters.

46a7e558772ddd039317ed76f89da21db67f7205

-------

<p> Use saturatedToNanos() in CacheBuilder to avoid overflows.

RELNOTES=Use saturatedToNanos() in CacheBuilder to avoid overflows.

3b0729d5d4c25ea705ac4ec9660bc7cb993888b6