### PR TITLE
Remove usages of deprecated CharMatcher functions

### DIFF
--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -242,6 +242,20 @@ public final class MediaType {
    */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
+  /**
+   * <a href="https://www.iana.org/assignments/media-types/image/heif">HEIF image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType HEIF = createConstant(IMAGE_TYPE, "heif");
+
+  /**
+   * <a href="https://tools.ietf.org/html/rfc3745">JP2K image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType JP2K = createConstant(IMAGE_TYPE, "jp2");
+
   /* audio types */
   public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
   public static final MediaType MPEG_AUDIO = createConstant(AUDIO_TYPE, "mpeg");

--- a/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
@@ -185,8 +185,9 @@ public final class SpliteratorTester<E> {
     return new Ordered() {
       @Override
       public void inOrder() {
-        resultsForAllStrategies.forEach(
-            resultsForStrategy -> assertEqualInOrder(elements, resultsForStrategy));
+        for (List<E> resultsForStrategy : resultsForAllStrategies) {
+          assertEqualInOrder(elements, resultsForStrategy);
+        }
       }
     };
   }

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -242,6 +242,20 @@ public final class MediaType {
    */
   public static final MediaType WEBP = createConstant(IMAGE_TYPE, "webp");
 
+  /**
+   * <a href="https://www.iana.org/assignments/media-types/image/heif">HEIF image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType HEIF = createConstant(IMAGE_TYPE, "heif");
+
+  /**
+   * <a href="https://tools.ietf.org/html/rfc3745">JP2K image format</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType JP2K = createConstant(IMAGE_TYPE, "jp2");
+
   /* audio types */
   public static final MediaType MP4_AUDIO = createConstant(AUDIO_TYPE, "mp4");
   public static final MediaType MPEG_AUDIO = createConstant(AUDIO_TYPE, "mpeg");


### PR DESCRIPTION
Methods like charMatcher.digit() or javaLetterDigit() which would match digit and digit or letters in string is being deprecated by guava. Such methods are replace by inRange methods. For example, instead of digit(), it would be inRange('0', '9').

This PR closes #3544.
