### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ removing things again, but officially, we're leaving our options open in case
 of surprises (like, say, a serious security problem).
 
 3. Guava has one dependency that is needed at runtime:
-`com.google.guava:failureaccess:1.0`
+`com.google.guava:failureaccess:1.0.1`
 
 4. Serialized forms of ALL objects are subject to change unless noted
 otherwise. Do not persist these and assume they can be read by a

--- a/guava/src/com/google/common/base/Platform.java
+++ b/guava/src/com/google/common/base/Platform.java
@@ -111,5 +111,12 @@ final class Platform {
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
+    logger.log(
+        java.util.logging.Level.WARNING,
+        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+            + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
+            + " can identify which type by looking at the class name in the attached stack trace.",
+        new Throwable());
+
   }
 }

--- a/guava/src/com/google/common/collect/Platform.java
+++ b/guava/src/com/google/common/collect/Platform.java
@@ -32,6 +32,9 @@ import java.util.Set;
  */
 @GwtCompatible(emulated = true)
 final class Platform {
+  private static final java.util.logging.Logger logger =
+      java.util.logging.Logger.getLogger(Platform.class.getName());
+
   /** Returns the platform preferred implementation of a map based on a hash table. */
   static <K, V> Map<K, V> newHashMapWithExpectedSize(int expectedSize) {
     return Maps.newHashMapWithExpectedSize(expectedSize);
@@ -125,6 +128,13 @@ final class Platform {
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
+    logger.log(
+        java.util.logging.Level.WARNING,
+        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+            + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
+            + " can identify which type by looking at the class name in the attached stack trace.",
+        new Throwable());
+
   }
 
   private Platform() {}

--- a/guava/src/com/google/common/primitives/Platform.java
+++ b/guava/src/com/google/common/primitives/Platform.java
@@ -22,6 +22,9 @@ import com.google.common.annotations.GwtCompatible;
 /** Methods factored out so that they can be emulated differently in GWT. */
 @GwtCompatible(emulated = true)
 final class Platform {
+  private static final java.util.logging.Logger logger =
+      java.util.logging.Logger.getLogger(Platform.class.getName());
+
   private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
 
   static void checkGwtRpcEnabled() {
@@ -35,6 +38,13 @@ final class Platform {
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
+    logger.log(
+        java.util.logging.Level.WARNING,
+        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+            + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
+            + " can identify which type by looking at the class name in the attached stack trace.",
+        new Throwable());
+
   }
 
   private Platform() {}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Log warnings for users who send Guava types over GWT-RPC.

(Roll forward CL 273803350, which was rolled back in CL 273825377. This time with updates to one-definition whitelist.)

[]

09a11ae36f186ba1ed5b0cd4d9eef2733028c496

-------

<p> update failureaccess version to match docs with code

Fixes #3653

dc01afd344fdf669f28e9e806dc8864622152177