### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
@@ -375,8 +375,7 @@ public final class DerivedCollectionGenerators {
 
     @Override
     public SortedSet<E> create(Object... elements) {
-      @SuppressWarnings("unchecked") // set generators must pass SampleElements values
-      List<E> normalValues = (List) Arrays.asList(elements);
+      List<?> normalValues = (List<?>) Arrays.asList(elements);
       List<E> extremeValues = new ArrayList<>();
 
       // nulls are usually out of bounds for a subset, so ban them altogether
@@ -399,12 +398,12 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<E> allEntries = new ArrayList<>();
+      List<Object> allEntries = new ArrayList<>();
       allEntries.addAll(extremeValues);
       allEntries.addAll(normalValues);
-      SortedSet<E> map = delegate.create(allEntries.toArray());
+      SortedSet<E> set = delegate.create(allEntries.toArray());
 
-      return createSubSet(map, firstExclusive, lastExclusive);
+      return createSubSet(set, firstExclusive, lastExclusive);
     }
 
     /** Calls the smallest subSet overload that filters out the extreme values. */
@@ -474,8 +473,6 @@ public final class DerivedCollectionGenerators {
 
     @Override
     public SortedMap<K, V> create(Object... entries) {
-      @SuppressWarnings("unchecked") // map generators must past entry objects
-      List<Entry<K, V>> normalValues = (List) Arrays.asList(entries);
       List<Entry<K, V>> extremeValues = new ArrayList<>();
 
       // prepare extreme values to be filtered out of view
@@ -491,12 +488,12 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<Entry<K, V>> allEntries = new ArrayList<>();
+      List<Entry<?, ?>> allEntries = new ArrayList<>();
       allEntries.addAll(extremeValues);
-      allEntries.addAll(normalValues);
-      SortedMap<K, V> map =
-          (SortedMap<K, V>)
-              delegate.create((Object[]) allEntries.toArray(new Entry<?, ?>[allEntries.size()]));
+      for (Object entry : entries) {
+        allEntries.add((Entry<?, ?>) entry);
+      }
+      SortedMap<K, V> map = (SortedMap<K, V>) delegate.create(allEntries.toArray());
 
       return createSubMap(map, firstExclusive, lastExclusive);
     }

--- a/android/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
@@ -168,10 +168,10 @@ public class SortedMultisetTestSuiteBuilder<E> extends MultisetTestSuiteBuilder<
               public SortedMultiset<E> create(Object... entries) {
                 @SuppressWarnings("unchecked")
                 // we dangerously assume E is a string
-                List<E> extremeValues = (List) getExtremeValues();
+                List<E> extremeValues = (List<E>) getExtremeValues();
                 @SuppressWarnings("unchecked")
                 // map generators must past entry objects
-                List<E> normalValues = (List) Arrays.asList(entries);
+                List<E> normalValues = (List<E>) Arrays.asList(entries);
 
                 // prepare extreme values to be filtered out of view
                 Collections.sort(extremeValues, comparator);

--- a/android/guava-tests/test/com/google/common/base/OptionalTest.java
+++ b/android/guava-tests/test/com/google/common/base/OptionalTest.java
@@ -288,7 +288,7 @@ public final class OptionalTest extends TestCase {
     // Sadly, the following is what users will have to do in some circumstances.
 
     @SuppressWarnings("unchecked") // safe covariant cast
-    Optional<Number> first = (Optional) numbers.first();
+    Optional<Number> first = (Optional<Number>) numbers.first();
     Number value = first.or(0.5); // fine
   }
 

--- a/android/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/android/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -393,7 +393,7 @@ class CacheTesting {
 
       ReferenceEntry<?, ?> originalHead = segment.accessQueue.peek();
       @SuppressWarnings("unchecked")
-      ReferenceEntry<Integer, Integer> entry = (ReferenceEntry) originalHead;
+      ReferenceEntry<Integer, Integer> entry = (ReferenceEntry<Integer, Integer>) originalHead;
       operation.accept(entry);
       drainRecencyQueue(segment);
 

--- a/android/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -2413,7 +2413,7 @@ public class LocalCacheTest extends TestCase {
         ReferenceEntry<Object, Object> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -2443,7 +2443,7 @@ public class LocalCacheTest extends TestCase {
         ValueReference<Object, Object> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -2471,7 +2471,7 @@ public class LocalCacheTest extends TestCase {
         ReferenceEntry<Object, Object> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {
@@ -2502,7 +2502,7 @@ public class LocalCacheTest extends TestCase {
         ValueReference<Object, Object> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {

--- a/android/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
@@ -845,7 +845,7 @@ public class MapMakerInternalMapTest extends TestCase {
         InternalEntry<Object, Object, ?> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -877,7 +877,7 @@ public class MapMakerInternalMapTest extends TestCase {
         WeakValueReference<Object, Object, ?> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -905,7 +905,7 @@ public class MapMakerInternalMapTest extends TestCase {
         InternalEntry<Object, Object, ?> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {
@@ -938,7 +938,7 @@ public class MapMakerInternalMapTest extends TestCase {
         WeakValueReference<Object, Object, ?> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {

--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
@@ -42,7 +42,7 @@ import junit.framework.TestCase;
  */
 public class AbstractServiceTest extends TestCase {
 
-  private static final long LONG_TIMEOUT_MILLIS = 2500;
+  private static final long LONG_TIMEOUT_MILLIS = 10000;
   private Thread executionThread;
   private Throwable thrownByExecutionThread;
 

--- a/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -608,7 +608,7 @@ public class ServiceManagerTest extends TestCase {
       }
       ServiceManager manager = new ServiceManager(services);
       manager.startAsync().awaitHealthy();
-      manager.stopAsync().awaitStopped(1, TimeUnit.SECONDS);
+      manager.stopAsync().awaitStopped(10, TimeUnit.SECONDS);
     }
   }
 

--- a/android/guava-tests/test/com/google/common/util/concurrent/SimpleTimeLimiterTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/SimpleTimeLimiterTest.java
@@ -38,7 +38,7 @@ import junit.framework.TestCase;
 public class SimpleTimeLimiterTest extends TestCase {
 
   private static final long DELAY_MS = 50;
-  private static final long ENOUGH_MS = 500;
+  private static final long ENOUGH_MS = 10000;
   private static final long NOT_ENOUGH_MS = 5;
 
   private static final String GOOD_CALLABLE_RESULT = "good callable result";

--- a/android/guava-tests/test/com/google/common/util/concurrent/UninterruptibleFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/UninterruptibleFutureTest.java
@@ -97,7 +97,7 @@ public class UninterruptibleFutureTest extends TestCase {
 
     assertFalse(Thread.interrupted());
     try {
-      delayedFuture.get(10000, TimeUnit.MILLISECONDS);
+      delayedFuture.get(20000, TimeUnit.MILLISECONDS);
       fail("expected to be interrupted");
     } catch (InterruptedException expected) {
     } catch (TimeoutException e) {

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -3584,7 +3584,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean remove(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       ReferenceEntry<K, V> previous = e.getPreviousInWriteQueue();
       ReferenceEntry<K, V> next = e.getNextInWriteQueue();
       connectWriteOrder(previous, next);
@@ -3596,7 +3596,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean contains(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       return e.getNextInWriteQueue() != NullEntry.INSTANCE;
     }
 
@@ -3723,7 +3723,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean remove(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       ReferenceEntry<K, V> previous = e.getPreviousInAccessQueue();
       ReferenceEntry<K, V> next = e.getNextInAccessQueue();
       connectAccessOrder(previous, next);
@@ -3735,7 +3735,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean contains(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       return e.getNextInAccessQueue() != NullEntry.INSTANCE;
     }
 

--- a/android/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
@@ -151,8 +151,7 @@ public final class ImmutableClassToInstanceMap<B> extends ForwardingMap<Class<? 
       Map<? extends Class<? extends S>, ? extends S> map) {
     if (map instanceof ImmutableClassToInstanceMap) {
       @SuppressWarnings("unchecked") // covariant casts safe (unmodifiable)
-      // Eclipse won't compile if we cast to the parameterized type.
-      ImmutableClassToInstanceMap<B> cast = (ImmutableClassToInstanceMap) map;
+      ImmutableClassToInstanceMap<B> cast = (ImmutableClassToInstanceMap<B>) map;
       return cast;
     }
     return new Builder<B>().putAll(map).build();

--- a/android/guava/src/com/google/common/collect/Maps.java
+++ b/android/guava/src/com/google/common/collect/Maps.java
@@ -3115,7 +3115,7 @@ public final class Maps {
     checkNotNull(map);
     if (map instanceof UnmodifiableNavigableMap) {
       @SuppressWarnings("unchecked") // covariant
-      NavigableMap<K, V> result = (NavigableMap) map;
+      NavigableMap<K, V> result = (NavigableMap<K, V>) map;
       return result;
     } else {
       return new UnmodifiableNavigableMap<>(map);

--- a/android/guava/src/com/google/common/collect/Multisets.java
+++ b/android/guava/src/com/google/common/collect/Multisets.java
@@ -1024,7 +1024,7 @@ public final class Multisets {
         if (entryCount != 0) {
           // Safe as long as we never add a new entry, which we won't.
           @SuppressWarnings("unchecked")
-          Multiset<Object> multiset = (Multiset) multiset();
+          Multiset<Object> multiset = (Multiset<Object>) multiset();
           return multiset.setCount(element, entryCount, 0);
         }
       }

--- a/android/guava/src/com/google/common/collect/TreeBasedTable.java
+++ b/android/guava/src/com/google/common/collect/TreeBasedTable.java
@@ -196,8 +196,8 @@ public class TreeBasedTable<R, C, V> extends StandardRowSortedTable<R, C, V> {
 
     int compare(Object a, Object b) {
       // pretend we can compare anything
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Comparator<Object> cmp = (Comparator) comparator();
+      @SuppressWarnings("unchecked")
+      Comparator<Object> cmp = (Comparator<Object>) comparator();
       return cmp.compare(a, b);
     }
 

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.CollectionFuture.ListFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateCancelledFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateFailedFuture;
-import com.google.common.util.concurrent.ImmediateFuture.ImmediateSuccessfulFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
 import java.util.List;
@@ -125,12 +124,12 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V> ListenableFuture<V> immediateFuture(@NullableDecl V value) {
     if (value == null) {
-      // This cast is safe because null is assignable to V for all V (i.e. it is covariant)
-      @SuppressWarnings({"unchecked", "rawtypes"})
-      ListenableFuture<V> typedNull = (ListenableFuture) ImmediateSuccessfulFuture.NULL;
+      // This cast is safe because null is assignable to V for all V (i.e. it is bivariant)
+      @SuppressWarnings("unchecked")
+      ListenableFuture<V> typedNull = (ListenableFuture<V>) ImmediateFuture.NULL;
       return typedNull;
     }
-    return new ImmediateSuccessfulFuture<V>(value);
+    return new ImmediateFuture<>(value);
   }
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.CollectionFuture.ListFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateCancelledFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateFailedFuture;
+import com.google.common.util.concurrent.ImmediateFuture.ImmediateSuccessfulFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
 import java.util.List;
@@ -124,12 +125,12 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V> ListenableFuture<V> immediateFuture(@NullableDecl V value) {
     if (value == null) {
-      // This cast is safe because null is assignable to V for all V (i.e. it is bivariant)
-      @SuppressWarnings("unchecked")
-      ListenableFuture<V> typedNull = (ListenableFuture<V>) ImmediateFuture.NULL;
+      // This cast is safe because null is assignable to V for all V (i.e. it is covariant)
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      ListenableFuture<V> typedNull = (ListenableFuture) ImmediateSuccessfulFuture.NULL;
       return typedNull;
     }
-    return new ImmediateFuture<>(value);
+    return new ImmediateSuccessfulFuture<V>(value);
   }
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,10 +25,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
-/** Implementations of {@code Futures.immediate*}. */
+/** Implementation of {@link Futures#immediateFuture}. */
 @GwtCompatible
-abstract class ImmediateFuture<V> implements ListenableFuture<V> {
+// TODO(cpovirk): Make this final (but that may break Mockito spy calls).
+class ImmediateFuture<V> implements ListenableFuture<V> {
+  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
+
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
+
+  @NullableDecl private final V value;
+
+  ImmediateFuture(@NullableDecl V value) {
+    this.value = value;
+  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -51,8 +60,11 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
+  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public abstract V get() throws ExecutionException;
+  public V get() {
+    return value;
+  }
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -70,25 +82,10 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
-    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
-    @NullableDecl private final V value;
-
-    ImmediateSuccessfulFuture(@NullableDecl V value) {
-      this.value = value;
-    }
-
-    // TODO(lukes): Consider throwing InterruptedException when appropriate.
-    @Override
-    public V get() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      // Behaviour analogous to AbstractFuture#toString().
-      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
-    }
+  @Override
+  public String toString() {
+    // Behaviour analogous to AbstractFuture#toString().
+    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {

--- a/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,10 +25,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
-/** Implementations of {@code Futures.immediate*}. */
+/** Implementation of {@link Futures#immediateFuture}. */
 @GwtCompatible
-abstract class ImmediateFuture<V> implements ListenableFuture<V> {
+final class ImmediateFuture<V> implements ListenableFuture<V> {
+  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
+
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
+
+  @NullableDecl private final V value;
+
+  ImmediateFuture(@NullableDecl V value) {
+    this.value = value;
+  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -51,8 +59,11 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
+  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public abstract V get() throws ExecutionException;
+  public V get() {
+    return value;
+  }
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -70,25 +81,10 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
-    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
-    @NullableDecl private final V value;
-
-    ImmediateSuccessfulFuture(@NullableDecl V value) {
-      this.value = value;
-    }
-
-    // TODO(lukes): Consider throwing InterruptedException when appropriate.
-    @Override
-    public V get() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      // Behaviour analogous to AbstractFuture#toString().
-      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
-    }
+  @Override
+  public String toString() {
+    // Behaviour analogous to AbstractFuture#toString().
+    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {

--- a/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,18 +25,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
-/** Implementation of {@link Futures#immediateFuture}. */
+/** Implementations of {@code Futures.immediate*}. */
 @GwtCompatible
-final class ImmediateFuture<V> implements ListenableFuture<V> {
-  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
-
+abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
-
-  @NullableDecl private final V value;
-
-  ImmediateFuture(@NullableDecl V value) {
-    this.value = value;
-  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -59,11 +51,8 @@ final class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
-  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public V get() {
-    return value;
-  }
+  public abstract V get() throws ExecutionException;
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -81,10 +70,25 @@ final class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  @Override
-  public String toString() {
-    // Behaviour analogous to AbstractFuture#toString().
-    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
+  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
+    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
+    @NullableDecl private final V value;
+
+    ImmediateSuccessfulFuture(@NullableDecl V value) {
+      this.value = value;
+    }
+
+    // TODO(lukes): Consider throwing InterruptedException when appropriate.
+    @Override
+    public V get() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      // Behaviour analogous to AbstractFuture#toString().
+      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
+    }
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {

--- a/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
+++ b/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
@@ -375,8 +375,7 @@ public final class DerivedCollectionGenerators {
 
     @Override
     public SortedSet<E> create(Object... elements) {
-      @SuppressWarnings("unchecked") // set generators must pass SampleElements values
-      List<E> normalValues = (List) Arrays.asList(elements);
+      List<?> normalValues = (List<?>) Arrays.asList(elements);
       List<E> extremeValues = new ArrayList<>();
 
       // nulls are usually out of bounds for a subset, so ban them altogether
@@ -399,12 +398,12 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<E> allEntries = new ArrayList<>();
+      List<Object> allEntries = new ArrayList<>();
       allEntries.addAll(extremeValues);
       allEntries.addAll(normalValues);
-      SortedSet<E> map = delegate.create(allEntries.toArray());
+      SortedSet<E> set = delegate.create(allEntries.toArray());
 
-      return createSubSet(map, firstExclusive, lastExclusive);
+      return createSubSet(set, firstExclusive, lastExclusive);
     }
 
     /** Calls the smallest subSet overload that filters out the extreme values. */
@@ -474,8 +473,6 @@ public final class DerivedCollectionGenerators {
 
     @Override
     public SortedMap<K, V> create(Object... entries) {
-      @SuppressWarnings("unchecked") // map generators must past entry objects
-      List<Entry<K, V>> normalValues = (List) Arrays.asList(entries);
       List<Entry<K, V>> extremeValues = new ArrayList<>();
 
       // prepare extreme values to be filtered out of view
@@ -491,12 +488,12 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<Entry<K, V>> allEntries = new ArrayList<>();
+      List<Entry<?, ?>> allEntries = new ArrayList<>();
       allEntries.addAll(extremeValues);
-      allEntries.addAll(normalValues);
-      SortedMap<K, V> map =
-          (SortedMap<K, V>)
-              delegate.create((Object[]) allEntries.toArray(new Entry<?, ?>[allEntries.size()]));
+      for (Object entry : entries) {
+        allEntries.add((Entry<?, ?>) entry);
+      }
+      SortedMap<K, V> map = (SortedMap<K, V>) delegate.create(allEntries.toArray());
 
       return createSubMap(map, firstExclusive, lastExclusive);
     }

--- a/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
@@ -168,10 +168,10 @@ public class SortedMultisetTestSuiteBuilder<E> extends MultisetTestSuiteBuilder<
               public SortedMultiset<E> create(Object... entries) {
                 @SuppressWarnings("unchecked")
                 // we dangerously assume E is a string
-                List<E> extremeValues = (List) getExtremeValues();
+                List<E> extremeValues = (List<E>) getExtremeValues();
                 @SuppressWarnings("unchecked")
                 // map generators must past entry objects
-                List<E> normalValues = (List) Arrays.asList(entries);
+                List<E> normalValues = (List<E>) Arrays.asList(entries);
 
                 // prepare extreme values to be filtered out of view
                 Collections.sort(extremeValues, comparator);

--- a/guava-tests/test/com/google/common/base/OptionalTest.java
+++ b/guava-tests/test/com/google/common/base/OptionalTest.java
@@ -305,7 +305,7 @@ public final class OptionalTest extends TestCase {
     // Sadly, the following is what users will have to do in some circumstances.
 
     @SuppressWarnings("unchecked") // safe covariant cast
-    Optional<Number> first = (Optional) numbers.first();
+    Optional<Number> first = (Optional<Number>) numbers.first();
     Number value = first.or(0.5); // fine
   }
 

--- a/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -393,7 +393,7 @@ class CacheTesting {
 
       ReferenceEntry<?, ?> originalHead = segment.accessQueue.peek();
       @SuppressWarnings("unchecked")
-      ReferenceEntry<Integer, Integer> entry = (ReferenceEntry) originalHead;
+      ReferenceEntry<Integer, Integer> entry = (ReferenceEntry<Integer, Integer>) originalHead;
       operation.accept(entry);
       drainRecencyQueue(segment);
 

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -2462,7 +2462,7 @@ public class LocalCacheTest extends TestCase {
         ReferenceEntry<Object, Object> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -2492,7 +2492,7 @@ public class LocalCacheTest extends TestCase {
         ValueReference<Object, Object> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -2520,7 +2520,7 @@ public class LocalCacheTest extends TestCase {
         ReferenceEntry<Object, Object> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {
@@ -2551,7 +2551,7 @@ public class LocalCacheTest extends TestCase {
         ValueReference<Object, Object> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {

--- a/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
+++ b/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
@@ -845,7 +845,7 @@ public class MapMakerInternalMapTest extends TestCase {
         InternalEntry<Object, Object, ?> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -877,7 +877,7 @@ public class MapMakerInternalMapTest extends TestCase {
         WeakValueReference<Object, Object, ?> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         map.put(keyTwo, valueTwo);
@@ -905,7 +905,7 @@ public class MapMakerInternalMapTest extends TestCase {
         InternalEntry<Object, Object, ?> entry = segment.getEntry(keyOne, hashOne);
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) entry;
+        Reference<Object> reference = (Reference<Object>) entry;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {
@@ -938,7 +938,7 @@ public class MapMakerInternalMapTest extends TestCase {
         WeakValueReference<Object, Object, ?> valueReference = entry.getValueReference();
 
         @SuppressWarnings("unchecked")
-        Reference<Object> reference = (Reference) valueReference;
+        Reference<Object> reference = (Reference<Object>) valueReference;
         reference.enqueue();
 
         for (int i = 0; i < SMALL_MAX_SIZE; i++) {

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractServiceTest.java
@@ -42,7 +42,7 @@ import junit.framework.TestCase;
  */
 public class AbstractServiceTest extends TestCase {
 
-  private static final long LONG_TIMEOUT_MILLIS = 2500;
+  private static final long LONG_TIMEOUT_MILLIS = 10000;
   private Thread executionThread;
   private Throwable thrownByExecutionThread;
 

--- a/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -608,7 +608,7 @@ public class ServiceManagerTest extends TestCase {
       }
       ServiceManager manager = new ServiceManager(services);
       manager.startAsync().awaitHealthy();
-      manager.stopAsync().awaitStopped(1, TimeUnit.SECONDS);
+      manager.stopAsync().awaitStopped(10, TimeUnit.SECONDS);
     }
   }
 

--- a/guava-tests/test/com/google/common/util/concurrent/SimpleTimeLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/SimpleTimeLimiterTest.java
@@ -38,7 +38,7 @@ import junit.framework.TestCase;
 public class SimpleTimeLimiterTest extends TestCase {
 
   private static final long DELAY_MS = 50;
-  private static final long ENOUGH_MS = 500;
+  private static final long ENOUGH_MS = 10000;
   private static final long NOT_ENOUGH_MS = 5;
 
   private static final String GOOD_CALLABLE_RESULT = "good callable result";

--- a/guava-tests/test/com/google/common/util/concurrent/UninterruptibleFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/UninterruptibleFutureTest.java
@@ -97,7 +97,7 @@ public class UninterruptibleFutureTest extends TestCase {
 
     assertFalse(Thread.interrupted());
     try {
-      delayedFuture.get(10000, TimeUnit.MILLISECONDS);
+      delayedFuture.get(20000, TimeUnit.MILLISECONDS);
       fail("expected to be interrupted");
     } catch (InterruptedException expected) {
     } catch (TimeoutException e) {

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -3687,7 +3687,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean remove(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       ReferenceEntry<K, V> previous = e.getPreviousInWriteQueue();
       ReferenceEntry<K, V> next = e.getNextInWriteQueue();
       connectWriteOrder(previous, next);
@@ -3699,7 +3699,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean contains(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       return e.getNextInWriteQueue() != NullEntry.INSTANCE;
     }
 
@@ -3826,7 +3826,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean remove(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       ReferenceEntry<K, V> previous = e.getPreviousInAccessQueue();
       ReferenceEntry<K, V> next = e.getNextInAccessQueue();
       connectAccessOrder(previous, next);
@@ -3838,7 +3838,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     @Override
     @SuppressWarnings("unchecked")
     public boolean contains(Object o) {
-      ReferenceEntry<K, V> e = (ReferenceEntry) o;
+      ReferenceEntry<K, V> e = (ReferenceEntry<K, V>) o;
       return e.getNextInAccessQueue() != NullEntry.INSTANCE;
     }
 

--- a/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ImmutableClassToInstanceMap.java
@@ -151,8 +151,7 @@ public final class ImmutableClassToInstanceMap<B> extends ForwardingMap<Class<? 
       Map<? extends Class<? extends S>, ? extends S> map) {
     if (map instanceof ImmutableClassToInstanceMap) {
       @SuppressWarnings("unchecked") // covariant casts safe (unmodifiable)
-      // Eclipse won't compile if we cast to the parameterized type.
-      ImmutableClassToInstanceMap<B> cast = (ImmutableClassToInstanceMap) map;
+      ImmutableClassToInstanceMap<B> cast = (ImmutableClassToInstanceMap<B>) map;
       return cast;
     }
     return new Builder<B>().putAll(map).build();

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -3268,7 +3268,7 @@ public final class Maps {
     checkNotNull(map);
     if (map instanceof UnmodifiableNavigableMap) {
       @SuppressWarnings("unchecked") // covariant
-      NavigableMap<K, V> result = (NavigableMap) map;
+      NavigableMap<K, V> result = (NavigableMap<K, V>) map;
       return result;
     } else {
       return new UnmodifiableNavigableMap<>(map);

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -1035,7 +1035,7 @@ public final class Multisets {
         if (entryCount != 0) {
           // Safe as long as we never add a new entry, which we won't.
           @SuppressWarnings("unchecked")
-          Multiset<Object> multiset = (Multiset) multiset();
+          Multiset<Object> multiset = (Multiset<Object>) multiset();
           return multiset.setCount(element, entryCount, 0);
         }
       }

--- a/guava/src/com/google/common/collect/TreeBasedTable.java
+++ b/guava/src/com/google/common/collect/TreeBasedTable.java
@@ -196,8 +196,8 @@ public class TreeBasedTable<R, C, V> extends StandardRowSortedTable<R, C, V> {
 
     int compare(Object a, Object b) {
       // pretend we can compare anything
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Comparator<Object> cmp = (Comparator) comparator();
+      @SuppressWarnings("unchecked")
+      Comparator<Object> cmp = (Comparator<Object>) comparator();
       return cmp.compare(a, b);
     }
 

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.CollectionFuture.ListFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateCancelledFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateFailedFuture;
-import com.google.common.util.concurrent.ImmediateFuture.ImmediateSuccessfulFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.Duration;
 import java.util.Collection;
@@ -127,12 +126,12 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V> ListenableFuture<V> immediateFuture(@Nullable V value) {
     if (value == null) {
-      // This cast is safe because null is assignable to V for all V (i.e. it is covariant)
-      @SuppressWarnings({"unchecked", "rawtypes"})
-      ListenableFuture<V> typedNull = (ListenableFuture) ImmediateSuccessfulFuture.NULL;
+      // This cast is safe because null is assignable to V for all V (i.e. it is bivariant)
+      @SuppressWarnings("unchecked")
+      ListenableFuture<V> typedNull = (ListenableFuture<V>) ImmediateFuture.NULL;
       return typedNull;
     }
-    return new ImmediateSuccessfulFuture<V>(value);
+    return new ImmediateFuture<>(value);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.CollectionFuture.ListFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateCancelledFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateFailedFuture;
+import com.google.common.util.concurrent.ImmediateFuture.ImmediateSuccessfulFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.Duration;
 import java.util.Collection;
@@ -126,12 +127,12 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V> ListenableFuture<V> immediateFuture(@Nullable V value) {
     if (value == null) {
-      // This cast is safe because null is assignable to V for all V (i.e. it is bivariant)
-      @SuppressWarnings("unchecked")
-      ListenableFuture<V> typedNull = (ListenableFuture<V>) ImmediateFuture.NULL;
+      // This cast is safe because null is assignable to V for all V (i.e. it is covariant)
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      ListenableFuture<V> typedNull = (ListenableFuture) ImmediateSuccessfulFuture.NULL;
       return typedNull;
     }
-    return new ImmediateFuture<>(value);
+    return new ImmediateSuccessfulFuture<V>(value);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,10 +25,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** Implementations of {@code Futures.immediate*}. */
+/** Implementation of {@link Futures#immediateFuture}. */
 @GwtCompatible
-abstract class ImmediateFuture<V> implements ListenableFuture<V> {
+// TODO(cpovirk): Make this final (but that may break Mockito spy calls).
+class ImmediateFuture<V> implements ListenableFuture<V> {
+  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
+
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
+
+  private final @Nullable V value;
+
+  ImmediateFuture(@Nullable V value) {
+    this.value = value;
+  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -51,8 +60,11 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
+  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public abstract V get() throws ExecutionException;
+  public V get() {
+    return value;
+  }
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -70,25 +82,10 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
-    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
-    private final @Nullable V value;
-
-    ImmediateSuccessfulFuture(@Nullable V value) {
-      this.value = value;
-    }
-
-    // TODO(lukes): Consider throwing InterruptedException when appropriate.
-    @Override
-    public V get() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      // Behaviour analogous to AbstractFuture#toString().
-      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
-    }
+  @Override
+  public String toString() {
+    // Behaviour analogous to AbstractFuture#toString().
+    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,18 +25,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** Implementation of {@link Futures#immediateFuture}. */
+/** Implementations of {@code Futures.immediate*}. */
 @GwtCompatible
-final class ImmediateFuture<V> implements ListenableFuture<V> {
-  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
-
+abstract class ImmediateFuture<V> implements ListenableFuture<V> {
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
-
-  private final @Nullable V value;
-
-  ImmediateFuture(@Nullable V value) {
-    this.value = value;
-  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -59,11 +51,8 @@ final class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
-  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public V get() {
-    return value;
-  }
+  public abstract V get() throws ExecutionException;
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -81,10 +70,25 @@ final class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  @Override
-  public String toString() {
-    // Behaviour analogous to AbstractFuture#toString().
-    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
+  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
+    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
+    private final @Nullable V value;
+
+    ImmediateSuccessfulFuture(@Nullable V value) {
+      this.value = value;
+    }
+
+    // TODO(lukes): Consider throwing InterruptedException when appropriate.
+    @Override
+    public V get() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      // Behaviour analogous to AbstractFuture#toString().
+      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
+    }
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {

--- a/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ImmediateFuture.java
@@ -25,10 +25,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** Implementations of {@code Futures.immediate*}. */
+/** Implementation of {@link Futures#immediateFuture}. */
 @GwtCompatible
-abstract class ImmediateFuture<V> implements ListenableFuture<V> {
+final class ImmediateFuture<V> implements ListenableFuture<V> {
+  static final ListenableFuture<?> NULL = new ImmediateFuture<>(null);
+
   private static final Logger log = Logger.getLogger(ImmediateFuture.class.getName());
+
+  private final @Nullable V value;
+
+  ImmediateFuture(@Nullable V value) {
+    this.value = value;
+  }
 
   @Override
   public void addListener(Runnable listener, Executor executor) {
@@ -51,8 +59,11 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return false;
   }
 
+  // TODO(lukes): Consider throwing InterruptedException when appropriate.
   @Override
-  public abstract V get() throws ExecutionException;
+  public V get() {
+    return value;
+  }
 
   @Override
   public V get(long timeout, TimeUnit unit) throws ExecutionException {
@@ -70,25 +81,10 @@ abstract class ImmediateFuture<V> implements ListenableFuture<V> {
     return true;
   }
 
-  static class ImmediateSuccessfulFuture<V> extends ImmediateFuture<V> {
-    static final ImmediateSuccessfulFuture<Object> NULL = new ImmediateSuccessfulFuture<>(null);
-    private final @Nullable V value;
-
-    ImmediateSuccessfulFuture(@Nullable V value) {
-      this.value = value;
-    }
-
-    // TODO(lukes): Consider throwing InterruptedException when appropriate.
-    @Override
-    public V get() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      // Behaviour analogous to AbstractFuture#toString().
-      return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
-    }
+  @Override
+  public String toString() {
+    // Behaviour analogous to AbstractFuture#toString().
+    return super.toString() + "[status=SUCCESS, result=[" + value + "]]";
   }
 
   static final class ImmediateFailedFuture<V> extends TrustedFuture<V> {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Combine ImmediateSuccessfulFuture into ImmediateFuture.

ImmediateFuture used to have other implementations, but we switched those to extend TrustedFuture instead.

d780cd5f2b0ccc2610c039c30c04e987771dd0a5

-------

<p> Rollback previous commit.

0812745bec6e345b232154d815ad242cbb4fda37

-------

<p> Roll forward previous rollback, but without making the type final.

4c984c649e1f4665a7dbee5f568cfa25def76727

-------

<p> Fix (and in one case, suppress) low-hanging rawtypes warnings.

It looks like at least some of these may once have been necessary for the Eclipse compiler (used by GWT). In fact, I had to revert one similar change because it broke a GWT build. I'm hoping that that means that the others are safe.

cabc402dbf3805f04e19ba9d72e7f8802ab6bb75

-------

<p> Increase various tests' timeouts.

25842ed29c2c13b949836082552c5fee0cdcb0d5