### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,25 @@ To add a dependency using Gradle:
 
 ```gradle
 dependencies {
-  compile 'com.google.guava:guava:28.1-jre'
-  // or, for Android:
-  api 'com.google.guava:guava:28.1-android'
+  // Pick one:
+
+  // 1. Use Guava in your implementation only:
+  implementation("com.google.guava:guava:28.1-jre")
+
+  // 2. Use Guava types in your public API:
+  api("com.google.guava:guava:28.1-jre")
+
+  // 3. Android - Use Guava in your implementation only:
+  implementation("com.google.guava:guava:28.1-android")
+
+  // 4. Android - Use Guava types in your public API:
+  api("com.google.guava:guava:28.1-android")
 }
 ```
+
+For more information on when to use `api` and when to use `implementation`,
+consult the
+[Gradle documentation on API and implementation separation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).
 
 ## Snapshots
 
@@ -52,21 +66,21 @@ Snapshots of Guava built from the `master` branch are available through Maven
 using version `HEAD-jre-SNAPSHOT`, or `HEAD-android-SNAPSHOT` for the Android
 flavor.
 
-- Snapshot API Docs: [guava][guava-snapshot-api-docs]
-- Snapshot API Diffs: [guava][guava-snapshot-api-diffs]
+-   Snapshot API Docs: [guava][guava-snapshot-api-docs]
+-   Snapshot API Diffs: [guava][guava-snapshot-api-diffs]
 
 ## Learn about Guava
 
-- Our users' guide, [Guava Explained]
+-   Our users' guide, [Guava Explained]
 - [A nice collection](http://www.tfnico.com/presentations/google-guava) of other helpful links
 
 ## Links
 
-- [GitHub project](https://github.com/google/guava)
-- [Issue tracker: Report a defect or feature request](https://github.com/google/guava/issues/new)
-- [StackOverflow: Ask "how-to" and "why-didn't-it-work" questions](https://stackoverflow.com/questions/ask?tags=guava+java)
-- [guava-announce: Announcements of releases and upcoming significant changes](http://groups.google.com/group/guava-announce)
-- [guava-discuss: For open-ended questions and discussion](http://groups.google.com/group/guava-discuss)
+-   [GitHub project](https://github.com/google/guava)
+-   [Issue tracker: Report a defect or feature request](https://github.com/google/guava/issues/new)
+-   [StackOverflow: Ask "how-to" and "why-didn't-it-work" questions](https://stackoverflow.com/questions/ask?tags=guava+java)
+-   [guava-announce: Announcements of releases and upcoming significant changes](http://groups.google.com/group/guava-announce)
+-   [guava-discuss: For open-ended questions and discussion](http://groups.google.com/group/guava-discuss)
 
 ## IMPORTANT WARNINGS
 
@@ -78,17 +92,17 @@ not use beta APIs, unless you [repackage] them. **If your
 code is a library, we strongly recommend using the [Guava Beta Checker] to
 ensure that you do not use any `@Beta` APIs!**
 
-2. APIs without `@Beta` will remain binary-compatible for the indefinite
+2.  APIs without `@Beta` will remain binary-compatible for the indefinite
 future. (Previously, we sometimes removed such APIs after a deprecation period.
 The last release to remove non-`@Beta` APIs was Guava 21.0.) Even `@Deprecated`
 APIs will remain (again, unless they are `@Beta`). We have no plans to start
 removing things again, but officially, we're leaving our options open in case
 of surprises (like, say, a serious security problem).
 
-3. Guava has one dependency that is needed at runtime:
+3.  Guava has one dependency that is needed at runtime:
 `com.google.guava:failureaccess:1.0.1`
 
-4. Serialized forms of ALL objects are subject to change unless noted
+4.  Serialized forms of ALL objects are subject to change unless noted
 otherwise. Do not persist these and assume they can be read by a
 future version of the library.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Guava's Maven group ID is `com.google.guava` and its artifact ID is `guava`.
 Guava provides two different "flavors": one for use on a (Java 8+) JRE and one
 for use on Android or Java 7 or by any library that wants to be compatible with
 either of those. These flavors are specified in the Maven version field as
-either `28.1-jre` or `28.1-android`. For more about depending on
-Guava, see [using Guava in your build].
+either `28.1-jre` or `28.1-android`. For more about depending on Guava, see
+[using Guava in your build].
 
 To add a dependency on Guava using Maven, use the following:
 
@@ -72,7 +72,8 @@ flavor.
 ## Learn about Guava
 
 -   Our users' guide, [Guava Explained]
-- [A nice collection](http://www.tfnico.com/presentations/google-guava) of other helpful links
+-   [A nice collection](http://www.tfnico.com/presentations/google-guava) of
+    other helpful links
 
 ## Links
 
@@ -84,36 +85,34 @@ flavor.
 
 ## IMPORTANT WARNINGS
 
-1. APIs marked with the `@Beta` annotation at the class or method level
-are subject to change. They can be modified in any way, or even
-removed, at any time. If your code is a library itself (i.e. it is
-used on the CLASSPATH of users outside your own control), you should
-not use beta APIs, unless you [repackage] them. **If your
-code is a library, we strongly recommend using the [Guava Beta Checker] to
-ensure that you do not use any `@Beta` APIs!**
+1.  APIs marked with the `@Beta` annotation at the class or method level are
+    subject to change. They can be modified in any way, or even removed, at any
+    time. If your code is a library itself (i.e. it is used on the CLASSPATH of
+    users outside your own control), you should not use beta APIs, unless you
+    [repackage] them. **If your code is a library, we strongly recommend using
+    the [Guava Beta Checker] to ensure that you do not use any `@Beta` APIs!**
 
 2.  APIs without `@Beta` will remain binary-compatible for the indefinite
-future. (Previously, we sometimes removed such APIs after a deprecation period.
-The last release to remove non-`@Beta` APIs was Guava 21.0.) Even `@Deprecated`
-APIs will remain (again, unless they are `@Beta`). We have no plans to start
-removing things again, but officially, we're leaving our options open in case
-of surprises (like, say, a serious security problem).
+    future. (Previously, we sometimes removed such APIs after a deprecation
+    period. The last release to remove non-`@Beta` APIs was Guava 21.0.) Even
+    `@Deprecated` APIs will remain (again, unless they are `@Beta`). We have no
+    plans to start removing things again, but officially, we're leaving our
+    options open in case of surprises (like, say, a serious security problem).
 
 3.  Guava has one dependency that is needed at runtime:
-`com.google.guava:failureaccess:1.0.1`
+    `com.google.guava:failureaccess:1.0.1`
 
 4.  Serialized forms of ALL objects are subject to change unless noted
-otherwise. Do not persist these and assume they can be read by a
-future version of the library.
+    otherwise. Do not persist these and assume they can be read by a future
+    version of the library.
 
-5. Our classes are not designed to protect against a malicious caller.
-You should not use them for communication between trusted and
-untrusted code.
+5.  Our classes are not designed to protect against a malicious caller. You
+    should not use them for communication between trusted and untrusted code.
 
-6. For the mainline flavor, we unit-test the libraries using only OpenJDK 1.8 on
-Linux. Some features, especially in `com.google.common.io`, may not work
-correctly in other environments. For the Android flavor, our unit tests run on
-API level 15 (Ice Cream Sandwich).
+6.  For the mainline flavor, we unit-test the libraries using only OpenJDK 1.8
+    on Linux. Some features, especially in `com.google.common.io`, may not work
+    correctly in other environments. For the Android flavor, our unit tests run
+    on API level 15 (Ice Cream Sandwich).
 
 [guava-snapshot-api-docs]: https://google.github.io/guava/releases/snapshot-jre/api/docs/
 [guava-snapshot-api-diffs]: https://google.github.io/guava/releases/snapshot-jre/api/diffs/

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -220,24 +220,6 @@
       </dependencies>
     </profile>
     <profile>
-      <id>srczip-base</id>
-      <activation>
-        <file>
-          <exists>${java.home}/src.zip</exists>
-        </file>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>jdk</groupId>
-          <artifactId>srczip</artifactId>
-          <version>999</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/src.zip</systemPath>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
       <id>srczip-lib</id>
       <activation>
         <file>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -220,24 +220,6 @@
       </dependencies>
     </profile>
     <profile>
-      <id>srczip-base</id>
-      <activation>
-        <file>
-          <exists>${java.home}/src.zip</exists>
-        </file>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>jdk</groupId>
-          <artifactId>srczip</artifactId>
-          <version>999</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/src.zip</systemPath>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
       <id>srczip-lib</id>
       <activation>
         <file>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rollback

*** Reason for rollback ***

Didn't work: https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/primitives/UnsignedInteger.html#equals-java.lang.Object-

*** Original change description ***

Attempt to fix inheriting Javadoc from the JDK again.

It's currently missing:
https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/primitives/UnsignedInteger.html#equals-java.lang.Object-

But I haven't managed to reproduce the problem locally.

I'm trying this on the theory that java.home might be pointing to the JDK (the top-level directory in which src.zip lives) rather than the JRE (a subdirectory).

Note that JDK11 has src.zip in a lib/ subdirectory. I tried adding it to a Ja...

***

5b6537baac6ae0569b9411e578c8d37f75cc716a

-------

<p> Update 'adding Guava to your build using Gradle' snippet

The notation with brackets - () - and double quotes - " - is valid
in both Gradle's Groovy and Kotlin DSL.

The "compile" configuration is already discouraged since some time and
officially deprecated with Gradle 6.

Fixes #3673

f4866c6d50df1551a75986b1bb5d34b9245634d1

-------

<p> Format README.md.

c850b5742a68be52b5d08a7fdf544627088beb4d