### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -526,6 +526,8 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * Creates a {@link FutureCombiner} that processes the completed futures whether or not they're
    * successful.
    *
+   * <p>Any failures from the input futures will not be propagated to the returned future.
+   *
    * @since 20.0
    */
   @Beta
@@ -537,6 +539,8 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   /**
    * Creates a {@link FutureCombiner} that processes the completed futures whether or not they're
    * successful.
+   *
+   * <p>Any failures from the input futures will not be propagated to the returned future.
    *
    * @since 20.0
    */

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -559,6 +559,8 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * Creates a {@link FutureCombiner} that processes the completed futures whether or not they're
    * successful.
    *
+   * <p>Any failures from the input futures will not be propagated to the returned future.
+   *
    * @since 20.0
    */
   @Beta
@@ -570,6 +572,8 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   /**
    * Creates a {@link FutureCombiner} that processes the completed futures whether or not they're
    * successful.
+   *
+   * <p>Any failures from the input futures will not be propagated to the returned future.
    *
    * @since 20.0
    */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Explicitly document that whenAllComplete will swallow failures (in contrast to waiting for all futures to complete and then propagating the first failure).

98971ae01e62ed36f99c8bb5c4e897eac8cb1988