### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/base/Splitter.java
+++ b/android/guava/src/com/google/common/base/Splitter.java
@@ -331,13 +331,13 @@ public final class Splitter {
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
    *
-   * @param limit the maximum number of items returned
+   * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration
    * @since 9.0
    */
-  public Splitter limit(int limit) {
-    checkArgument(limit > 0, "must be greater than zero: %s", limit);
-    return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
+  public Splitter limit(int maxItems) {
+    checkArgument(maxItems > 0, "must be greater than zero: %s", maxItems);
+    return new Splitter(strategy, omitEmptyStrings, trimmer, maxItems);
   }
 
   /**

--- a/android/guava/src/com/google/common/io/ByteSource.java
+++ b/android/guava/src/com/google/common/io/ByteSource.java
@@ -215,10 +215,7 @@ public abstract class ByteSource {
     }
   }
 
-  /**
-   * Counts the bytes in the given input stream using skip if possible. Returns SKIP_FAILED if the
-   * first call to skip threw, in which case skip may just not be supported.
-   */
+  /** Counts the bytes in the given input stream using skip if possible. */
   private long countBySkipping(InputStream in) throws IOException {
     long count = 0;
     long skipped;

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -242,6 +242,20 @@ public final class MediaType {
    */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
+  /**
+   * <a href="https://www.iana.org/assignments/media-types/image/heif">HEIF image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType HEIF = createConstant(IMAGE_TYPE, "heif");
+
+  /**
+   * <a href="https://tools.ietf.org/html/rfc3745">JP2K image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType JP2K = createConstant(IMAGE_TYPE, "jp2");
+
   /* audio types */
   public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
   public static final MediaType MPEG_AUDIO = createConstant(AUDIO_TYPE, "mpeg");

--- a/guava-gwt/test/com/google/common/collect/testModule.gwt.xml
+++ b/guava-gwt/test/com/google/common/collect/testModule.gwt.xml
@@ -11,7 +11,6 @@
   <inherits name="com.google.common.io.Io"/>
   <inherits name="com.google.common.testing.Testing"/>
   <inherits name="com.google.common.truth.Truth"/>
-  <inherits name="com.google.common.truth.Truth8"/>
   <entry-point class="com.google.common.collect.TestModuleEntryPoint"/>
    
   <source path=""/>

--- a/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
@@ -185,8 +185,9 @@ public final class SpliteratorTester<E> {
     return new Ordered() {
       @Override
       public void inOrder() {
-        resultsForAllStrategies.forEach(
-            resultsForStrategy -> assertEqualInOrder(elements, resultsForStrategy));
+        for (List<E> resultsForStrategy : resultsForAllStrategies) {
+          assertEqualInOrder(elements, resultsForStrategy);
+        }
       }
     };
   }

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -331,13 +331,13 @@ public final class Splitter {
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
    *
-   * @param limit the maximum number of items returned
+   * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration
    * @since 9.0
    */
-  public Splitter limit(int limit) {
-    checkArgument(limit > 0, "must be greater than zero: %s", limit);
-    return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
+  public Splitter limit(int maxItems) {
+    checkArgument(maxItems > 0, "must be greater than zero: %s", maxItems);
+    return new Splitter(strategy, omitEmptyStrings, trimmer, maxItems);
   }
 
   /**

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -215,10 +215,7 @@ public abstract class ByteSource {
     }
   }
 
-  /**
-   * Counts the bytes in the given input stream using skip if possible. Returns SKIP_FAILED if the
-   * first call to skip threw, in which case skip may just not be supported.
-   */
+  /** Counts the bytes in the given input stream using skip if possible. */
   private long countBySkipping(InputStream in) throws IOException {
     long count = 0;
     long skipped;

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -242,6 +242,20 @@ public final class MediaType {
    */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
+  /**
+   * <a href="https://www.iana.org/assignments/media-types/image/heif">HEIF image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType HEIF = createConstant(IMAGE_TYPE, "heif");
+
+  /**
+   * <a href="https://tools.ietf.org/html/rfc3745">JP2K image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType JP2K = createConstant(IMAGE_TYPE, "jp2");
+
   /* audio types */
   public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
   public static final MediaType MPEG_AUDIO = createConstant(AUDIO_TYPE, "mpeg");


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove inaccurate comment.

2cc9ccd8f58402927f4903ebf40f19a63f47c789

-------

<p> Change the Splitter::limit arg to maxItems, for IDE usage.

The old name of `limit` was uninformative when presented in e.g. IDE autocompletions. `maxItems` will help distinguish it from the alternative meaning of max number of splits to make.

013d0f1b058f7c6e3ac159745fcead5f481f5b66

-------

<p> gwt.xml change from internal change.

a13896bd6b55883dbe1f4ae71603597f3831a89d

-------

<p> Add MediaType for "image/heif" and "image/jp2"

RELNOTES=Add MediaType for "image/heif" and "image/jp2"

4c70d7f3c3083946aa74e59098b51f521da27239

-------

<p> Change a use of Iterable.forEach, which isn't available under Desugar.

6508a374b7483ea2ec7f5170b94489cb9dc3537d