### PR TITLE
Upgrade maven source plugin from 3.1.0 to 3.2.0 - Reproducible Builds

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -17,7 +17,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+    <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <truth.version>0.44</truth.version>
     <animal.sniffer.version>1.18</animal.sniffer.version>
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+    <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>


### PR DESCRIPTION
Upgrade maven source plugin from 3.1.0 to [3.2.0](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) 
Maven source and jar plugins both introduced [build reproducibility](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) (Maven jar plugin upgrade in #3534) in 3.2.0