### PR TITLE
Guava/consistent hash validate buckets

### DIFF
--- a/guava-tests/test/com/google/common/hash/HashingTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingTest.java
@@ -209,9 +209,17 @@ public class HashingTest extends TestCase {
   private static final int ITERS = 10000;
   private static final int MAX_SHARDS = 500;
 
-  public void testConsistentHash_outOfRange() {
+  public void testConsistentHash_lower_bound_outOfRange() {
     try {
       Hashing.consistentHash(5L, 0);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  public void testConsistentHash_upper_bound_outOfRange() {
+    try {
+      Hashing.consistentHash(5L, 981);
       fail();
     } catch (IllegalArgumentException expected) {
     }

--- a/guava/src/com/google/common/hash/Hashing.java
+++ b/guava/src/com/google/common/hash/Hashing.java
@@ -460,6 +460,8 @@ public final class Hashing {
    *
    * <p>See the <a href="http://en.wikipedia.org/wiki/Consistent_hashing">Wikipedia article on
    * consistent hashing</a> for more information.
+   *
+   * @throws IllegalArgumentException if {@code buckets} is less than 1 or greater than 980.
    */
   public static int consistentHash(HashCode hashCode, int buckets) {
     return consistentHash(hashCode.padToLong(), buckets);
@@ -495,9 +497,11 @@ public final class Hashing {
    *
    * <p>See the <a href="http://en.wikipedia.org/wiki/Consistent_hashing">Wikipedia article on
    * consistent hashing</a> for more information.
+   *
+   * @throws IllegalArgumentException if {@code buckets} is less than 1 or greater than 980.
    */
   public static int consistentHash(long input, int buckets) {
-    checkArgument(buckets > 0, "buckets must be positive: %s", buckets);
+    checkArgument(buckets > 0 && buckets < 981, "buckets must be from 1-980: %s", buckets);
     LinearCongruentialGenerator generator = new LinearCongruentialGenerator(input);
     int candidate = 0;
     int next;


### PR DESCRIPTION
This addresses issue https://github.com/google/guava/issues/3539.

I'm not sure whether this is undocumented (expected) behavior or a bug. But if it is a bug that should be fixed, we should document and alert users to the actual behavior pending a bug fix.