### PR TITLE
Moe Sync

### DIFF
--- a/android/guava-tests/test/com/google/common/math/QuantilesTest.java
+++ b/android/guava-tests/test/com/google/common/math/QuantilesTest.java
@@ -744,4 +744,13 @@ public class QuantilesTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
   }
+
+  public void testScale_indexes_indexes_computeInPlace_empty() {
+    int[] emptyIndexes = {};
+    try {
+      Quantiles.ScaleAndIndexes unused = Quantiles.scale(10).indexes(emptyIndexes);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
 }

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -3815,9 +3815,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
         }
         sum -= segments[i].modCount;
       }
-      if (sum != 0L) {
-        return false;
-      }
+      return sum == 0L;
     }
     return true;
   }

--- a/android/guava/src/com/google/common/collect/Iterators.java
+++ b/android/guava/src/com/google/common/collect/Iterators.java
@@ -1078,6 +1078,9 @@ public final class Iterators {
    * <p>This method has no equivalent in {@link Iterables} because viewing an {@code Enumeration} as
    * an {@code Iterable} is impossible. However, the contents can be <i>copied</i> into a collection
    * using {@link Collections#list}.
+   *
+   * <p><b>Java 9 users:</b> use {@code enumeration.asIterator()} instead, unless it is important to
+   * return an {@code UnmodifiableIterator} instead of a plain {@code Iterator}.
    */
   public static <T> UnmodifiableIterator<T> forEnumeration(final Enumeration<T> enumeration) {
     checkNotNull(enumeration);

--- a/android/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/android/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -2320,9 +2320,7 @@ class MapMakerInternalMap<
         }
         sum -= segments[i].modCount;
       }
-      if (sum != 0L) {
-        return false;
-      }
+      return sum == 0L;
     }
     return true;
   }

--- a/android/guava/src/com/google/common/math/Quantiles.java
+++ b/android/guava/src/com/google/common/math/Quantiles.java
@@ -186,6 +186,7 @@ public final class Quantiles {
      * @param indexes the quantile indexes, each of which must be in the inclusive range [0, q] for
      *     q-quantiles; the order of the indexes is unimportant, duplicates will be ignored, and the
      *     set will be snapshotted when this method is called
+     * @throws IllegalArgumentException if {@code indexes} is empty
      */
     public ScaleAndIndexes indexes(int... indexes) {
       return new ScaleAndIndexes(scale, indexes.clone());
@@ -198,6 +199,7 @@ public final class Quantiles {
      * @param indexes the quantile indexes, each of which must be in the inclusive range [0, q] for
      *     q-quantiles; the order of the indexes is unimportant, duplicates will be ignored, and the
      *     set will be snapshotted when this method is called
+     * @throws IllegalArgumentException if {@code indexes} is empty
      */
     public ScaleAndIndexes indexes(Collection<Integer> indexes) {
       return new ScaleAndIndexes(scale, Ints.toArray(indexes));
@@ -318,6 +320,7 @@ public final class Quantiles {
       for (int index : indexes) {
         checkIndex(index, scale);
       }
+      checkArgument(indexes.length > 0, "Indexes must be a non empty array");
       this.scale = scale;
       this.indexes = indexes;
     }

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -537,6 +537,18 @@ public final class MediaType {
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
+   * Media type for <a
+   * href="https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP">Dynamic Adaptive
+   * Streaming over HTTP (DASH)</a>. This is <a
+   * href="https://www.iana.org/assignments/media-types/application/dash+xml">registered</a> with
+   * the IANA.
+   *
+   * @since NEXT
+   */
+  public static final MediaType MEDIA_PRESENTATION_DESCRIPTION =
+      createConstant(APPLICATION_TYPE, "dash+xml");
+
+  /**
    * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
    * overview</a>.
    *

--- a/android/guava/src/com/google/common/reflect/Parameter.java
+++ b/android/guava/src/com/google/common/reflect/Parameter.java
@@ -87,7 +87,7 @@ public final class Parameter implements AnnotatedElement {
   // @Override on JDK8
   @Override
   public Annotation[] getDeclaredAnnotations() {
-    return annotations.toArray(new Annotation[annotations.size()]);
+    return annotations.toArray(new Annotation[0]);
   }
 
   /** @since 18.0 */

--- a/android/guava/src/com/google/common/reflect/Types.java
+++ b/android/guava/src/com/google/common/reflect/Types.java
@@ -514,7 +514,7 @@ final class Types {
   }
 
   private static Type[] toArray(Collection<Type> types) {
-    return types.toArray(new Type[types.size()]);
+    return types.toArray(new Type[0]);
   }
 
   private static Iterable<Type> filterUpperBounds(Iterable<Type> bounds) {

--- a/android/guava/src/com/google/common/util/concurrent/Callables.java
+++ b/android/guava/src/com/google/common/util/concurrent/Callables.java
@@ -129,9 +129,10 @@ public final class Callables {
   /** Tries to set name of the given {@link Thread}, returns true if successful. */
   @GwtIncompatible // threads
   private static boolean trySetName(final String threadName, Thread currentThread) {
-    // In AppEngine, this will always fail. Should we test for that explicitly using
-    // MoreExecutors.isAppEngine? More generally, is there a way to see if we have the modifyThread
-    // permission without catching an exception?
+    /*
+     * setName should usually succeed, but the security manager can prohibit it. Is there a way to
+     * see if we have the modifyThread permission without catching an exception?
+     */
     try {
       currentThread.setName(threadName);
       return true;

--- a/guava-gwt/test/com/google/common/util/concurrent/testModule.gwt.xml
+++ b/guava-gwt/test/com/google/common/util/concurrent/testModule.gwt.xml
@@ -9,6 +9,7 @@
   <inherits name="com.google.common.testing.Testing"/>
   <inherits name="com.google.common.util.concurrent.Concurrent"/>
   <inherits name="com.google.common.truth.Truth"/>
+  <inherits name="activation.Activation"/>
   <entry-point class="com.google.common.util.concurrent.TestModuleEntryPoint"/>
    
   <source path=""/>

--- a/guava-tests/test/com/google/common/math/QuantilesTest.java
+++ b/guava-tests/test/com/google/common/math/QuantilesTest.java
@@ -744,4 +744,13 @@ public class QuantilesTest extends TestCase {
     } catch (IllegalArgumentException expected) {
     }
   }
+
+  public void testScale_indexes_indexes_computeInPlace_empty() {
+    int[] emptyIndexes = {};
+    try {
+      Quantiles.ScaleAndIndexes unused = Quantiles.scale(10).indexes(emptyIndexes);
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
 }

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -3918,9 +3918,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
         }
         sum -= segments[i].modCount;
       }
-      if (sum != 0L) {
-        return false;
-      }
+      return sum == 0L;
     }
     return true;
   }

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -1071,6 +1071,9 @@ public final class Iterators {
    * <p>This method has no equivalent in {@link Iterables} because viewing an {@code Enumeration} as
    * an {@code Iterable} is impossible. However, the contents can be <i>copied</i> into a collection
    * using {@link Collections#list}.
+   *
+   * <p><b>Java 9 users:</b> use {@code enumeration.asIterator()} instead, unless it is important to
+   * return an {@code UnmodifiableIterator} instead of a plain {@code Iterator}.
    */
   public static <T> UnmodifiableIterator<T> forEnumeration(final Enumeration<T> enumeration) {
     checkNotNull(enumeration);

--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -2315,9 +2315,7 @@ class MapMakerInternalMap<
         }
         sum -= segments[i].modCount;
       }
-      if (sum != 0L) {
-        return false;
-      }
+      return sum == 0L;
     }
     return true;
   }

--- a/guava/src/com/google/common/math/Quantiles.java
+++ b/guava/src/com/google/common/math/Quantiles.java
@@ -186,6 +186,7 @@ public final class Quantiles {
      * @param indexes the quantile indexes, each of which must be in the inclusive range [0, q] for
      *     q-quantiles; the order of the indexes is unimportant, duplicates will be ignored, and the
      *     set will be snapshotted when this method is called
+     * @throws IllegalArgumentException if {@code indexes} is empty
      */
     public ScaleAndIndexes indexes(int... indexes) {
       return new ScaleAndIndexes(scale, indexes.clone());
@@ -198,6 +199,7 @@ public final class Quantiles {
      * @param indexes the quantile indexes, each of which must be in the inclusive range [0, q] for
      *     q-quantiles; the order of the indexes is unimportant, duplicates will be ignored, and the
      *     set will be snapshotted when this method is called
+     * @throws IllegalArgumentException if {@code indexes} is empty
      */
     public ScaleAndIndexes indexes(Collection<Integer> indexes) {
       return new ScaleAndIndexes(scale, Ints.toArray(indexes));
@@ -318,6 +320,7 @@ public final class Quantiles {
       for (int index : indexes) {
         checkIndex(index, scale);
       }
+      checkArgument(indexes.length > 0, "Indexes must be a non empty array");
       this.scale = scale;
       this.indexes = indexes;
     }

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -537,6 +537,18 @@ public final class MediaType {
   public static final MediaType MICROSOFT_WORD = createConstant(APPLICATION_TYPE, "msword");
 
   /**
+   * Media type for <a
+   * href="https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP">Dynamic Adaptive
+   * Streaming over HTTP (DASH)</a>. This is <a
+   * href="https://www.iana.org/assignments/media-types/application/dash+xml">registered</a> with
+   * the IANA.
+   *
+   * @since NEXT
+   */
+  public static final MediaType MEDIA_PRESENTATION_DESCRIPTION =
+      createConstant(APPLICATION_TYPE, "dash+xml");
+
+  /**
    * WASM applications. For more information see <a href="https://webassembly.org/">the Web Assembly
    * overview</a>.
    *

--- a/guava/src/com/google/common/reflect/Parameter.java
+++ b/guava/src/com/google/common/reflect/Parameter.java
@@ -94,7 +94,7 @@ public final class Parameter implements AnnotatedElement {
   // @Override on JDK8
   @Override
   public Annotation[] getDeclaredAnnotations() {
-    return annotations.toArray(new Annotation[annotations.size()]);
+    return annotations.toArray(new Annotation[0]);
   }
 
   /** @since 18.0 */

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -511,7 +511,7 @@ final class Types {
   }
 
   private static Type[] toArray(Collection<Type> types) {
-    return types.toArray(new Type[types.size()]);
+    return types.toArray(new Type[0]);
   }
 
   private static Iterable<Type> filterUpperBounds(Iterable<Type> bounds) {

--- a/guava/src/com/google/common/util/concurrent/Callables.java
+++ b/guava/src/com/google/common/util/concurrent/Callables.java
@@ -129,9 +129,10 @@ public final class Callables {
   /** Tries to set name of the given {@link Thread}, returns true if successful. */
   @GwtIncompatible // threads
   private static boolean trySetName(final String threadName, Thread currentThread) {
-    // In AppEngine, this will always fail. Should we test for that explicitly using
-    // MoreExecutors.isAppEngine? More generally, is there a way to see if we have the modifyThread
-    // permission without catching an exception?
+    /*
+     * setName should usually succeed, but the security manager can prohibit it. Is there a way to
+     * see if we have the modifyThread permission without catching an exception?
+     */
     try {
       currentThread.setName(threadName);
       return true;

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -814,15 +814,17 @@ public final class MoreExecutors {
   /**
    * Returns a default thread factory used to create new threads.
    *
-   * <p>On AppEngine, returns {@code ThreadManager.currentRequestThreadFactory()}. Otherwise,
-   * returns {@link Executors#defaultThreadFactory()}.
+   * <p>When running on AppEngine with access to <a
+   * href="https://cloud.google.com/appengine/docs/standard/java/javadoc/">AppEngine legacy
+   * APIs</a>, this method returns {@code ThreadManager.currentRequestThreadFactory()}. Otherwise,
+   * it returns {@link Executors#defaultThreadFactory()}.
    *
    * @since 14.0
    */
   @Beta
   @GwtIncompatible // concurrency
   public static ThreadFactory platformThreadFactory() {
-    if (!isAppEngine()) {
+    if (!isAppEngineWithApiClasses()) {
       return Executors.defaultThreadFactory();
     }
     try {
@@ -847,8 +849,13 @@ public final class MoreExecutors {
   }
 
   @GwtIncompatible // TODO
-  private static boolean isAppEngine() {
+  private static boolean isAppEngineWithApiClasses() {
     if (System.getProperty("com.google.appengine.runtime.environment") == null) {
+      return false;
+    }
+    try {
+      Class.forName("com.google.appengine.api.utils.SystemProperty");
+    } catch (ClassNotFoundException e) {
       return false;
     }
     try {
@@ -908,10 +915,6 @@ public final class MoreExecutors {
   static Executor renamingDecorator(final Executor executor, final Supplier<String> nameSupplier) {
     checkNotNull(executor);
     checkNotNull(nameSupplier);
-    if (isAppEngine()) {
-      // AppEngine doesn't support thread renaming, so don't even try
-      return executor;
-    }
     return new Executor() {
       @Override
       public void execute(Runnable command) {
@@ -937,10 +940,6 @@ public final class MoreExecutors {
       final ExecutorService service, final Supplier<String> nameSupplier) {
     checkNotNull(service);
     checkNotNull(nameSupplier);
-    if (isAppEngine()) {
-      // AppEngine doesn't support thread renaming, so don't even try.
-      return service;
-    }
     return new WrappingExecutorService(service) {
       @Override
       protected <T> Callable<T> wrapTask(Callable<T> callable) {
@@ -971,10 +970,6 @@ public final class MoreExecutors {
       final ScheduledExecutorService service, final Supplier<String> nameSupplier) {
     checkNotNull(service);
     checkNotNull(nameSupplier);
-    if (isAppEngine()) {
-      // AppEngine doesn't support thread renaming, so don't even try.
-      return service;
-    }
     return new WrappingScheduledExecutorService(service) {
       @Override
       protected <T> Callable<T> wrapTask(Callable<T> callable) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Check the array indexes in Quantiles.ScaleAndIndexes is non empty.

Fixes #3210
Fixes #3211

823a432ddaa2d274b539e12ed2bb46e5be0658ee

-------

<p> Simplify some code.

Fixes #3580

e2362def3408478a4a74d24671aef39171a1e93f

-------

<p> Document the JDK 9+ alternative to `Iterators#forEnumeration`

Fixes #3382

e432be553038b4c67f22abb8c27f82ab6d480f3d

-------

<p> Add a MIME type MPEG-DASH (mpd files)

Fixes #2677

RELNOTES=`net`: Added the `MediaType` constant for MPEG-DASH.

579ccf6c0181097be7b895ec145f04502234ef0e

-------

<p> Fix the logic that decides whether to use currentRequestThreadFactory() under App Engine.

While there, also support thread renaming under App Engine.

Fixes https://github.com/google/guava/issues/3598
Relevant to https://github.com/google/guava/issues/3606
(also, the CL in which I experimented with https://github.com/google/guava/issues/3569 before backing it out)

7bd4b2351c1483f34e7192768b4f3e7a10447c33