### PR TITLE
MOE Sync 2019-11-06

### DIFF
--- a/android/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
@@ -34,7 +34,8 @@ public class ForwardingCacheTest extends TestCase {
   private Cache<String, Boolean> forward;
   private Cache<String, Boolean> mock;
 
-  @SuppressWarnings("unchecked") // mock
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/android/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
@@ -34,7 +34,8 @@ public class ForwardingLoadingCacheTest extends TestCase {
   private LoadingCache<String, Boolean> forward;
   private LoadingCache<String, Boolean> mock;
 
-  @SuppressWarnings("unchecked") // mock
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/android/guava-tests/test/com/google/common/collect/ConcurrentHashMultisetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ConcurrentHashMultisetTest.java
@@ -20,8 +20,8 @@ import static com.google.common.collect.MapMakerInternalMap.Strength.STRONG;
 import static com.google.common.collect.MapMakerInternalMap.Strength.WEAK;
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/android/guava-tests/test/com/google/common/collect/ForwardingMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ForwardingMapTest.java
@@ -17,7 +17,7 @@
 package com.google.common.collect;
 
 import static java.lang.reflect.Modifier.STATIC;
-import static org.mockito.Mockito.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -231,10 +231,10 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardEntrySet
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsKey(anyObject());
-    verify(map, atLeast(0)).get(anyObject());
+    verify(map, atLeast(0)).containsKey(any());
+    verify(map, atLeast(0)).get(any());
     verify(map, atLeast(0)).isEmpty();
-    verify(map, atLeast(0)).remove(anyObject());
+    verify(map, atLeast(0)).remove(any());
     verify(map, atLeast(0)).size();
     verifyNoMoreInteractions(map);
   }
@@ -259,9 +259,9 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardKeySet
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsKey(anyObject());
+    verify(map, atLeast(0)).containsKey(any());
     verify(map, atLeast(0)).isEmpty();
-    verify(map, atLeast(0)).remove(anyObject());
+    verify(map, atLeast(0)).remove(any());
     verify(map, atLeast(0)).size();
     verify(map, atLeast(0)).entrySet();
     verifyNoMoreInteractions(map);
@@ -287,7 +287,7 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardValues
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsValue(anyObject());
+    verify(map, atLeast(0)).containsValue(any());
     verify(map, atLeast(0)).isEmpty();
     verify(map, atLeast(0)).size();
     verify(map, atLeast(0)).entrySet();

--- a/android/guava-tests/test/com/google/common/hash/FunnelsTest.java
+++ b/android/guava-tests/test/com/google/common/hash/FunnelsTest.java
@@ -93,7 +93,8 @@ public class FunnelsTest extends TestCase {
   }
 
   public void testSequential() {
-    @SuppressWarnings("unchecked")
+    // go/do-not-mock-common-types-lsc
+    @SuppressWarnings({"unchecked", "DoNotMock"})
     Funnel<Object> elementFunnel = mock(Funnel.class);
     PrimitiveSink primitiveSink = mock(PrimitiveSink.class);
     Funnel<Iterable<?>> sequential = Funnels.sequentialFunnel(elementFunnel);

--- a/android/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
+++ b/android/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
@@ -35,6 +35,8 @@ public class HashingInputStreamTest extends TestCase {
   private static final byte[] testBytes = new byte[] {'y', 'a', 'm', 's'};
   private ByteArrayInputStream buffer;
 
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {
     super.setUp();

--- a/android/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
+++ b/android/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
@@ -33,6 +33,8 @@ public class HashingOutputStreamTest extends TestCase {
   private HashFunction hashFunction;
   private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {
     super.setUp();

--- a/android/guava/src/com/google/common/graph/AbstractGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/AbstractGraphBuilder.java
@@ -27,6 +27,8 @@ abstract class AbstractGraphBuilder<N> {
   final boolean directed;
   boolean allowsSelfLoops = false;
   ElementOrder<N> nodeOrder = ElementOrder.insertion();
+  ElementOrder<N> incidentEdgeOrder = ElementOrder.unordered();
+
   Optional<Integer> expectedNodeCount = Optional.absent();
 
   /**

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -16,6 +16,7 @@
 
 package com.google.common.graph;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.graph.Graphs.checkNonNegative;
 
@@ -89,6 +90,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
     return new GraphBuilder<N>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
         .nodeOrder(graph.nodeOrder());
+    // TODO(b/142723300): Add incidentEdgeOrder
   }
 
   /**
@@ -133,6 +135,31 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   public <N1 extends N> GraphBuilder<N1> nodeOrder(ElementOrder<N1> nodeOrder) {
     GraphBuilder<N1> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);
+    return newBuilder;
+  }
+
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#edges()}, {@link
+   * Graph#adjacentNodes(Object)}, {@link Graph#predecessors(Object)}, {@link
+   * Graph#successors(Object)} and {@link Graph#incidentEdges(Object)}.
+   *
+   * <p>The default value is {@link ElementOrder#unordered() unordered} for mutable graphs. For
+   * immutable graphs, this value is ignored; they always have a {@link ElementOrder#stable()
+   * stable} order.
+   *
+   * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
+   *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
+   */
+  // TODO(b/142723300): Make this method public
+  <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+    checkArgument(
+        incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
+            || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,
+        "The given elementOrder (%s) is unsupported. incidentEdgeOrder() only supports"
+            + " ElementOrder.unordered() and ElementOrder.stable().",
+        incidentEdgeOrder);
+    GraphBuilder<N1> newBuilder = cast();
+    newBuilder.incidentEdgeOrder = checkNotNull(incidentEdgeOrder);
     return newBuilder;
   }
 

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -98,6 +98,9 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    *
    * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
    *
+   * <p>Note that the returned builder will always have {@link #incidentEdgeOrder} set to {@link
+   * ElementOrder#stable()}, regardless of the value that was set in this builder.
+   *
    * @since 28.0
    */
   public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
@@ -166,6 +169,15 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   /** Returns an empty {@link MutableGraph} with the properties of this {@link GraphBuilder}. */
   public <N1 extends N> MutableGraph<N1> build() {
     return new ConfigurableMutableGraph<N1>(this);
+  }
+
+  GraphBuilder<N> copy() {
+    GraphBuilder<N> newBuilder = new GraphBuilder<>(directed);
+    newBuilder.allowsSelfLoops = allowsSelfLoops;
+    newBuilder.nodeOrder = nodeOrder;
+    newBuilder.expectedNodeCount = expectedNodeCount;
+    newBuilder.incidentEdgeOrder = incidentEdgeOrder;
+    return newBuilder;
   }
 
   @SuppressWarnings("unchecked")

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -124,7 +124,9 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     private final MutableGraph<N> mutableGraph;
 
     Builder(GraphBuilder<N> graphBuilder) {
-      this.mutableGraph = graphBuilder.build();
+      // The incidentEdgeOrder for immutable graphs is always stable. However, we don't want to
+      // modify this builder, so we make a copy instead.
+      this.mutableGraph = graphBuilder.copy().incidentEdgeOrder(ElementOrder.<N>stable()).build();
     }
 
     /**

--- a/android/guava/src/com/google/common/net/InternetDomainName.java
+++ b/android/guava/src/com/google/common/net/InternetDomainName.java
@@ -237,8 +237,13 @@ public final class InternetDomainName {
 
   private static final CharMatcher DASH_MATCHER = CharMatcher.anyOf("-_");
 
+  private static final CharMatcher DIGIT_MATCHER = CharMatcher.inRange('0', '9');
+
+  private static final CharMatcher LETTER_MATCHER =
+      CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z'));
+
   private static final CharMatcher PART_CHAR_MATCHER =
-      CharMatcher.javaLetterOrDigit().or(DASH_MATCHER);
+      DIGIT_MATCHER.or(LETTER_MATCHER).or(DASH_MATCHER);
 
   /**
    * Helper method for {@link #validateSyntax(List)}. Validates that one part of a domain name is
@@ -287,7 +292,7 @@ public final class InternetDomainName {
      * address like 127.0.0.1 from looking like a valid domain name.
      */
 
-    if (isFinalPart && CharMatcher.digit().matches(part.charAt(0))) {
+    if (isFinalPart && DIGIT_MATCHER.matches(part.charAt(0))) {
       return false;
     }
 

--- a/android/guava/src/com/google/common/reflect/ClassPath.java
+++ b/android/guava/src/com/google/common/reflect/ClassPath.java
@@ -296,7 +296,7 @@ public final class ClassPath {
         String innerClassName = className.substring(lastDollarSign + 1);
         // local and anonymous classes are prefixed with number (1,2,3...), anonymous classes are
         // entirely numeric whereas local classes have the user supplied name as a suffix
-        return CharMatcher.digit().trimLeadingFrom(innerClassName);
+        return CharMatcher.inRange('0', '9').trimLeadingFrom(innerClassName);
       }
       String packageName = getPackageName();
       if (packageName.isEmpty()) {

--- a/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
@@ -34,7 +34,8 @@ public class ForwardingCacheTest extends TestCase {
   private Cache<String, Boolean> forward;
   private Cache<String, Boolean> mock;
 
-  @SuppressWarnings("unchecked") // mock
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
@@ -34,7 +34,8 @@ public class ForwardingLoadingCacheTest extends TestCase {
   private LoadingCache<String, Boolean> forward;
   private LoadingCache<String, Boolean> mock;
 
-  @SuppressWarnings("unchecked") // mock
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/guava-tests/test/com/google/common/collect/ConcurrentHashMultisetTest.java
+++ b/guava-tests/test/com/google/common/collect/ConcurrentHashMultisetTest.java
@@ -20,8 +20,8 @@ import static com.google.common.collect.MapMakerInternalMap.Strength.STRONG;
 import static com.google.common.collect.MapMakerInternalMap.Strength.WEAK;
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/guava-tests/test/com/google/common/collect/ForwardingMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ForwardingMapTest.java
@@ -17,7 +17,7 @@
 package com.google.common.collect;
 
 import static java.lang.reflect.Modifier.STATIC;
-import static org.mockito.Mockito.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -231,10 +231,10 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardEntrySet
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsKey(anyObject());
-    verify(map, atLeast(0)).get(anyObject());
+    verify(map, atLeast(0)).containsKey(any());
+    verify(map, atLeast(0)).get(any());
     verify(map, atLeast(0)).isEmpty();
-    verify(map, atLeast(0)).remove(anyObject());
+    verify(map, atLeast(0)).remove(any());
     verify(map, atLeast(0)).size();
     verifyNoMoreInteractions(map);
   }
@@ -259,9 +259,9 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardKeySet
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsKey(anyObject());
+    verify(map, atLeast(0)).containsKey(any());
     verify(map, atLeast(0)).isEmpty();
-    verify(map, atLeast(0)).remove(anyObject());
+    verify(map, atLeast(0)).remove(any());
     verify(map, atLeast(0)).size();
     verify(map, atLeast(0)).entrySet();
     verifyNoMoreInteractions(map);
@@ -287,7 +287,7 @@ public class ForwardingMapTest extends TestCase {
 
     // These are the methods specified by StandardValues
     verify(map, atLeast(0)).clear();
-    verify(map, atLeast(0)).containsValue(anyObject());
+    verify(map, atLeast(0)).containsValue(any());
     verify(map, atLeast(0)).isEmpty();
     verify(map, atLeast(0)).size();
     verify(map, atLeast(0)).entrySet();

--- a/guava-tests/test/com/google/common/hash/FunnelsTest.java
+++ b/guava-tests/test/com/google/common/hash/FunnelsTest.java
@@ -93,7 +93,8 @@ public class FunnelsTest extends TestCase {
   }
 
   public void testSequential() {
-    @SuppressWarnings("unchecked")
+    // go/do-not-mock-common-types-lsc
+    @SuppressWarnings({"unchecked", "DoNotMock"})
     Funnel<Object> elementFunnel = mock(Funnel.class);
     PrimitiveSink primitiveSink = mock(PrimitiveSink.class);
     Funnel<Iterable<?>> sequential = Funnels.sequentialFunnel(elementFunnel);

--- a/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
@@ -35,6 +35,8 @@ public class HashingInputStreamTest extends TestCase {
   private static final byte[] testBytes = new byte[] {'y', 'a', 'm', 's'};
   private ByteArrayInputStream buffer;
 
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {
     super.setUp();

--- a/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
@@ -33,6 +33,8 @@ public class HashingOutputStreamTest extends TestCase {
   private HashFunction hashFunction;
   private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
+  // go/do-not-mock-common-types-lsc
+  @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {
     super.setUp();

--- a/guava/src/com/google/common/graph/AbstractGraphBuilder.java
+++ b/guava/src/com/google/common/graph/AbstractGraphBuilder.java
@@ -27,6 +27,8 @@ abstract class AbstractGraphBuilder<N> {
   final boolean directed;
   boolean allowsSelfLoops = false;
   ElementOrder<N> nodeOrder = ElementOrder.insertion();
+  ElementOrder<N> incidentEdgeOrder = ElementOrder.unordered();
+
   Optional<Integer> expectedNodeCount = Optional.absent();
 
   /**

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -16,6 +16,7 @@
 
 package com.google.common.graph;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.graph.Graphs.checkNonNegative;
 
@@ -89,6 +90,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
     return new GraphBuilder<N>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
         .nodeOrder(graph.nodeOrder());
+    // TODO(b/142723300): Add incidentEdgeOrder
   }
 
   /**
@@ -133,6 +135,31 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   public <N1 extends N> GraphBuilder<N1> nodeOrder(ElementOrder<N1> nodeOrder) {
     GraphBuilder<N1> newBuilder = cast();
     newBuilder.nodeOrder = checkNotNull(nodeOrder);
+    return newBuilder;
+  }
+
+  /**
+   * Specifies the order of iteration for the elements of {@link Graph#edges()}, {@link
+   * Graph#adjacentNodes(Object)}, {@link Graph#predecessors(Object)}, {@link
+   * Graph#successors(Object)} and {@link Graph#incidentEdges(Object)}.
+   *
+   * <p>The default value is {@link ElementOrder#unordered() unordered} for mutable graphs. For
+   * immutable graphs, this value is ignored; they always have a {@link ElementOrder#stable()
+   * stable} order.
+   *
+   * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
+   *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
+   */
+  // TODO(b/142723300): Make this method public
+  <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+    checkArgument(
+        incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
+            || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,
+        "The given elementOrder (%s) is unsupported. incidentEdgeOrder() only supports"
+            + " ElementOrder.unordered() and ElementOrder.stable().",
+        incidentEdgeOrder);
+    GraphBuilder<N1> newBuilder = cast();
+    newBuilder.incidentEdgeOrder = checkNotNull(incidentEdgeOrder);
     return newBuilder;
   }
 

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -98,6 +98,9 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    *
    * <p>The returned builder can be used for populating an {@link ImmutableGraph}.
    *
+   * <p>Note that the returned builder will always have {@link #incidentEdgeOrder} set to {@link
+   * ElementOrder#stable()}, regardless of the value that was set in this builder.
+   *
    * @since 28.0
    */
   public <N1 extends N> ImmutableGraph.Builder<N1> immutable() {
@@ -166,6 +169,15 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   /** Returns an empty {@link MutableGraph} with the properties of this {@link GraphBuilder}. */
   public <N1 extends N> MutableGraph<N1> build() {
     return new ConfigurableMutableGraph<N1>(this);
+  }
+
+  GraphBuilder<N> copy() {
+    GraphBuilder<N> newBuilder = new GraphBuilder<>(directed);
+    newBuilder.allowsSelfLoops = allowsSelfLoops;
+    newBuilder.nodeOrder = nodeOrder;
+    newBuilder.expectedNodeCount = expectedNodeCount;
+    newBuilder.incidentEdgeOrder = incidentEdgeOrder;
+    return newBuilder;
   }
 
   @SuppressWarnings("unchecked")

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -124,7 +124,9 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     private final MutableGraph<N> mutableGraph;
 
     Builder(GraphBuilder<N> graphBuilder) {
-      this.mutableGraph = graphBuilder.build();
+      // The incidentEdgeOrder for immutable graphs is always stable. However, we don't want to
+      // modify this builder, so we make a copy instead.
+      this.mutableGraph = graphBuilder.copy().incidentEdgeOrder(ElementOrder.<N>stable()).build();
     }
 
     /**

--- a/guava/src/com/google/common/net/InternetDomainName.java
+++ b/guava/src/com/google/common/net/InternetDomainName.java
@@ -237,8 +237,13 @@ public final class InternetDomainName {
 
   private static final CharMatcher DASH_MATCHER = CharMatcher.anyOf("-_");
 
+  private static final CharMatcher DIGIT_MATCHER = CharMatcher.inRange('0', '9');
+
+  private static final CharMatcher LETTER_MATCHER =
+      CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('A', 'Z'));
+
   private static final CharMatcher PART_CHAR_MATCHER =
-      CharMatcher.javaLetterOrDigit().or(DASH_MATCHER);
+      DIGIT_MATCHER.or(LETTER_MATCHER).or(DASH_MATCHER);
 
   /**
    * Helper method for {@link #validateSyntax(List)}. Validates that one part of a domain name is
@@ -287,7 +292,7 @@ public final class InternetDomainName {
      * address like 127.0.0.1 from looking like a valid domain name.
      */
 
-    if (isFinalPart && CharMatcher.digit().matches(part.charAt(0))) {
+    if (isFinalPart && DIGIT_MATCHER.matches(part.charAt(0))) {
       return false;
     }
 

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -296,7 +296,7 @@ public final class ClassPath {
         String innerClassName = className.substring(lastDollarSign + 1);
         // local and anonymous classes are prefixed with number (1,2,3...), anonymous classes are
         // entirely numeric whereas local classes have the user supplied name as a suffix
-        return CharMatcher.digit().trimLeadingFrom(innerClassName);
+        return CharMatcher.inRange('0', '9').trimLeadingFrom(innerClassName);
       }
       String packageName = getPackageName();
       if (packageName.isEmpty()) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add @SuppressWarnings("DoNotMock") to mocked com.google.common types

@DoNotMock will be added to these types. This change suppresses warnings for current cases where these types are mocked.

13ed6d3846bb3765b19ec06819a215ae93644b6c

-------

<p> Add GraphBuilder.incidentEdgeOrder().

2c1db61cfae457a58554f4390c3907f18f406b6a

-------

<p> Remove usages of deprecated CharMatcher functions

Fixes #3565

213ec90d8647412c4d25870fbc1c8bb3a44798ff

-------

<p> Have ImmutableGraph.Builder set incidentEdgeOrder to stable().

c43a2bf57ccc089bb64f2704321e175a611cdc4b

-------

<p> Migrate org.mockito.Matchers#any* to org.mockito.ArgumentMatchers

The former is deprecated and replaced by the latter in Mockito 2. However, there is a
functional difference: ArgumentMatchers will reject `null` and check the type
if the matcher specified a type (e.g. `any(Class)` or `anyInt()`). `any()` will
remain to accept anything.

All remaining `any(Class)` references are migrated to `nulllable(Class)` to maintain the functionality of Mockito 1.
All remaining `anyString()` references are migrated to `nullable(String.class)` to maintain the functionality of Mockito 1.

3e96e06575ea0bb1e8be61ce2edd57ac9427c71d