### PR TITLE
Add blockCancellation method to FluentFuture

### DIFF
--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -401,4 +401,15 @@ public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecializat
   public final void addCallback(FutureCallback<? super V> callback, Executor executor) {
     Futures.addCallback(this, callback, executor);
   }
+
+  /**
+   * Returns a {@code ListenableFuture} whose result is set from this future when it
+   * completes. Cancelling this future will also cancel the returned future, but cancelling
+   * the returned future will have no effect on this future.
+   *
+   * @since NEXT
+   */
+  public final FluentFuture<V> blockCancellation() {
+    return (FluentFuture<V>) Futures.nonCancellationPropagating(this);
+  }
 }


### PR DESCRIPTION
Maybe there is some reason that this wasn't originally included but it seems like a natural addition and would be handy for me at least.