### PR TITLE
Update Javadoc of UnsignedBytes.java

### DIFF
--- a/guava/src/com/google/common/primitives/UnsignedBytes.java
+++ b/guava/src/com/google/common/primitives/UnsignedBytes.java
@@ -121,11 +121,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the least value present in {@code array}.
+   * Returns the least value present in {@code array}, treating values as unsigned.
    *
-   * @param array a <i>nonempty</i> array of {@code byte} values
+   * @param array a <i>nonempty</i> array of unsigned {@code byte} values
    * @return the value present in {@code array} that is less than or equal to every other value in
-   *     the array
+   *     the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte min(byte... array) {
@@ -141,11 +141,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the greatest value present in {@code array}.
+   * Returns the greatest value present in {@code array}, treating values as unsigned.
    *
-   * @param array a <i>nonempty</i> array of {@code byte} values
+   * @param array a <i>nonempty</i> array of unsigned {@code byte} values
    * @return the value present in {@code array} that is greater than or equal to every other value
-   *     in the array
+   *     in the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte max(byte... array) {


### PR DESCRIPTION
UnsignedBytes ```min()``` and ```max()``` method treat its parameter as unsigned and returns the least and greatest value also too as unsigned respectively. It should be updated in the Javadoc.

Test Case:-

Input:-
```
import com.google.common.primitives.UnsignedBytes;

class ex{
    static void pr(byte []a) {
        System.out.println(UnsignedBytes.min(a)); // 10 is less than -100 when treated as unsigned
        System.out.println(UnsignedBytes.max(a)); // -100 is greater than 10 when treated as unsigned
    }
    public static void main(String[] args) {
        byte []a={-100,10};
        pr(a);
    }
}
```
Run it by typing in the terminal:-
```
javac ex.java
java ex
```
Output:-
```
10
-100
```