### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -42,11 +42,6 @@
       <groupId>com.google.j2objc</groupId>
       <artifactId>j2objc-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>animal-sniffer-annotations</artifactId>
-      <version>${animal.sniffer.version}</version>
-    </dependency>
     <!-- TODO(cpovirk): does this comment belong on the <dependency> in <profiles>? -->
     <!-- TODO(cpovirk): want this only for dependency plugin but seems not to work there? Maven runs without failure, but the resulting Javadoc is missing the hoped-for inherited text -->
   </dependencies>

--- a/android/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/android/guava/src/com/google/common/cache/CacheBuilder.java
@@ -662,6 +662,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getExpireAfterWriteNanos() {
     return (expireAfterWriteNanos == UNSET_INT) ? DEFAULT_EXPIRATION_NANOS : expireAfterWriteNanos;
   }
@@ -701,6 +702,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getExpireAfterAccessNanos() {
     return (expireAfterAccessNanos == UNSET_INT)
         ? DEFAULT_EXPIRATION_NANOS
@@ -743,6 +745,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getRefreshNanos() {
     return (refreshNanos == UNSET_INT) ? DEFAULT_REFRESH_NANOS : refreshNanos;
   }

--- a/android/guava/src/com/google/common/cache/ReferenceEntry.java
+++ b/android/guava/src/com/google/common/cache/ReferenceEntry.java
@@ -64,6 +64,7 @@ interface ReferenceEntry<K, V> {
    */
 
   /** Returns the time that this entry was last accessed, in ns. */
+  @SuppressWarnings("GoodTime")
   long getAccessTime();
 
   /** Sets the entry access time in ns. */
@@ -88,6 +89,7 @@ interface ReferenceEntry<K, V> {
    * expired from the head of the list.
    */
 
+  @SuppressWarnings("GoodTime")
   /** Returns the time that this entry was last written, in ns. */
   long getWriteTime();
 

--- a/android/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
+++ b/android/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Static methods used to implement {@link Futures#getChecked(Future, Class)}. */
 @GwtIncompatible

--- a/android/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
+++ b/android/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+@interface IgnoreJRERequirement {}

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -149,6 +149,7 @@
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>${animal.sniffer.version}</version>
           <configuration>
+            <annotations>com.google.common.util.concurrent.IgnoreJRERequirement</annotations>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>
               <artifactId>java16-sun</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -42,11 +42,6 @@
       <groupId>com.google.j2objc</groupId>
       <artifactId>j2objc-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>animal-sniffer-annotations</artifactId>
-      <version>${animal.sniffer.version}</version>
-    </dependency>
     <!-- TODO(cpovirk): does this comment belong on the <dependency> in <profiles>? -->
     <!-- TODO(cpovirk): want this only for dependency plugin but seems not to work there? Maven runs without failure, but the resulting Javadoc is missing the hoped-for inherited text -->
   </dependencies>

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -657,7 +657,7 @@ public final class CacheBuilder<K, V> {
   @GwtIncompatible // java.time.Duration
   @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> expireAfterWrite(java.time.Duration duration) {
-    return expireAfterWrite(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
+    return expireAfterWrite(toNanosSaturated(duration), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -726,7 +726,7 @@ public final class CacheBuilder<K, V> {
   @GwtIncompatible // java.time.Duration
   @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> expireAfterAccess(java.time.Duration duration) {
-    return expireAfterAccess(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
+    return expireAfterAccess(toNanosSaturated(duration), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -803,7 +803,7 @@ public final class CacheBuilder<K, V> {
   @GwtIncompatible // java.time.Duration
   @SuppressWarnings("GoodTime") // java.time.Duration decomposition
   public CacheBuilder<K, V> refreshAfterWrite(java.time.Duration duration) {
-    return refreshAfterWrite(saturatedToNanos(duration), TimeUnit.NANOSECONDS);
+    return refreshAfterWrite(toNanosSaturated(duration), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -1040,7 +1040,7 @@ public final class CacheBuilder<K, V> {
    */
   @GwtIncompatible // java.time.Duration
   @SuppressWarnings("GoodTime") // duration decomposition
-  private static long saturatedToNanos(java.time.Duration duration) {
+  private static long toNanosSaturated(java.time.Duration duration) {
     // Using a try/catch seems lazy, but the catch block will rarely get invoked (except for
     // durations longer than approximately +/- 292 years).
     try {

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -693,6 +693,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getExpireAfterWriteNanos() {
     return (expireAfterWriteNanos == UNSET_INT) ? DEFAULT_EXPIRATION_NANOS : expireAfterWriteNanos;
   }
@@ -767,6 +768,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getExpireAfterAccessNanos() {
     return (expireAfterAccessNanos == UNSET_INT)
         ? DEFAULT_EXPIRATION_NANOS
@@ -845,6 +847,7 @@ public final class CacheBuilder<K, V> {
     return this;
   }
 
+  @SuppressWarnings("GoodTime") // nanos internally, should be Duration
   long getRefreshNanos() {
     return (refreshNanos == UNSET_INT) ? DEFAULT_REFRESH_NANOS : refreshNanos;
   }

--- a/guava/src/com/google/common/cache/ReferenceEntry.java
+++ b/guava/src/com/google/common/cache/ReferenceEntry.java
@@ -64,6 +64,7 @@ interface ReferenceEntry<K, V> {
    */
 
   /** Returns the time that this entry was last accessed, in ns. */
+  @SuppressWarnings("GoodTime")
   long getAccessTime();
 
   /** Sets the entry access time in ns. */
@@ -88,6 +89,7 @@ interface ReferenceEntry<K, V> {
    * expired from the head of the list.
    */
 
+  @SuppressWarnings("GoodTime")
   /** Returns the time that this entry was last written, in ns. */
   long getWriteTime();
 

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -16,7 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 
 import com.google.common.annotations.Beta;
@@ -126,7 +126,7 @@ public abstract class AbstractScheduledService implements Service {
      */
     public static Scheduler newFixedDelaySchedule(Duration initialDelay, Duration delay) {
       return newFixedDelaySchedule(
-          saturatedToNanos(initialDelay), saturatedToNanos(delay), TimeUnit.NANOSECONDS);
+          toNanosSaturated(initialDelay), toNanosSaturated(delay), TimeUnit.NANOSECONDS);
     }
 
     /**
@@ -162,7 +162,7 @@ public abstract class AbstractScheduledService implements Service {
      */
     public static Scheduler newFixedRateSchedule(Duration initialDelay, Duration period) {
       return newFixedRateSchedule(
-          saturatedToNanos(initialDelay), saturatedToNanos(period), TimeUnit.NANOSECONDS);
+          toNanosSaturated(initialDelay), toNanosSaturated(period), TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -15,7 +15,7 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -261,7 +261,7 @@ public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecializat
   @GwtIncompatible // ScheduledExecutorService
   public final FluentFuture<V> withTimeout(
       Duration timeout, ScheduledExecutorService scheduledExecutor) {
-    return withTimeout(saturatedToNanos(timeout), TimeUnit.NANOSECONDS, scheduledExecutor);
+    return withTimeout(toNanosSaturated(timeout), TimeUnit.NANOSECONDS, scheduledExecutor);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -16,7 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 
@@ -206,7 +206,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @GwtIncompatible // java.util.concurrent.ScheduledExecutorService
   public static <O> ListenableFuture<O> scheduleAsync(
       AsyncCallable<O> callable, Duration delay, ScheduledExecutorService executorService) {
-    return scheduleAsync(callable, saturatedToNanos(delay), TimeUnit.NANOSECONDS, executorService);
+    return scheduleAsync(callable, toNanosSaturated(delay), TimeUnit.NANOSECONDS, executorService);
   }
 
   /**
@@ -369,7 +369,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @GwtIncompatible // java.util.concurrent.ScheduledExecutorService
   public static <V> ListenableFuture<V> withTimeout(
       ListenableFuture<V> delegate, Duration time, ScheduledExecutorService scheduledExecutor) {
-    return withTimeout(delegate, saturatedToNanos(time), TimeUnit.NANOSECONDS, scheduledExecutor);
+    return withTimeout(delegate, toNanosSaturated(time), TimeUnit.NANOSECONDS, scheduledExecutor);
   }
 
   /**
@@ -1192,7 +1192,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @GwtIncompatible // reflection
   public static <V, X extends Exception> V getChecked(
       Future<V> future, Class<X> exceptionClass, Duration timeout) throws X {
-    return getChecked(future, exceptionClass, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return getChecked(future, exceptionClass, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
+++ b/guava/src/com/google/common/util/concurrent/FuturesGetChecked.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Static methods used to implement {@link Futures#getChecked(Future, Class)}. */
 @GwtIncompatible

--- a/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
+++ b/guava/src/com/google/common/util/concurrent/IgnoreJRERequirement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.util.concurrent;
+
+@interface IgnoreJRERequirement {}

--- a/guava/src/com/google/common/util/concurrent/Internal.java
+++ b/guava/src/com/google/common/util/concurrent/Internal.java
@@ -28,7 +28,7 @@ final class Internal {
    * {@link Long#MAX_VALUE} or {@link Long#MIN_VALUE}. This behavior can be useful when decomposing
    * a duration in order to call a legacy API which requires a {@code long, TimeUnit} pair.
    */
-  static long saturatedToNanos(Duration duration) {
+  static long toNanosSaturated(Duration duration) {
     // Using a try/catch seems lazy, but the catch block will rarely get invoked (except for
     // durations longer than approximately +/- 292 years).
     try {

--- a/guava/src/com/google/common/util/concurrent/Monitor.java
+++ b/guava/src/com/google/common/util/concurrent/Monitor.java
@@ -15,7 +15,7 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
@@ -390,7 +390,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enter(Duration time) {
-    return enter(saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enter(toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -440,7 +440,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enterInterruptibly(Duration time) throws InterruptedException {
-    return enterInterruptibly(saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enterInterruptibly(toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -501,7 +501,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enterWhen(Guard guard, Duration time) throws InterruptedException {
-    return enterWhen(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enterWhen(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -594,7 +594,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enterWhenUninterruptibly(Guard guard, Duration time) {
-    return enterWhenUninterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enterWhenUninterruptibly(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -695,7 +695,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enterIf(Guard guard, Duration time) {
-    return enterIf(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enterIf(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -755,7 +755,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean enterIfInterruptibly(Guard guard, Duration time) throws InterruptedException {
-    return enterIfInterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return enterIfInterruptibly(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -836,7 +836,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean waitFor(Guard guard, Duration time) throws InterruptedException {
-    return waitFor(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return waitFor(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -882,7 +882,7 @@ public final class Monitor {
    * @since 28.0
    */
   public boolean waitForUninterruptibly(Guard guard, Duration time) {
-    return waitForUninterruptibly(guard, saturatedToNanos(time), TimeUnit.NANOSECONDS);
+    return waitForUninterruptibly(guard, toNanosSaturated(time), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -16,7 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -84,7 +84,7 @@ public final class MoreExecutors {
   public static ExecutorService getExitingExecutorService(
       ThreadPoolExecutor executor, Duration terminationTimeout) {
     return getExitingExecutorService(
-        executor, saturatedToNanos(terminationTimeout), TimeUnit.NANOSECONDS);
+        executor, toNanosSaturated(terminationTimeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -145,7 +145,7 @@ public final class MoreExecutors {
   public static ScheduledExecutorService getExitingScheduledExecutorService(
       ScheduledThreadPoolExecutor executor, Duration terminationTimeout) {
     return getExitingScheduledExecutorService(
-        executor, saturatedToNanos(terminationTimeout), TimeUnit.NANOSECONDS);
+        executor, toNanosSaturated(terminationTimeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -204,7 +204,7 @@ public final class MoreExecutors {
   @Beta
   @GwtIncompatible // java.time.Duration
   public static void addDelayedShutdownHook(ExecutorService service, Duration terminationTimeout) {
-    addDelayedShutdownHook(service, saturatedToNanos(terminationTimeout), TimeUnit.NANOSECONDS);
+    addDelayedShutdownHook(service, toNanosSaturated(terminationTimeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -707,7 +707,7 @@ public final class MoreExecutors {
       Duration timeout)
       throws InterruptedException, ExecutionException, TimeoutException {
     return invokeAnyImpl(
-        executorService, tasks, timed, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+        executorService, tasks, timed, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -1010,7 +1010,7 @@ public final class MoreExecutors {
   @CanIgnoreReturnValue
   @GwtIncompatible // java.time.Duration
   public static boolean shutdownAndAwaitTermination(ExecutorService service, Duration timeout) {
-    return shutdownAndAwaitTermination(service, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return shutdownAndAwaitTermination(service, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -16,7 +16,7 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -161,7 +161,7 @@ public abstract class RateLimiter {
    * @since 28.0
    */
   public static RateLimiter create(double permitsPerSecond, Duration warmupPeriod) {
-    return create(permitsPerSecond, saturatedToNanos(warmupPeriod), TimeUnit.NANOSECONDS);
+    return create(permitsPerSecond, toNanosSaturated(warmupPeriod), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -331,7 +331,7 @@ public abstract class RateLimiter {
    * @since 28.0
    */
   public boolean tryAcquire(Duration timeout) {
-    return tryAcquire(1, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return tryAcquire(1, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -390,7 +390,7 @@ public abstract class RateLimiter {
    * @since 28.0
    */
   public boolean tryAcquire(int permits, Duration timeout) {
-    return tryAcquire(permits, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return tryAcquire(permits, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Service.java
+++ b/guava/src/com/google/common/util/concurrent/Service.java
@@ -14,7 +14,7 @@
 
 package com.google.common.util.concurrent;
 
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
@@ -109,7 +109,7 @@ public interface Service {
    * @since 28.0
    */
   default void awaitRunning(Duration timeout) throws TimeoutException {
-    awaitRunning(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    awaitRunning(toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -145,7 +145,7 @@ public interface Service {
    * @since 28.0
    */
   default void awaitTerminated(Duration timeout) throws TimeoutException {
-    awaitTerminated(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    awaitTerminated(toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Predicates.not;
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.Service.State.FAILED;
 import static com.google.common.util.concurrent.Service.State.NEW;
@@ -328,7 +328,7 @@ public final class ServiceManager {
    * @since 28.0
    */
   public void awaitHealthy(Duration timeout) throws TimeoutException {
-    awaitHealthy(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    awaitHealthy(toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -380,7 +380,7 @@ public final class ServiceManager {
    * @since 28.0
    */
   public void awaitStopped(Duration timeout) throws TimeoutException {
-    awaitStopped(saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    awaitStopped(toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/TimeLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/TimeLimiter.java
@@ -14,7 +14,7 @@
 
 package com.google.common.util.concurrent;
 
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
@@ -120,7 +120,7 @@ public interface TimeLimiter {
    * @since 28.0
    */
   default <T> T newProxy(T target, Class<T> interfaceType, Duration timeout) {
-    return newProxy(target, interfaceType, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return newProxy(target, interfaceType, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -164,7 +164,7 @@ public interface TimeLimiter {
   @CanIgnoreReturnValue
   default <T> T callWithTimeout(Callable<T> callable, Duration timeout)
       throws TimeoutException, InterruptedException, ExecutionException {
-    return callWithTimeout(callable, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return callWithTimeout(callable, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -214,7 +214,7 @@ public interface TimeLimiter {
   default <T> T callUninterruptiblyWithTimeout(Callable<T> callable, Duration timeout)
       throws TimeoutException, ExecutionException {
     return callUninterruptiblyWithTimeout(
-        callable, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+        callable, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -252,7 +252,7 @@ public interface TimeLimiter {
    */
   default void runWithTimeout(Runnable runnable, Duration timeout)
       throws TimeoutException, InterruptedException {
-    runWithTimeout(runnable, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    runWithTimeout(runnable, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -294,6 +294,6 @@ public interface TimeLimiter {
    */
   default void runUninterruptiblyWithTimeout(Runnable runnable, Duration timeout)
       throws TimeoutException {
-    runUninterruptiblyWithTimeout(runnable, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    runUninterruptiblyWithTimeout(runnable, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 }

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -14,7 +14,7 @@
 
 package com.google.common.util.concurrent;
 
-import static com.google.common.util.concurrent.Internal.saturatedToNanos;
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.google.common.annotations.Beta;
@@ -77,7 +77,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @Beta
   public static boolean awaitUninterruptibly(CountDownLatch latch, Duration timeout) {
-    return awaitUninterruptibly(latch, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return awaitUninterruptibly(latch, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -118,7 +118,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @Beta
   public static boolean awaitUninterruptibly(Condition condition, Duration timeout) {
-    return awaitUninterruptibly(condition, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return awaitUninterruptibly(condition, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -179,7 +179,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @Beta
   public static void joinUninterruptibly(Thread toJoin, Duration timeout) {
-    joinUninterruptibly(toJoin, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    joinUninterruptibly(toJoin, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -270,7 +270,7 @@ public final class Uninterruptibles {
   @Beta
   public static <V> V getUninterruptibly(Future<V> future, Duration timeout)
       throws ExecutionException, TimeoutException {
-    return getUninterruptibly(future, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return getUninterruptibly(future, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -372,7 +372,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @Beta
   public static void sleepUninterruptibly(Duration sleepFor) {
-    sleepUninterruptibly(saturatedToNanos(sleepFor), TimeUnit.NANOSECONDS);
+    sleepUninterruptibly(toNanosSaturated(sleepFor), TimeUnit.NANOSECONDS);
   }
 
   // TODO(user): Support Sleeper somehow (wrapper or interface method)?
@@ -410,7 +410,7 @@ public final class Uninterruptibles {
   @GwtIncompatible // concurrency
   @Beta
   public static boolean tryAcquireUninterruptibly(Semaphore semaphore, Duration timeout) {
-    return tryAcquireUninterruptibly(semaphore, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+    return tryAcquireUninterruptibly(semaphore, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**
@@ -437,7 +437,7 @@ public final class Uninterruptibles {
   public static boolean tryAcquireUninterruptibly(
       Semaphore semaphore, int permits, Duration timeout) {
     return tryAcquireUninterruptibly(
-        semaphore, permits, saturatedToNanos(timeout), TimeUnit.NANOSECONDS);
+        semaphore, permits, toNanosSaturated(timeout), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>${animal.sniffer.version}</version>
           <configuration>
+            <annotations>com.google.common.util.concurrent.IgnoreJRERequirement</annotations>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>
               <artifactId>java18</artifactId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> switch to an internal annotation for ignoring JRE
requirements

Fixes #3652

RELNOTES=Removed dependency on `animal-sniffer-annotations`.

3324ce6af9d672b4a1e4431ebaf84b0e22d7ca86

-------

<p> Rename package-private Duration APIs:
  saturatedToNanos() -> toNanosSaturated()
  saturatedToMillis() -> toMillisSaturated()

#goodtime

f3a053ea12ae808ddd52094d36fcd88fe95881f2

-------

<p> Suppress more GoodTime errors.

9e885c85265c3686aa876acebe6bb6bda18de1f3