### PR TITLE
MOE Sync 2019-11-14

### DIFF
--- a/android/guava-tests/test/com/google/common/net/InetAddressesTest.java
+++ b/android/guava-tests/test/com/google/common/net/InetAddressesTest.java
@@ -164,6 +164,58 @@ public class InetAddressesTest extends TestCase {
     }
   }
 
+  // see https://github.com/google/guava/issues/2587
+  private static final ImmutableSet<String> SCOPE_IDS =
+      ImmutableSet.of("eno1", "en1", "eth0", "X", "1", "2", "14", "20");
+
+  public void testIPv4AddressWithScopeId() {
+    ImmutableSet<String> ipStrings = ImmutableSet.of("1.2.3.4", "192.168.0.1");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertFalse(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be false but was true",
+            InetAddresses.isInetAddress(withScopeId));
+      }
+    }
+  }
+
+  public void testDottedQuadAddressWithScopeId() {
+    ImmutableSet<String> ipStrings =
+        ImmutableSet.of("7::0.128.0.127", "7::0.128.0.128", "7::128.128.0.127", "7::0.128.128.127");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertFalse(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be false but was true",
+            InetAddresses.isInetAddress(withScopeId));
+      }
+    }
+  }
+
+  public void testIPv6AddressWithScopeId() {
+    ImmutableSet<String> ipStrings =
+        ImmutableSet.of(
+            "0:0:0:0:0:0:0:1",
+            "fe80::a",
+            "fe80::1",
+            "fe80::2",
+            "fe80::42",
+            "fe80::3dd0:7f8e:57b7:34d5",
+            "fe80::71a3:2b00:ddd3:753f",
+            "fe80::8b2:d61e:e5c:b333",
+            "fe80::b059:65f4:e877:c40");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertTrue(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be true but was false",
+            InetAddresses.isInetAddress(withScopeId));
+        assertEquals(InetAddresses.forString(withScopeId), InetAddresses.forString(ipString));
+      }
+    }
+  }
+
   public void testToAddrStringIPv4() {
     // Don't need to test IPv4 much; it just calls getHostAddress().
     assertEquals("1.2.3.4", InetAddresses.toAddrString(InetAddresses.forString("1.2.3.4")));

--- a/android/guava/src/com/google/common/net/InetAddresses.java
+++ b/android/guava/src/com/google/common/net/InetAddresses.java
@@ -976,12 +976,12 @@ public final class InetAddresses {
 
     // Check the extra bytes in the BigInteger are all zero.
     for (int i = 0; i < srcPos; i++) {
-      checkArgument(
-          addressBytes[i] == 0x00,
-          String.format(
-              "BigInteger cannot be converted to InetAddress because it has more than %d"
-                  + " bytes: %s",
-              numBytes, address));
+      if (addressBytes[i] != 0x00) {
+        throw formatIllegalArgumentException(
+            "BigInteger cannot be converted to InetAddress because it has more than %d"
+                + " bytes: %s",
+            numBytes, address);
+      }
     }
 
     // Copy the bytes into the least significant positions.

--- a/android/guava/src/com/google/common/net/InetAddresses.java
+++ b/android/guava/src/com/google/common/net/InetAddresses.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
+import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -896,6 +897,19 @@ public final class InetAddresses {
   }
 
   /**
+   * Returns a BigInteger representing the address.
+   *
+   * <p>Unlike {@code coerceToInteger}, IPv6 addresses are not coerced to IPv4 addresses.
+   *
+   * @param address {@link InetAddress} to convert
+   * @return {@code BigInteger} representation of the address
+   * @since NEXT
+   */
+  public static BigInteger toBigInteger(InetAddress address) {
+    return new BigInteger(1, address.getAddress());
+  }
+
+  /**
    * Returns an Inet4Address having the integer value specified by the argument.
    *
    * @param address {@code int}, the 32bit integer address to be converted
@@ -903,6 +917,71 @@ public final class InetAddresses {
    */
   public static Inet4Address fromInteger(int address) {
     return getInet4Address(Ints.toByteArray(address));
+  }
+
+  /**
+   * Returns the {@code Inet4Address} corresponding to a given {@code BigInteger}.
+   *
+   * @param address BigInteger representing the IPv4 address
+   * @return Inet4Address representation of the given BigInteger
+   * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^32-1
+   * @since NEXT
+   */
+  public static Inet4Address fromIpv4BigInteger(BigInteger address) {
+    return (Inet4Address) fromBigInteger(address, false);
+  }
+  /**
+   * Returns the {@code Inet6Address} corresponding to a given {@code BigInteger}.
+   *
+   * @param address BigInteger representing the IPv6 address
+   * @return Inet6Address representation of the given BigInteger
+   * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^128-1
+   * @since NEXT
+   */
+  public static Inet6Address fromIpv6BigInteger(BigInteger address) {
+    return (Inet6Address) fromBigInteger(address, true);
+  }
+
+  /**
+   * Converts a BigInteger to either an IPv4 or IPv6 address. If the IP is IPv4, it must be
+   * constrainted to 32 bits, otherwise it is constrained to 128 bits.
+   *
+   * @param address the address represented as a big integer
+   * @param isIpv6 whether the created address should be IPv4 or IPv6
+   * @return the BigInteger converted to an address
+   * @throws IllegalArgumentException if the BigInteger is not between 0 and maximum value for IPv4
+   *     or IPv6 respectively
+   */
+  private static InetAddress fromBigInteger(BigInteger address, boolean isIpv6) {
+    checkArgument(address.signum() >= 0, "BigInteger must be greater than or equal to 0");
+
+    int numBytes = isIpv6 ? 16 : 4;
+
+    byte[] addressBytes = address.toByteArray();
+    byte[] targetCopyArray = new byte[numBytes];
+
+    int srcPos = Math.max(0, addressBytes.length - numBytes);
+    int copyLength = addressBytes.length - srcPos;
+    int destPos = numBytes - copyLength;
+
+    // Check the extra bytes in the BigInteger are all zero.
+    for (int i = 0; i < srcPos; i++) {
+      checkArgument(
+          addressBytes[i] == 0x00,
+          String.format(
+              "BigInteger cannot be converted to InetAddress because it has more than %d"
+                  + " bytes: %s",
+              numBytes, address));
+    }
+
+    // Copy the bytes into the least significant positions.
+    System.arraycopy(addressBytes, srcPos, targetCopyArray, destPos, copyLength);
+
+    try {
+      return InetAddress.getByAddress(targetCopyArray);
+    } catch (UnknownHostException impossible) {
+      throw new AssertionError(impossible);
+    }
   }
 
   /**

--- a/guava-tests/test/com/google/common/net/InetAddressesTest.java
+++ b/guava-tests/test/com/google/common/net/InetAddressesTest.java
@@ -164,6 +164,58 @@ public class InetAddressesTest extends TestCase {
     }
   }
 
+  // see https://github.com/google/guava/issues/2587
+  private static final ImmutableSet<String> SCOPE_IDS =
+      ImmutableSet.of("eno1", "en1", "eth0", "X", "1", "2", "14", "20");
+
+  public void testIPv4AddressWithScopeId() {
+    ImmutableSet<String> ipStrings = ImmutableSet.of("1.2.3.4", "192.168.0.1");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertFalse(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be false but was true",
+            InetAddresses.isInetAddress(withScopeId));
+      }
+    }
+  }
+
+  public void testDottedQuadAddressWithScopeId() {
+    ImmutableSet<String> ipStrings =
+        ImmutableSet.of("7::0.128.0.127", "7::0.128.0.128", "7::128.128.0.127", "7::0.128.128.127");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertFalse(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be false but was true",
+            InetAddresses.isInetAddress(withScopeId));
+      }
+    }
+  }
+
+  public void testIPv6AddressWithScopeId() {
+    ImmutableSet<String> ipStrings =
+        ImmutableSet.of(
+            "0:0:0:0:0:0:0:1",
+            "fe80::a",
+            "fe80::1",
+            "fe80::2",
+            "fe80::42",
+            "fe80::3dd0:7f8e:57b7:34d5",
+            "fe80::71a3:2b00:ddd3:753f",
+            "fe80::8b2:d61e:e5c:b333",
+            "fe80::b059:65f4:e877:c40");
+    for (String ipString : ipStrings) {
+      for (String scopeId : SCOPE_IDS) {
+        String withScopeId = ipString + "%" + scopeId;
+        assertTrue(
+            "InetAddresses.isInetAddress(" + withScopeId + ") should be true but was false",
+            InetAddresses.isInetAddress(withScopeId));
+        assertEquals(InetAddresses.forString(withScopeId), InetAddresses.forString(ipString));
+      }
+    }
+  }
+
   public void testToAddrStringIPv4() {
     // Don't need to test IPv4 much; it just calls getHostAddress().
     assertEquals("1.2.3.4", InetAddresses.toAddrString(InetAddresses.forString("1.2.3.4")));

--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -971,12 +971,12 @@ public final class InetAddresses {
 
     // Check the extra bytes in the BigInteger are all zero.
     for (int i = 0; i < srcPos; i++) {
-      checkArgument(
-          addressBytes[i] == 0x00,
-          String.format(
-              "BigInteger cannot be converted to InetAddress because it has more than %d"
-                  + " bytes: %s",
-              numBytes, address));
+      if (addressBytes[i] != 0x00) {
+        throw formatIllegalArgumentException(
+            "BigInteger cannot be converted to InetAddress because it has more than %d"
+                + " bytes: %s",
+            numBytes, address);
+      }
     }
 
     // Copy the bytes into the least significant positions.

--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -131,6 +131,8 @@ public final class InetAddresses {
    *
    * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
    *
+   * <p>Anything after a {@code %} in an IPv6 address is ignored (assumed to be a Scope ID).
+   *
    * @param ipString {@code String} containing an IPv4 or IPv6 string literal, e.g. {@code
    *     "192.168.0.1"} or {@code "2001:db8::1"}
    * @return {@link InetAddress} representing the argument
@@ -158,10 +160,12 @@ public final class InetAddresses {
     return ipStringToBytes(ipString) != null;
   }
 
+  /** Returns {@code null} if unable to parse into a {@code byte[]}. */
   private static byte @Nullable [] ipStringToBytes(String ipString) {
     // Make a first pass to categorize the characters in this string.
     boolean hasColon = false;
     boolean hasDot = false;
+    int percentIndex = -1;
     for (int i = 0; i < ipString.length(); i++) {
       char c = ipString.charAt(i);
       if (c == '.') {
@@ -171,6 +175,9 @@ public final class InetAddresses {
           return null; // Colons must not appear after dots.
         }
         hasColon = true;
+      } else if (c == '%') {
+        percentIndex = i;
+        break; // everything after a '%' is ignored (it's a Scope ID): http://superuser.com/a/99753
       } else if (Character.digit(c, 16) == -1) {
         return null; // Everything else must be a decimal or hex digit.
       }
@@ -183,6 +190,9 @@ public final class InetAddresses {
         if (ipString == null) {
           return null;
         }
+      }
+      if (percentIndex != -1) {
+        ipString = ipString.substring(0, percentIndex);
       }
       return textToNumericFormatV6(ipString);
     } else if (hasDot) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move the big integer conversion code into InetAddresses

RELNOTES=Add toBigInteger and fromIpv4BigInteger/fromIpv6BigInteger to InetAddresses for manipulating InetAddresses as BigIntegers

a544e97d10572d0a71c481e2b833ad19a3a7de4f

-------

<p> Add support for scope IDs to InetAddresses.isInetAddress().

Fixes https://github.com/google/guava/issues/2587

1d3780724431da91b28bbf50fcb13f27459f4710

-------

<p> Format with Locale.ROOT.

This guarantees that the message matches across locales, including hi-IN, which we test with under Maven:
https://travis-ci.org/google/guava/jobs/611945191
https://github.com/google/guava/blob/cc6cff2df9d66d4d9cd18f378cb75d03f7002852/pom.xml#L212

b29efa54b23b3cb28f4e150d045b83b8196d9050