### PR TITLE
Remove @Beta: Immutable{BiMap,List,Map,Set}.builderWithExpectedSize

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -132,7 +132,6 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableBiMapFauxverideShim<
    *
    * @since 23.1
    */
-  @Beta
   public static <K, V> Builder<K, V> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
     return new Builder<>(expectedSize);

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -719,7 +719,6 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    *
    * @since 23.1
    */
-  @Beta
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
     return new ImmutableList.Builder<E>(expectedSize);

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -196,7 +196,6 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    *
    * @since 23.1
    */
-  @Beta
   public static <K, V> Builder<K, V> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
     return new Builder<>(expectedSize);

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -430,7 +430,6 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    *
    * @since 23.1
    */
-  @Beta
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
     return new Builder<E>(expectedSize);


### PR DESCRIPTION
Previously, I modified Dagger so that its generated code is using
`builderWithExpectedSize` for immutable collections whenever it's
available, i.e., Guava 23.1 or later:
https://github.com/google/dagger/pull/1094

Since `builderWithExpectedSize` is a @Beta API, if a Bazel client
project depends on Dagger, and if the depended Dagger is using
Guava 23.1 or later, Dagger generates code that uses this Guava
@Beta API, which fails ErrorProne, thus failing Bazel build:
https://github.com/google/dagger/issues/1569

The same issue could also happen if a Maven client project has a
`maven-compiler-plugin` that also uses ErrorProne.

If the Guava team feel confident about those
`builderWithExpectedSize` static factory methods, maybe it's time
to remove `@Beta` for them altogether.

Happy to discuss.  Thank you!

Reference:
https://github.com/google/guava/wiki/PhilosophyExplained#beta-apis