### PR TITLE
switch to an internal annotation for ignoring JRE requirements

### DIFF
--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -42,11 +42,6 @@
       <groupId>com.google.j2objc</groupId>
       <artifactId>j2objc-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>animal-sniffer-annotations</artifactId>
-      <version>${animal.sniffer.version}</version>
-    </dependency>
     <!-- TODO(cpovirk): does this comment belong on the <dependency> in <profiles>? -->
     <!-- TODO(cpovirk): want this only for dependency plugin but seems not to work there? Maven runs without failure, but the resulting Javadoc is missing the hoped-for inherited text -->
   </dependencies>

--- a/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
+++ b/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Static methods used to implement {@link Futures#getChecked(Future, Class)}. */
 @GwtIncompatible

--- a/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
+++ b/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+@interface IgnoreJRERequirement {
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>${animal.sniffer.version}</version>
           <configuration>
+            <annotations>com.google.common.util.concurrent.IgnoreJRERequirement</annotations>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>
               <artifactId>java18</artifactId>


### PR DESCRIPTION
@cpovirk This completely removes the dependency on animal-sniffer annotations