### PR TITLE
optimize buffer-memory allocation

### DIFF
--- a/guava-tests/benchmark/com/google/common/io/ByteSourceBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteSourceBenchmark.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.caliper.BeforeExperiment;
+import com.google.caliper.Benchmark;
+import com.google.caliper.Param;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Benchmark for {@code ByteSource} performance.
+ */
+public class ByteSourceBenchmark {
+    @Param({"10", "100", "1000", "10000", "100000"})
+    int n;
+
+    private ByteSource byteSource;
+    private ByteSource byteSourceCopy;
+
+    @BeforeExperiment
+    public void setUp() {
+        Random rng = new Random();
+
+        byte[] bytes = new byte[n];
+
+        rng.nextBytes(bytes);
+
+        byteSource = ByteSource.wrap(bytes);
+        byteSourceCopy = ByteSource.wrap(Arrays.copyOf(bytes, bytes.length));
+    }
+
+    @Benchmark
+    public void contentEquals(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            byteSource.contentEquals(byteSourceCopy);
+        }
+    }
+}

--- a/guava-tests/benchmark/com/google/common/io/ByteStreamsBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteStreamsBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2015 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.caliper.BeforeExperiment;
+import com.google.caliper.Benchmark;
+import com.google.caliper.Param;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Benchmark for {@code ByteStreams} performance.
+ */
+public class ByteStreamsBenchmark {
+    @Param({"10", "100", "10000"})
+    int n;
+
+    private byte[] randomData;
+    private ByteArrayInputStream byteArrayInputStream;
+    private ByteArrayOutputStream byteArrayOutputStream;
+
+    @BeforeExperiment
+    public void setUp() {
+        Random rng = new Random();
+        randomData = new byte[n];
+        rng.nextBytes(randomData);
+        byteArrayInputStream = new ByteArrayInputStream(randomData);
+        byteArrayOutputStream = new ByteArrayOutputStream(randomData.length);
+    }
+
+    @Benchmark
+    public void copy(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.copy(byteArrayInputStream, byteArrayOutputStream);
+            byteArrayInputStream.reset();
+            byteArrayOutputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void toByteArray(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.toByteArray(byteArrayInputStream);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void toByteArrayWithExpectedSize(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.toByteArray(byteArrayInputStream, randomData.length);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void skipFully(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.skipFully(byteArrayInputStream, randomData.length);
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitOneQuarter(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.25));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitHalf(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.5));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void limitThreeQuarter(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.limit(byteArrayInputStream, Math.round(randomData.length * 0.75));
+            byteArrayInputStream.reset();
+        }
+    }
+
+    @Benchmark
+    public void readBytes(int reps) throws IOException {
+        for (int i = 0; i < reps; i++) {
+            ByteStreams.readBytes(
+                    byteArrayInputStream,
+                    new ByteProcessor<Object>() {
+                        @Override
+                        public boolean processBytes(byte[] buf, int off, int len) throws IOException {
+                            return true;
+                        }
+
+                        @Override
+                        public Object getResult() {
+                            return null;
+                        }
+                    }
+            );
+            byteArrayInputStream.reset();
+        }
+    }
+}

--- a/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
@@ -37,7 +37,7 @@ public class CharStreamsCopyBenchmark {
     OLD {
       @Override
       long copy(Readable from, Appendable to) throws IOException {
-        CharBuffer buf = CharStreams.createBuffer();
+        CharBuffer buf = CharBuffer.allocate(4096);
         long total = 0;
         while (from.read(buf) != -1) {
           buf.flip();

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -16,7 +16,6 @@ package com.google.common.io;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.io.ByteStreams.createBuffer;
 import static com.google.common.io.ByteStreams.skipUpTo;
 
 import com.google.common.annotations.Beta;
@@ -339,19 +338,28 @@ public abstract class ByteSource {
   public boolean contentEquals(ByteSource other) throws IOException {
     checkNotNull(other);
 
-    byte[] buf1 = createBuffer();
-    byte[] buf2 = createBuffer();
-
     Closer closer = Closer.create();
-    try {
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      byte[] bytes = buffer.get();
+      int bufferSize = bytes.length / 2;
+
       InputStream in1 = closer.register(openStream());
       InputStream in2 = closer.register(other.openStream());
       while (true) {
-        int read1 = ByteStreams.read(in1, buf1, 0, buf1.length);
-        int read2 = ByteStreams.read(in2, buf2, 0, buf2.length);
-        if (read1 != read2 || !Arrays.equals(buf1, buf2)) {
+        int read1 = ByteStreams.read(in1,  bytes, 0, bufferSize);
+        int read2 = ByteStreams.read(in2, bytes, bufferSize, bufferSize);
+
+        if (read1 != read2) {
           return false;
-        } else if (read1 != buf1.length) {
+        }
+
+        for (int i = 0; i < read1; i++) {
+          if (bytes[i] != bytes[i + bufferSize]) {
+            return false;
+          }
+        }
+
+        if (read1 != bufferSize) {
           return true;
         }
       }

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -53,11 +53,6 @@ public final class ByteStreams {
 
   private static final int BUFFER_SIZE = 8192;
 
-  /** Creates a new byte array for buffering reads or writes. */
-  static byte[] createBuffer() {
-    return new byte[BUFFER_SIZE];
-  }
-
   /**
    * There are three methods to implement {@link FileChannel#transferTo(long, long,
    * WritableByteChannel)}:
@@ -102,17 +97,20 @@ public final class ByteStreams {
   public static long copy(InputStream from, OutputStream to) throws IOException {
     checkNotNull(from);
     checkNotNull(to);
-    byte[] buf = createBuffer();
-    long total = 0;
-    while (true) {
-      int r = from.read(buf);
-      if (r == -1) {
-        break;
+
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      byte[] buf = buffer.get();
+      long total = 0;
+      while (true) {
+        int r = from.read(buf);
+        if (r == -1) {
+          break;
+        }
+        to.write(buf, 0, r);
+        total += r;
       }
-      to.write(buf, 0, r);
-      total += r;
+      return total;
     }
-    return total;
   }
 
   /**
@@ -141,16 +139,18 @@ public final class ByteStreams {
       return position - oldPosition;
     }
 
-    ByteBuffer buf = ByteBuffer.wrap(createBuffer());
-    long total = 0;
-    while (from.read(buf) != -1) {
-      buf.flip();
-      while (buf.hasRemaining()) {
-        total += to.write(buf);
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      ByteBuffer buf = ByteBuffer.wrap(buffer.get());
+      long total = 0;
+      while (from.read(buf) != -1) {
+        buf.flip();
+        while (buf.hasRemaining()) {
+          total += to.write(buf);
+        }
+        buf.clear();
       }
-      buf.clear();
+      return total;
     }
-    return total;
   }
 
   /** Max array length on JVM. */
@@ -269,11 +269,14 @@ public final class ByteStreams {
   public static long exhaust(InputStream in) throws IOException {
     long total = 0;
     long read;
-    byte[] buf = createBuffer();
-    while ((read = in.read(buf)) != -1) {
-      total += read;
+
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      byte[] buf = buffer.get();
+      while ((read = in.read(buf)) != -1) {
+        total += read;
+      }
+      return total;
     }
-    return total;
   }
 
   /**
@@ -816,26 +819,28 @@ public final class ByteStreams {
    */
   static long skipUpTo(InputStream in, final long n) throws IOException {
     long totalSkipped = 0;
-    byte[] buf = createBuffer();
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      byte[] buf = buffer.get();
 
-    while (totalSkipped < n) {
-      long remaining = n - totalSkipped;
-      long skipped = skipSafely(in, remaining);
+      while (totalSkipped < n) {
+        long remaining = n - totalSkipped;
+        long skipped = skipSafely(in, remaining);
 
-      if (skipped == 0) {
-        // Do a buffered read since skipSafely could return 0 repeatedly, for example if
-        // in.available() always returns 0 (the default).
-        int skip = (int) Math.min(remaining, buf.length);
-        if ((skipped = in.read(buf, 0, skip)) == -1) {
-          // Reached EOF
-          break;
+        if (skipped == 0) {
+          // Do a buffered read since skipSafely could return 0 repeatedly, for example if
+          // in.available() always returns 0 (the default).
+          int skip = (int) Math.min(remaining, buf.length);
+          if ((skipped = in.read(buf, 0, skip)) == -1) {
+            // Reached EOF
+            break;
+          }
         }
+
+        totalSkipped += skipped;
       }
 
-      totalSkipped += skipped;
+      return totalSkipped;
     }
-
-    return totalSkipped;
   }
 
   /**
@@ -865,12 +870,14 @@ public final class ByteStreams {
     checkNotNull(input);
     checkNotNull(processor);
 
-    byte[] buf = createBuffer();
-    int read;
-    do {
-      read = input.read(buf);
-    } while (read != -1 && processor.processBytes(buf, 0, read));
-    return processor.getResult();
+    try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+      byte[] buf = buffer.get();
+      int read;
+      do {
+        read = input.read(buf);
+      } while (read != -1 && processor.processBytes(buf, 0, read));
+      return processor.getResult();
+    }
   }
 
   /**

--- a/guava/src/com/google/common/io/LineReader.java
+++ b/guava/src/com/google/common/io/LineReader.java
@@ -15,7 +15,6 @@
 package com.google.common.io;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.io.CharStreams.createBuffer;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
@@ -40,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class LineReader {
   private final Readable readable;
   private final @Nullable Reader reader;
-  private final CharBuffer cbuf = createBuffer();
+  private final CharBuffer cbuf = CharBuffer.allocate(4096);
   private final char[] buf = cbuf.array();
 
   private final Queue<String> lines = new LinkedList<>();

--- a/guava/src/com/google/common/io/TransferBuffer.java
+++ b/guava/src/com/google/common/io/TransferBuffer.java
@@ -1,0 +1,152 @@
+package com.google.common.io;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.GwtIncompatible;
+import com.google.common.base.Supplier;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.util.Arrays;
+
+/**
+ * Provides byte-Arrays to be used as method-local transfer buffers, to e.g. move data
+ * from an {@link java.io.InputStream} to an {@link java.io.OutputStream}. This gives a
+ * significant performance-boost compared to allocating new byte- or char-arrays as buffers everytime a
+ * transfer-buffer is needed.
+ * The arrays are stored per thread and may be collected by the garbage collection if it decides so,
+ * in which case a new array needs to be allocated the next time {@link TransferBuffer#getByteArrayTransferBuffer()}
+ * is being called.
+ *
+ * TransferBuffers must not be stored and must be closed after use:
+ *
+ * <code>
+ *   try (TransferBuffer<byte[]> buffer = TransferBuffer.getByteArrayTransferBuffer()) {
+ *      byte[] array = buffer.getArray();
+ *      int read;
+ *
+ *      do {
+ *          read = inputStream.read(array);
+ *          outputStream.write(array);
+ *      } while (read != 0);
+ *   }
+ * </code>
+ *
+ * @author Bernd Hopp
+ * @since 29
+ */
+@Beta
+@GwtIncompatible
+final class TransferBuffer<T> implements Closeable, Supplier<T> {
+
+  // 8K bytes
+  private static final int BYTE_BUFFER_SIZE = 0x2000;
+  // 2K chars (4K bytes)
+  private static final int CHAR_BUFFER_SIZE = 0x800;
+  
+  private static final ThreadLocal<SoftReference<TransferBuffer<byte[]>>> byteArrayBufferHolder = new ThreadLocal<>();
+  private static final ThreadLocal<SoftReference<TransferBuffer<char[]>>> charArrayBufferHolder = new ThreadLocal<>();
+  
+  private final T array;
+  private boolean inUse = false;
+
+  private TransferBuffer(T array) {
+    this.array = array;
+  }
+
+  /**
+   * Returns a {@link TransferBuffer} of byte[], which is guaranteed to be thread-local
+   */
+  static TransferBuffer<byte[]> getByteArrayTransferBuffer() {
+    final SoftReference<TransferBuffer<byte[]>> bufferReference = byteArrayBufferHolder.get();
+
+    if (bufferReference == null) {
+      return createAndCacheByteBuffer();
+    }
+
+    TransferBuffer<byte[]> buffer = bufferReference.get();
+
+    if (buffer == null) {
+      return createAndCacheByteBuffer();
+    }
+
+    /*
+    it could - in rare scenarios - be possible that a single thread may need more than
+    one buffer simultaneously, even if the TransferBuffer-class is package-private and could not be called
+    by users directly. For example, let's assume there is a class called 'ConcatenatingInputStream' which
+    subclasses java.io.InputStream. The implementation uses ByteStreams#copyTo to move data between streams,
+    which means that the ConcatenatingInputStream#read-method will use the TransferBuffer for that thread.
+    If now it happens that an instance of this ConcatenatingInputStream is being passed to ByteStreams#copyTo,
+    this would mean a double-use of the buffer, somewhat similar to 'use-after-free'-flaws in languages with manual
+    memory allocation. 
+    In order to avoid this, a private flag 'inUse' was introduced to mark the buffer as being currently under use. 
+    If this flag is set on the current TransferBuffer and 
+    , a new 'throwaway'-buffer is being created, which will not be stored thread-locally afterwards. 
+    **/
+    if (buffer.isInUse()) {
+      return new TransferBuffer<>(new byte[BYTE_BUFFER_SIZE]);
+    }
+
+    Arrays.fill(buffer.get(), (byte) 0);
+    buffer.setInUse();
+    return buffer;
+  }
+
+  private static TransferBuffer<byte[]> createAndCacheByteBuffer() {
+    TransferBuffer<byte[]> buffer = new TransferBuffer<>(new byte[BYTE_BUFFER_SIZE]);
+    SoftReference<TransferBuffer<byte[]>> bufferReference = new SoftReference<>(buffer);
+    byteArrayBufferHolder.set(bufferReference);
+    return buffer;
+  }
+
+  /**
+   * Returns a {@link TransferBuffer} of char[], which is guaranteed to be thread-local
+   */
+  static TransferBuffer<char[]> getCharArrayTransferBuffer() {
+    final SoftReference<TransferBuffer<char[]>> bufferReference = charArrayBufferHolder.get();
+
+    if (bufferReference == null) {
+      return createAndCacheCharBuffer();
+    }
+
+    TransferBuffer<char[]> buffer = bufferReference.get();
+
+    if (buffer == null) {
+      return createAndCacheCharBuffer();
+    }
+
+    //see comment in getByteArrayTransferBuffer()
+    if (buffer.isInUse()) {
+      return new TransferBuffer<>(new char[CHAR_BUFFER_SIZE]);
+    }
+
+    Arrays.fill(buffer.get(), (char) 0);
+    buffer.setInUse();
+
+    return buffer;
+  }
+
+  private static TransferBuffer<char[]> createAndCacheCharBuffer() {
+    TransferBuffer<char[]> buffer = new TransferBuffer<>(new char[CHAR_BUFFER_SIZE]);
+    SoftReference<TransferBuffer<char[]>> bufferReference = new SoftReference<>(buffer);
+    charArrayBufferHolder.set(bufferReference);
+    return buffer;
+  }
+
+  @Override
+  public void close() {
+    inUse = false;
+  }
+
+  private void setInUse() {
+    inUse = true;
+  }
+
+  private boolean isInUse() {
+    return inUse;
+  }
+
+  @Override
+  public T get() {
+    return array;
+  }
+}


### PR DESCRIPTION
This patch is to avoid unnecessary allocation of memory to create transfer-buffers to e.g. move data from an InputStream to an OutputStream by introducing a package-local class TransferBuffer to the com.google.io package. The code does not change the public API in any way. 

TransferBuffers provide to package-local static methods to obtain a TransferBuffer for byte- or char-arrays, TransferBuffer.getCharArrayTransferBuffer() and TransferBuffer.getByteArrayTransferBuffer(). These are being used to avoid memory-allocation in a couple of places in the com.google.io-package, 

The microbenchmarks show that avoiding buffer allocation yields a significant performance boost

| tested method | bytes copied | runtime (seconds) with patch | runtime (seconds) without patch | performance increase in % |
| --- | --- | --- | --- | --- |
| ByteStreams.copy | 10 | 105569 | 681130 | 545,2 |
| ByteStreams.copy | 100 | 107411 | 698152 | 549,98 |
| ByteStreams.copy | 10000 | 840354 | 1186307 | 41,17 |
| ByteStreams.readBytes | 10 | 68917 | 633365 | 819,03 |
| ByteStreams.readBytes | 100 | 69802 | 660336 | 846,01 |
| ByteStreams.readBytes | 10000 | 360357 | 934588 | 159,35 |
| ByteStreams.toByteArray | 10 | 122681 | 750095 | 511,42 |
| ByteStreams.toByteArray | 100 | 131705 | 773561 | 487,34 |
| ByteStreams.toByteArray | 10000 | 1962961 | 4962929 | 152,83 |
| ByteSource.contentEquals | 10 | 647140 | 3614650 | 458,56 |
| ByteSource.contentEquals | 100 | 685559 | 647694 | 453,81 |
| ByteSource.contentEquals | 10000 | 5987317 | 9460941 | 58,02 |

references

[ByteStreamsBenchmark w/ ThreadLocal](https://microbenchmarks.appspot.com/runs/087a68fc-af92-4971-97ae-346be17ee50b#r:scenario.benchmarkSpec.methodName,scenario.benchmarkSpec.parameters.n)
[ByteStreamsBenchmark w/out ThreadLocal](https://microbenchmarks.appspot.com/runs/dfb1c1b7-b9e2-431c-91f9-3be2f19db2a7#r:scenario.benchmarkSpec.methodName,scenario.benchmarkSpec.parameters.n)
[ByteSourceBenchmark w ThreadLocal](https://microbenchmarks.appspot.com/runs/f5517421-8f23-4237-9de1-f7d9e4c8f3ce#r:scenario.benchmarkSpec.parameters.n)
[ByteSourceBenchmark w/out ThreadLocal](https://microbenchmarks.appspot.com/runs/573ac1ff-a1e9-4870-9b0d-414e77e163e6#r:scenario.benchmarkSpec.parameters.n)

there had been a similar PR from me before, but I think it is worth reconsidering the new code, which is a re-write of the original idea.