### PR TITLE
Moe Sync

### DIFF
--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -173,7 +173,7 @@
   </build>
   <profiles>
     <profile>
-      <id>srczip</id>
+      <id>srczip-parent</id>
       <activation>
         <file>
           <exists>${java.home}/../src.zip</exists>
@@ -186,6 +186,24 @@
           <version>999</version>
           <scope>system</scope>
           <systemPath>${java.home}/../src.zip</systemPath>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>srczip-base</id>
+      <activation>
+        <file>
+          <exists>${java.home}/src.zip</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>jdk</groupId>
+          <artifactId>srczip</artifactId>
+          <version>999</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/src.zip</systemPath>
           <optional>true</optional>
         </dependency>
       </dependencies>

--- a/android/guava/src/com/google/common/collect/ImmutableList.java
+++ b/android/guava/src/com/google/common/collect/ImmutableList.java
@@ -69,7 +69,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
 
   /**
    * Returns an immutable list containing a single element. This list behaves and performs
-   * comparably to {@link Collections#singleton}, but will not accept a null element. It is
+   * comparably to {@link Collections#singletonList}, but will not accept a null element. It is
    * preferable mainly for consistency and maintainability of your code.
    *
    * @throws NullPointerException if {@code element} is null

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -173,7 +173,7 @@
   </build>
   <profiles>
     <profile>
-      <id>srczip</id>
+      <id>srczip-parent</id>
       <activation>
         <file>
           <exists>${java.home}/../src.zip</exists>
@@ -186,6 +186,24 @@
           <version>999</version>
           <scope>system</scope>
           <systemPath>${java.home}/../src.zip</systemPath>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>srczip-base</id>
+      <activation>
+        <file>
+          <exists>${java.home}/src.zip</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>jdk</groupId>
+          <artifactId>srczip</artifactId>
+          <version>999</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/src.zip</systemPath>
           <optional>true</optional>
         </dependency>
       </dependencies>

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -84,7 +84,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
 
   /**
    * Returns an immutable list containing a single element. This list behaves and performs
-   * comparably to {@link Collections#singleton}, but will not accept a null element. It is
+   * comparably to {@link Collections#singletonList}, but will not accept a null element. It is
    * preferable mainly for consistency and maintainability of your code.
    *
    * @throws NullPointerException if {@code element} is null


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix ImmutableList#of Javadoc

Fixes #3561

a14d317807e63770c5e57a4307cd1e69ea233ba0

-------

<p> Attempt to fix inheriting Javadoc from the JDK again.

It's currently missing:
https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/primitives/UnsignedInteger.html#equals-java.lang.Object-

But I haven't managed to reproduce the problem locally.

I'm trying this on the theory that java.home might be pointing to the JDK (the top-level directory in which src.zip lives) rather than the JRE (a subdirectory).

Note that JDK11 has src.zip in a lib/ subdirectory. I tried adding it to a Java 11 build of Guava, but things blew up because the JDK contains module declarations, which naturally are incompatible with our -source 8. Possibly the right fix there is to avoid -source 8 in favor of the approach I used for jimfs in CL 272937179 -- except that maybe I already tried that and it wasn't sufficient? I'm happy to punt on that for now, especially since I just tried removing -source 8 and got a bunch of "too many module declarations found" errors :)

4c83832db7e6ae8d0cd351fac7fe28f4116ef0de