### PR TITLE
Fix https://github.com/google/guava/issues/3570

### DIFF
--- a/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
@@ -582,4 +582,12 @@ public class ImmutableSetTest extends AbstractImmutableSetTest {
     }
     return worstCalls;
   }
+
+  public void testReuseBuilderReducingHashTableSizeWithPowerOfTwoTotalElements() {
+    final ImmutableSet.Builder<Object> builder = ImmutableSet.builderWithExpectedSize(6);
+    builder.add(0);
+    builder.build();
+    final ImmutableSet<Object> subject = builder.add(1).add(2).add(3).build();
+    assertFalse(subject.contains(4));
+  }
 }

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -811,8 +811,10 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
     @Override
     SetBuilderImpl<E> review() {
       int targetTableSize = chooseTableSize(distinct);
-      if (targetTableSize * 2 < hashTable.length) {
+      if (targetTableSize * 2 < hashTable.length ) {
         hashTable = rebuildHashTable(targetTableSize, dedupedElements, distinct);
+        expandTableThreshold = (int) (DESIRED_LOAD_FACTOR * targetTableSize);
+        maxRunBeforeFallback = maxRunBeforeFallback(targetTableSize);
       }
       return hashFloodingDetected(hashTable) ? new JdkBackedSetBuilderImpl<E>(this) : this;
     }


### PR DESCRIPTION
Fix https://github.com/google/guava/issues/3570 by resetting expandTableThreshold and maxRunBeforeFallback after resizing the hashTable. Unit test included: testReuseBuilderReducingHashTableSizeWithPowerOfTwoTotalElements