### PR TITLE
update failureaccess version to match docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ removing things again, but officially, we're leaving our options open in case
 of surprises (like, say, a serious security problem).
 
 3. Guava has one dependency that is needed at runtime:
-`com.google.guava:failureaccess:1.0`
+`com.google.guava:failureaccess:1.0.1`
 
 4. Serialized forms of ALL objects are subject to change unless noted
 otherwise. Do not persist these and assume they can be read by a
@@ -110,4 +110,3 @@ API level 15 (Ice Cream Sandwich).
 
 [using Guava in your build]: https://github.com/google/guava/wiki/UseGuavaInYourBuild
 [repackage]: https://github.com/google/guava/wiki/UseGuavaInYourBuild#what-if-i-want-to-use-beta-apis-from-a-library-that-people-use-as-a-dependency
-


### PR DESCRIPTION
@cpovirk fix #3651 

Other uses of 1.0.0 are in `@since` tags