### PR TITLE
Skip file.createNewFile in Files.touch if file exists.

### DIFF
--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -441,8 +441,10 @@ public final class Files {
   @SuppressWarnings("GoodTime") // reading system time without TimeSource
   public static void touch(File file) throws IOException {
     checkNotNull(file);
-    if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {
-      throw new IOException("Unable to update modification time of " + file);
+    if (!file.exists()) {
+      if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {
+        throw new IOException("Unable to update modification time of " + file);
+      }
     }
   }
 

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -441,8 +441,10 @@ public final class Files {
   @SuppressWarnings("GoodTime") // reading system time without TimeSource
   public static void touch(File file) throws IOException {
     checkNotNull(file);
-    if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {
-      throw new IOException("Unable to update modification time of " + file);
+    if (!file.exists()) {
+      if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {
+        throw new IOException("Unable to update modification time of " + file);
+      }
     }
   }
 


### PR DESCRIPTION
When calling Files.touch(foo) on a file that already exists,
 java.io.File#createNewFile() will should not be called.

Fixes #3612 