### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
@@ -123,7 +123,6 @@ public class ByteSourceAsCharSourceReadBenchmark {
     data = ByteSource.wrap(string.getBytes(charset));
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public int timeCopy(int reps) throws IOException {
     int r = 0;

--- a/android/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
@@ -96,7 +96,6 @@ public class CharStreamsCopyBenchmark {
     data = sb.toString();
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeCopy(int reps) throws IOException {
     long r = 0;

--- a/android/guava-tests/benchmark/com/google/common/util/concurrent/SingleThreadAbstractFutureBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/util/concurrent/SingleThreadAbstractFutureBenchmark.java
@@ -99,7 +99,6 @@ public class SingleThreadAbstractFutureBenchmark {
     return r;
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeGetWith0Timeout(long reps) throws Exception {
     Facade<?> f = notDoneFuture;
@@ -115,7 +114,6 @@ public class SingleThreadAbstractFutureBenchmark {
     return r;
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeGetWithSmallTimeout(long reps) throws Exception {
     Facade<?> f = notDoneFuture;

--- a/android/guava/src/com/google/common/collect/SortedSetMultimap.java
+++ b/android/guava/src/com/google/common/collect/SortedSetMultimap.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -95,7 +96,11 @@ public interface SortedSetMultimap<K, V> extends SetMultimap<K, V> {
    *
    * <p><b>Note:</b> The returned map's values are guaranteed to be of type {@link SortedSet}. To
    * obtain this map with the more specific generic type {@code Map<K, SortedSet<V>>}, call {@link
-   * Multimaps#asMap(SortedSetMultimap)} instead.
+   * Multimaps#asMap(SortedSetMultimap)} instead. <b>However</b>, the returned map <i>itself</i> is
+   * not necessarily a {@link SortedMap}: A {@code SortedSetMultimap} must expose the <i>values</i>
+   * for a given key in sorted order, but it need not expose the <i>keys</i> in sorted order.
+   * Individual {@code SortedSetMultimap} implementations, like those built with {@link
+   * MultimapBuilder#treeKeys()}, may make additional guarantees.
    */
   @Override
   Map<K, Collection<V>> asMap();

--- a/android/guava/src/com/google/common/io/Closer.java
+++ b/android/guava/src/com/google/common/io/Closer.java
@@ -265,9 +265,9 @@ public final class Closer implements Closeable {
       return addSuppressed != null;
     }
 
-    static final Method addSuppressed = getAddSuppressed();
+    static final Method addSuppressed = addSuppressedMethodOrNull();
 
-    private static Method getAddSuppressed() {
+    private static Method addSuppressedMethodOrNull() {
       try {
         return Throwable.class.getMethod("addSuppressed", Throwable.class);
       } catch (Throwable e) {

--- a/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
@@ -123,7 +123,6 @@ public class ByteSourceAsCharSourceReadBenchmark {
     data = ByteSource.wrap(string.getBytes(charset));
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public int timeCopy(int reps) throws IOException {
     int r = 0;

--- a/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/CharStreamsCopyBenchmark.java
@@ -96,7 +96,6 @@ public class CharStreamsCopyBenchmark {
     data = sb.toString();
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeCopy(int reps) throws IOException {
     long r = 0;

--- a/guava-tests/benchmark/com/google/common/util/concurrent/SingleThreadAbstractFutureBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/util/concurrent/SingleThreadAbstractFutureBenchmark.java
@@ -99,7 +99,6 @@ public class SingleThreadAbstractFutureBenchmark {
     return r;
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeGetWith0Timeout(long reps) throws Exception {
     Facade<?> f = notDoneFuture;
@@ -115,7 +114,6 @@ public class SingleThreadAbstractFutureBenchmark {
     return r;
   }
 
-  @SuppressWarnings("GoodTime") // b/130759882
   @Benchmark
   public long timeGetWithSmallTimeout(long reps) throws Exception {
     Facade<?> f = notDoneFuture;

--- a/guava/src/com/google/common/collect/SortedSetMultimap.java
+++ b/guava/src/com/google/common/collect/SortedSetMultimap.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -95,7 +96,11 @@ public interface SortedSetMultimap<K, V> extends SetMultimap<K, V> {
    *
    * <p><b>Note:</b> The returned map's values are guaranteed to be of type {@link SortedSet}. To
    * obtain this map with the more specific generic type {@code Map<K, SortedSet<V>>}, call {@link
-   * Multimaps#asMap(SortedSetMultimap)} instead.
+   * Multimaps#asMap(SortedSetMultimap)} instead. <b>However</b>, the returned map <i>itself</i> is
+   * not necessarily a {@link SortedMap}: A {@code SortedSetMultimap} must expose the <i>values</i>
+   * for a given key in sorted order, but it need not expose the <i>keys</i> in sorted order.
+   * Individual {@code SortedSetMultimap} implementations, like those built with {@link
+   * MultimapBuilder#treeKeys()}, may make additional guarantees.
    */
   @Override
   Map<K, Collection<V>> asMap();

--- a/guava/src/com/google/common/io/Closer.java
+++ b/guava/src/com/google/common/io/Closer.java
@@ -265,9 +265,9 @@ public final class Closer implements Closeable {
       return addSuppressed != null;
     }
 
-    static final Method addSuppressed = getAddSuppressed();
+    static final Method addSuppressed = addSuppressedMethodOrNull();
 
-    private static Method getAddSuppressed() {
+    private static Method addSuppressedMethodOrNull() {
       try {
         return Throwable.class.getMethod("addSuppressed", Throwable.class);
       } catch (Throwable e) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Clarify that SortedSetMultimap exposes the values for a key in sorted order but does *not* necessarily expose the keys in sorted order.

09bf107763561ae37ddd99cf024d6c5604eedfff

-------

<p> Remove unneeded @SuppressWarnings from @Benchmark methods.

RELNOTES=none

3c3f7c9f7bfd997c5528a4ce7dd0c802c3aeb26f

-------

<p> Rename a method to avoid J2ObjC collisions

Prevent J2ObjC from treating `getAddSuppressed` as a getter by renaming it `generateAddSuppressed`. This silences a -Wobjc-property-implementation warning; soon, such warnings will become errors. See the referenced bug for full context.

cc5a55e487791db6ab2b7a98bcfd1be69d7a3638