### PR TITLE
Allow for names that have labels starting with underscore

### DIFF
--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -282,7 +282,12 @@ public final class InternetDomainName {
       return false;
     }
 
-    // non-final labels may start with a underscore but not end with a dash or underscore.
+    /* 
+     * non-final labels can start with an underscore but not with a dash.
+     * The label is not allowed to end with a dash or underscore.
+     * This will allow parsing of DKIM (https://tools.ietf.org/html/rfc6376) names
+    */
+
     if (DASH_MATCHER_ACTUAL.matches(part.charAt(0))
         || DASH_MATCHER.matches(part.charAt(part.length() - 1))) {
       return false;

--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -235,6 +235,8 @@ public final class InternetDomainName {
     return true;
   }
 
+  private static final CharMatcher DASH_MATCHER_ACTUAL = CharMatcher.anyOf("-");
+
   private static final CharMatcher DASH_MATCHER = CharMatcher.anyOf("-_");
 
   private static final CharMatcher PART_CHAR_MATCHER =
@@ -273,9 +275,15 @@ public final class InternetDomainName {
       return false;
     }
 
-    // No initial or final dashes or underscores.
+     
+    // last label may not start with dash and not end with dah or underscore.
+    if (isFinalPart && DASH_MATCHER_ACTUAL.matches(part.charAt(0))
+        || DASH_MATCHER.matches(part.charAt(part.length() - 1))) {
+      return false;
+    }
 
-    if (DASH_MATCHER.matches(part.charAt(0))
+    // non-final labels my start with a dash but not end with a dash or underscore.
+    if (DASH_MATCHER_ACTUAL.matches(part.charAt(0))
         || DASH_MATCHER.matches(part.charAt(part.length() - 1))) {
       return false;
     }

--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -276,13 +276,13 @@ public final class InternetDomainName {
     }
 
      
-    // last label may not start with dash and not end with dah or underscore.
-    if (isFinalPart && DASH_MATCHER_ACTUAL.matches(part.charAt(0))
+    // final label may not start or end with dash or underscore.
+    if (isFinalPart && DASH_MATCHER.matches(part.charAt(0))
         || DASH_MATCHER.matches(part.charAt(part.length() - 1))) {
       return false;
     }
 
-    // non-final labels my start with a dash but not end with a dash or underscore.
+    // non-final labels may start with a underscore but not end with a dash or underscore.
     if (DASH_MATCHER_ACTUAL.matches(part.charAt(0))
         || DASH_MATCHER.matches(part.charAt(part.length() - 1))) {
       return false;


### PR DESCRIPTION
This fix allows for names that have labels starting with underscore, this is useful for parsing names that have non-final labels that start with an underscore.

multiple protocols use this naming scheme, such a DKIM, which uses _domainkey labels.
see: https://tools.ietf.org/html/rfc6376