### PR TITLE
Upgrade checker-qual to v2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>2.10.0</version>
+        <version>2.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
The `checker-qual` version that `guava` is using (`v2.8.1`) is a few releases behind. It would be good to upgrade to the latest version `v2.11.1`. There doesn't seem to be any breaking changes on the [changelog](https://github.com/typetools/checker-framework/releases) and tests are passing after the change.

## Changelog

- Upgrade `org.checkerframework:checker-qual` from v2.8.1 to v2.11.1.