### PR TITLE
MOE Sync 2019-10-31

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -895,6 +895,21 @@ public class AbstractFutureTest extends TestCase {
     assertThat(orig.toString()).contains("[status=SUCCESS, result=[this future]]");
   }
 
+  public void testSetFutureSelf_toStringException() {
+    SettableFuture<String> orig = SettableFuture.create();
+    orig.setFuture(
+        new AbstractFuture<String>() {
+          @Override
+          public String toString() {
+            throw new NullPointerException();
+          }
+        });
+    assertThat(orig.toString())
+        .contains(
+            "[status=PENDING, setFuture=[Exception thrown from implementation: class"
+                + " java.lang.NullPointerException]]");
+  }
+
   public void testSetIndirectSelf_toString() {
     final SettableFuture<Object> orig = SettableFuture.create();
     // unlike the above this indirection defeats the trivial cycle detection and causes a SOE

--- a/android/guava/src/com/google/common/primitives/UnsignedBytes.java
+++ b/android/guava/src/com/google/common/primitives/UnsignedBytes.java
@@ -121,11 +121,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the least value present in {@code array}.
+   * Returns the least value present in {@code array}, treating values as unsigned.
    *
    * @param array a <i>nonempty</i> array of {@code byte} values
    * @return the value present in {@code array} that is less than or equal to every other value in
-   *     the array
+   *     the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte min(byte... array) {
@@ -141,11 +141,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the greatest value present in {@code array}.
+   * Returns the greatest value present in {@code array}, treating values as unsigned.
    *
    * @param array a <i>nonempty</i> array of {@code byte} values
    * @return the value present in {@code array} that is greater than or equal to every other value
-   *     in the array
+   *     in the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte max(byte... array) {

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -1143,7 +1143,13 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
     if (o == this) {
       return "this future";
     }
-    return String.valueOf(o);
+    try {
+      return String.valueOf(o);
+    } catch (RuntimeException e) {
+      // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+      // user object is implemented with bugs similar to the user object.
+      return "Exception thrown from implementation: " + e.getClass();
+    }
   }
 
   /**

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -895,6 +895,21 @@ public class AbstractFutureTest extends TestCase {
     assertThat(orig.toString()).contains("[status=SUCCESS, result=[this future]]");
   }
 
+  public void testSetFutureSelf_toStringException() {
+    SettableFuture<String> orig = SettableFuture.create();
+    orig.setFuture(
+        new AbstractFuture<String>() {
+          @Override
+          public String toString() {
+            throw new NullPointerException();
+          }
+        });
+    assertThat(orig.toString())
+        .contains(
+            "[status=PENDING, setFuture=[Exception thrown from implementation: class"
+                + " java.lang.NullPointerException]]");
+  }
+
   public void testSetIndirectSelf_toString() {
     final SettableFuture<Object> orig = SettableFuture.create();
     // unlike the above this indirection defeats the trivial cycle detection and causes a SOE

--- a/guava/src/com/google/common/primitives/UnsignedBytes.java
+++ b/guava/src/com/google/common/primitives/UnsignedBytes.java
@@ -121,11 +121,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the least value present in {@code array}.
+   * Returns the least value present in {@code array}, treating values as unsigned.
    *
    * @param array a <i>nonempty</i> array of {@code byte} values
    * @return the value present in {@code array} that is less than or equal to every other value in
-   *     the array
+   *     the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte min(byte... array) {
@@ -141,11 +141,11 @@ public final class UnsignedBytes {
   }
 
   /**
-   * Returns the greatest value present in {@code array}.
+   * Returns the greatest value present in {@code array}, treating values as unsigned.
    *
    * @param array a <i>nonempty</i> array of {@code byte} values
    * @return the value present in {@code array} that is greater than or equal to every other value
-   *     in the array
+   *     in the array according to {@link #compare}
    * @throws IllegalArgumentException if {@code array} is empty
    */
   public static byte max(byte... array) {

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -1142,7 +1142,13 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
     if (o == this) {
       return "this future";
     }
-    return String.valueOf(o);
+    try {
+      return String.valueOf(o);
+    } catch (RuntimeException e) {
+      // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+      // user object is implemented with bugs similar to the user object.
+      return "Exception thrown from implementation: " + e.getClass();
+    }
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -1087,43 +1087,46 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
   }
 
   private void addPendingString(StringBuilder builder) {
-    // Be careful not to append to the builder with anything that might be invalidated
-
-    String pendingDescription;
-    try {
-      pendingDescription = Strings.emptyToNull(pendingToString());
-    } catch (RuntimeException e) {
-      // Don't call getMessage or toString() on the exception, in case the exception thrown by the
-      // subclass is implemented with bugs similar to the subclass.
-      pendingDescription = "Exception thrown from implementation: " + e.getClass();
-    }
-
-    String setFutureString = null;
-    Object localValue = value;
-    if (localValue instanceof SetFuture) {
-      setFutureString = userObjectToString(((SetFuture) localValue).future);
-    }
-
-    // The future may complete before we reach this point, so we check once more to see if the
-    // future is done
-    if (isDone()) {
-      addDoneString(builder);
-      return;
-    }
+    // Capture current builder length so it can be truncated if this future ends up completing while
+    // the toString is being calculated
+    int truncateLength = builder.length();
 
     builder.append("PENDING");
-    if (pendingDescription != null) {
-      builder.append(", info=[").append(pendingDescription).append("]");
+
+    Object localValue = value;
+    if (localValue instanceof SetFuture) {
+      builder.append(", setFuture=[");
+      appendUserObject(builder, ((SetFuture) localValue).future);
+      builder.append("]");
+    } else {
+      String pendingDescription;
+      try {
+        pendingDescription = Strings.emptyToNull(pendingToString());
+      } catch (RuntimeException | StackOverflowError e) {
+        // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+        // subclass is implemented with bugs similar to the subclass.
+        pendingDescription = "Exception thrown from implementation: " + e.getClass();
+      }
+      if (pendingDescription != null) {
+        builder.append(", info=[").append(pendingDescription).append("]");
+      }
     }
-    if (setFutureString != null) {
-      builder.append(", setFuture=[").append(setFutureString).append("]");
+
+    // The future may complete while calculating the toString, so we check once more to see if the
+    // future is done
+    if (isDone()) {
+      // Truncate anything that was appended before realizing this future is done
+      builder.delete(truncateLength, builder.length());
+      addDoneString(builder);
     }
   }
 
   private void addDoneString(StringBuilder builder) {
     try {
       V value = getUninterruptibly(this);
-      builder.append("SUCCESS, result=[").append(userObjectToString(value)).append("]");
+      builder.append("SUCCESS, result=[");
+      appendUserObject(builder, value);
+      builder.append("]");
     } catch (ExecutionException e) {
       builder.append("FAILURE, cause=[").append(e.getCause()).append("]");
     } catch (CancellationException e) {
@@ -1134,20 +1137,21 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
   }
 
   /** Helper for printing user supplied objects into our toString method. */
-  private String userObjectToString(Object o) {
-    // This is some basic recursion detection for when people create cycles via set/setFuture
-    // This is however only partial protection though since it only detects self loops.  We could
-    // detect arbitrary cycles using a thread local or possibly by catching StackOverflowExceptions
-    // but this should be a good enough solution (it is also what jdk collections do in these cases)
-    if (o == this) {
-      return "this future";
-    }
+  private void appendUserObject(StringBuilder builder, Object o) {
+    // This is some basic recursion detection for when people create cycles via set/setFuture or
+    // when deep chains of futures exist resulting in a StackOverflowException. We could detect
+    // arbitrary cycles using a thread local but this should be a good enough solution (it is also
+    // what jdk collections do in these cases)
     try {
-      return String.valueOf(o);
-    } catch (RuntimeException e) {
+      if (o == this) {
+        builder.append("this future");
+      } else {
+        builder.append(o);
+      }
+    } catch (RuntimeException | StackOverflowError e) {
       // Don't call getMessage or toString() on the exception, in case the exception thrown by the
       // user object is implemented with bugs similar to the user object.
-      return "Exception thrown from implementation: " + e.getClass();
+      builder.append("Exception thrown from implementation: ").append(e.getClass());
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix toString exception handling change from 957c37116fb2cc52b2f8b405871b65a84917f2ca.

This is not an ideal code fix but it restores the previous functionality and adds a test that verifies the exception handling logic.

82b7589dfbfc5f2b6f68d6a6a1bb34e4633f4f3c

-------

<p> Handle StackOverflowError from both pendingToString and appendUserObject.

Adds a bunch of tests to validate error handling in toString code
- Verify that a future completing during the toString call results in a done formatted string
- Verify that an exception thrown by pendingToString doesn't cause toString to fail
- Verify that cycles don't cause toString to fail
- Verify that deep chains of SetFuture don't cause toString to fail

RELNOTES=Catch StackOverflowError in AbstractFuture.toString to prevent long chains of futures from failing toString calls.

29981d416d6b4214e65360ad3d932ba0881a4c8f

-------

<p> Update Documentation

Fixes #3507

8a0d6bb345341fc0ba91781070da5b522d4b714b