### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/base/Splitter.java
+++ b/android/guava/src/com/google/common/base/Splitter.java
@@ -331,13 +331,13 @@ public final class Splitter {
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
    *
-   * @param limit the maximum number of items returned
+   * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration
    * @since 9.0
    */
-  public Splitter limit(int limit) {
-    checkArgument(limit > 0, "must be greater than zero: %s", limit);
-    return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
+  public Splitter limit(int maxItems) {
+    checkArgument(maxItems > 0, "must be greater than zero: %s", maxItems);
+    return new Splitter(strategy, omitEmptyStrings, trimmer, maxItems);
   }
 
   /**

--- a/android/guava/src/com/google/common/io/ByteSource.java
+++ b/android/guava/src/com/google/common/io/ByteSource.java
@@ -215,10 +215,7 @@ public abstract class ByteSource {
     }
   }
 
-  /**
-   * Counts the bytes in the given input stream using skip if possible. Returns SKIP_FAILED if the
-   * first call to skip threw, in which case skip may just not be supported.
-   */
+  /** Counts the bytes in the given input stream using skip if possible. */
   private long countBySkipping(InputStream in) throws IOException {
     long count = 0;
     long skipped;

--- a/guava-gwt/test/com/google/common/collect/testModule.gwt.xml
+++ b/guava-gwt/test/com/google/common/collect/testModule.gwt.xml
@@ -11,7 +11,6 @@
   <inherits name="com.google.common.io.Io"/>
   <inherits name="com.google.common.testing.Testing"/>
   <inherits name="com.google.common.truth.Truth"/>
-  <inherits name="com.google.common.truth.Truth8"/>
   <entry-point class="com.google.common.collect.TestModuleEntryPoint"/>
    
   <source path=""/>

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -331,13 +331,13 @@ public final class Splitter {
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
    *
-   * @param limit the maximum number of items returned
+   * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration
    * @since 9.0
    */
-  public Splitter limit(int limit) {
-    checkArgument(limit > 0, "must be greater than zero: %s", limit);
-    return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
+  public Splitter limit(int maxItems) {
+    checkArgument(maxItems > 0, "must be greater than zero: %s", maxItems);
+    return new Splitter(strategy, omitEmptyStrings, trimmer, maxItems);
   }
 
   /**

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -215,10 +215,7 @@ public abstract class ByteSource {
     }
   }
 
-  /**
-   * Counts the bytes in the given input stream using skip if possible. Returns SKIP_FAILED if the
-   * first call to skip threw, in which case skip may just not be supported.
-   */
+  /** Counts the bytes in the given input stream using skip if possible. */
   private long countBySkipping(InputStream in) throws IOException {
     long count = 0;
     long skipped;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove inaccurate comment.

dabcfd49f7c6d57da4064832f2377e14df947604

-------

<p> Change the Splitter::limit arg to maxItems, for IDE usage.

The old name of `limit` was uninformative when presented in e.g. IDE autocompletions. `maxItems` will help distinguish it from the alternative meaning of max number of splits to make.

cb7a0f377ddf90a8466beac1b19d03c70539d310

-------

<p> Adjust testModule.gwt.xml due to an internal restructure of how truth targets are built.

ace42bca6f797245292e5cec9f442ebb30cb6dea