### PR TITLE
MOE Sync 2019-10-29

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureFallbackAtomicHelperTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureFallbackAtomicHelperTest.java
@@ -39,7 +39,7 @@ import junit.framework.TestSuite;
  * </ul>
  *
  * To force selection of our fallback strategies we load {@link AbstractFuture} (and all of {@code
- * com.google.common.util.concurrent} in degenerate class loaders which make certain platform
+ * com.google.common.util.concurrent}) in degenerate class loaders which make certain platform
  * classes unavailable. Then we construct a test suite so we can run the normal AbstractFutureTest
  * test methods in these degenerate classloaders.
  */

--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -290,8 +290,8 @@ public class AbstractFutureTest extends TestCase {
     testFuture3.setFuture(testFuture2);
     assertThat(testFuture3.toString())
         .matches(
-            "[^\\[]+\\[status=PENDING, info=\\[setFuture="
-                + "\\[[^\\[]+\\[status=PENDING, info=\\[cause=\\[Someday...\\]\\]\\]\\]\\]\\]");
+            "[^\\[]+\\[status=PENDING, setFuture=\\[[^\\[]+\\[status=PENDING,"
+                + " info=\\[cause=\\[Someday...]]]]]");
     testFuture2.set("result string");
     assertThat(testFuture3.toString())
         .matches("[^\\[]+\\[status=SUCCESS, result=\\[result string\\]\\]");
@@ -886,7 +886,7 @@ public class AbstractFutureTest extends TestCase {
   public void testSetFutureSelf_toString() {
     SettableFuture<String> orig = SettableFuture.create();
     orig.setFuture(orig);
-    assertThat(orig.toString()).contains("[status=PENDING, info=[setFuture=[this future]]]");
+    assertThat(orig.toString()).contains("[status=PENDING, setFuture=[this future]]");
   }
 
   public void testSetSelf_toString() {

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.internal.InternalFutureFailureAccess;
 import com.google.common.util.concurrent.internal.InternalFutures;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -1064,23 +1065,7 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
     } else if (isDone()) {
       addDoneString(builder);
     } else {
-      String pendingDescription;
-      try {
-        pendingDescription = pendingToString();
-      } catch (RuntimeException e) {
-        // Don't call getMessage or toString() on the exception, in case the exception thrown by the
-        // subclass is implemented with bugs similar to the subclass.
-        pendingDescription = "Exception thrown from implementation: " + e.getClass();
-      }
-      // The future may complete during or before the call to getPendingToString, so we use null
-      // as a signal that we should try checking if the future is done again.
-      if (pendingDescription != null && !pendingDescription.isEmpty()) {
-        builder.append("PENDING, info=[").append(pendingDescription).append("]");
-      } else if (isDone()) {
-        addDoneString(builder);
-      } else {
-        builder.append("PENDING");
-      }
+      addPendingString(builder); // delegates to addDoneString if future completes mid-way
     }
     return builder.append("]").toString();
   }
@@ -1088,20 +1073,52 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
   /**
    * Provide a human-readable explanation of why this future has not yet completed.
    *
-   * @return null if an explanation cannot be provided because the future is done.
+   * @return null if an explanation cannot be provided (e.g. because the future is done).
    * @since 23.0
    */
   @NullableDecl
   protected String pendingToString() {
-    Object localValue = value;
-    if (localValue instanceof SetFuture) {
-      return "setFuture=[" + userObjectToString(((SetFuture) localValue).future) + "]";
-    } else if (this instanceof ScheduledFuture) {
+    // TODO(diamondm) consider moving this into addPendingString so it's always in the output
+    if (this instanceof ScheduledFuture) {
       return "remaining delay=["
           + ((ScheduledFuture) this).getDelay(TimeUnit.MILLISECONDS)
           + " ms]";
     }
     return null;
+  }
+
+  private void addPendingString(StringBuilder builder) {
+    // Be careful not to append to the builder with anything that might be invalidated
+
+    String pendingDescription;
+    try {
+      pendingDescription = Strings.emptyToNull(pendingToString());
+    } catch (RuntimeException e) {
+      // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+      // subclass is implemented with bugs similar to the subclass.
+      pendingDescription = "Exception thrown from implementation: " + e.getClass();
+    }
+
+    String setFutureString = null;
+    Object localValue = value;
+    if (localValue instanceof SetFuture) {
+      setFutureString = userObjectToString(((SetFuture) localValue).future);
+    }
+
+    // The future may complete before we reach this point, so we check once more to see if the
+    // future is done
+    if (isDone()) {
+      addDoneString(builder);
+      return;
+    }
+
+    builder.append("PENDING");
+    if (pendingDescription != null) {
+      builder.append(", info=[").append(pendingDescription).append("]");
+    }
+    if (setFutureString != null) {
+      builder.append(", setFuture=[").append(setFutureString).append("]");
+    }
   }
 
   private void addDoneString(StringBuilder builder) {

--- a/android/guava/src/com/google/common/util/concurrent/AggregateFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AggregateFuture.java
@@ -90,9 +90,9 @@ abstract class AggregateFuture<InputT, OutputT> extends AggregateFutureState<Out
   protected final String pendingToString() {
     ImmutableCollection<? extends Future<?>> localFutures = futures;
     if (localFutures != null) {
-      return "futures=[" + localFutures + "]";
+      return "futures=" + localFutures;
     }
-    return null;
+    return super.pendingToString();
   }
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -105,7 +105,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
         listenerExecutor.execute(this);
       } catch (RejectedExecutionException e) {
         if (thrownByExecute) {
-          setException(e);
+          CombinedFuture.this.setException(e);
         }
       }
     }
@@ -127,11 +127,11 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
       if (error != null) {
         if (error instanceof ExecutionException) {
-          setException(error.getCause());
+          CombinedFuture.this.setException(error.getCause());
         } else if (error instanceof CancellationException) {
           cancel(false);
         } else {
-          setException(error);
+          CombinedFuture.this.setException(error);
         }
       } else {
         setValue(result);
@@ -164,7 +164,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     void setValue(ListenableFuture<V> value) {
-      setFuture(value);
+      CombinedFuture.this.setFuture(value);
     }
 
     @Override

--- a/guava-gwt/test/com/google/common/util/concurrent/FuturesTest_gwt.java
+++ b/guava-gwt/test/com/google/common/util/concurrent/FuturesTest_gwt.java
@@ -3069,33 +3069,6 @@ public void testWhenAllComplete_asyncError() throws Exception {
   }
 }
 
-public void testWhenAllComplete_asyncResult() throws Exception {
-  com.google.common.util.concurrent.FuturesTest testCase = new com.google.common.util.concurrent.FuturesTest();
-  testCase.setUp();
-  Throwable failure = null;
-  try {
-    testCase.testWhenAllComplete_asyncResult();
-  } catch (Throwable t) {
-    failure = t;
-  }
-  try {
-    testCase.tearDown();
-  } catch (Throwable t) {
-    if (failure == null) {
-      failure = t;
-    }
-  }
-  if (failure instanceof Exception) {
-    throw (Exception) failure;
-  }
-  if (failure instanceof Error) {
-    throw (Error) failure;
-  }
-  if (failure != null) {
-    throw new RuntimeException(failure);
-  }
-}
-
 public void testWhenAllComplete_runnableError() throws Exception {
   com.google.common.util.concurrent.FuturesTest testCase = new com.google.common.util.concurrent.FuturesTest();
   testCase.setUp();

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureFallbackAtomicHelperTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureFallbackAtomicHelperTest.java
@@ -39,7 +39,7 @@ import junit.framework.TestSuite;
  * </ul>
  *
  * To force selection of our fallback strategies we load {@link AbstractFuture} (and all of {@code
- * com.google.common.util.concurrent} in degenerate class loaders which make certain platform
+ * com.google.common.util.concurrent}) in degenerate class loaders which make certain platform
  * classes unavailable. Then we construct a test suite so we can run the normal AbstractFutureTest
  * test methods in these degenerate classloaders.
  */

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -290,8 +290,8 @@ public class AbstractFutureTest extends TestCase {
     testFuture3.setFuture(testFuture2);
     assertThat(testFuture3.toString())
         .matches(
-            "[^\\[]+\\[status=PENDING, info=\\[setFuture="
-                + "\\[[^\\[]+\\[status=PENDING, info=\\[cause=\\[Someday...\\]\\]\\]\\]\\]\\]");
+            "[^\\[]+\\[status=PENDING, setFuture=\\[[^\\[]+\\[status=PENDING,"
+                + " info=\\[cause=\\[Someday...]]]]]");
     testFuture2.set("result string");
     assertThat(testFuture3.toString())
         .matches("[^\\[]+\\[status=SUCCESS, result=\\[result string\\]\\]");
@@ -886,7 +886,7 @@ public class AbstractFutureTest extends TestCase {
   public void testSetFutureSelf_toString() {
     SettableFuture<String> orig = SettableFuture.create();
     orig.setFuture(orig);
-    assertThat(orig.toString()).contains("[status=PENDING, info=[setFuture=[this future]]]");
+    assertThat(orig.toString()).contains("[status=PENDING, setFuture=[this future]]");
   }
 
   public void testSetSelf_toString() {

--- a/guava/src/com/google/common/util/concurrent/AggregateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AggregateFuture.java
@@ -90,9 +90,9 @@ abstract class AggregateFuture<InputT, OutputT> extends AggregateFutureState<Out
   protected final String pendingToString() {
     ImmutableCollection<? extends Future<?>> localFutures = futures;
     if (localFutures != null) {
-      return "futures=[" + localFutures + "]";
+      return "futures=" + localFutures;
     }
-    return null;
+    return super.pendingToString();
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -105,7 +105,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
         listenerExecutor.execute(this);
       } catch (RejectedExecutionException e) {
         if (thrownByExecute) {
-          setException(e);
+          CombinedFuture.this.setException(e);
         }
       }
     }
@@ -127,11 +127,11 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
       if (error != null) {
         if (error instanceof ExecutionException) {
-          setException(error.getCause());
+          CombinedFuture.this.setException(error.getCause());
         } else if (error instanceof CancellationException) {
           cancel(false);
         } else {
-          setException(error);
+          CombinedFuture.this.setException(error);
         }
       } else {
         setValue(result);
@@ -164,7 +164,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     void setValue(ListenableFuture<V> value) {
-      setFuture(value);
+      CombinedFuture.this.setFuture(value);
     }
 
     @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move the SetFuture check into AbstractFuture.toString() and out of pendingToString(), so that even if the latter is overriden we can include the SetFuture detail.

This is useful for futures that initially do some of their own work, but then delegate to setFuture(), as FutureCombiner.callAsync() does.

68bdc31a5cc1ff0dfb3af4003703d93d09ef6485