### PR TITLE
Update 'adding Guava to your build using Gradle' snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,24 @@ To add a dependency using Gradle:
 
 ```gradle
 dependencies {
-  compile 'com.google.guava:guava:28.1-jre'
-  // or, for Android:
-  api 'com.google.guava:guava:28.1-android'
+  // Pick one:
+
+  // 1. Use Guava in your implementation only:
+  implementation("com.google.guava:guava:28.1-jre")
+
+  // 2. Use Guava types in your public API:
+  api("com.google.guava:guava:28.1-jre")
+
+  // 3. Android - Use Guava in your implementation only:
+  implementation("com.google.guava:guava:28.1-android")
+
+  // 4. Android - Use Guava types in your public API:
+  api("com.google.guava:guava:28.1-android")
 }
 ```
+
+For more information on when to use `api` and when to use `implementation`, consult the
+[Gradle documentation on API and implementation separation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).
 
 ## Snapshots
 


### PR DESCRIPTION
Hello from Gradle 👋 

I noticed that the 'adding Guava to your build using Gradle' section in the README could use an update. So here it is.

The notation with brackets - () - and double quotes - " - is valid in both Gradle's Groovy and Kotlin DSL. The keyword (the 'configuration') determines the scopes in which  the dependency is visible. "compile" is already discouraged since some time and officially deprecated with Gradle 6. "implementation" and "api" are both possible, but the initial recommendation for using a
library should be "implementation".

https://docs.gradle.org/6.0-rc-1/userguide/java_library_plugin.html#sec:java_library_recognizing_dependencies