### PR TITLE
Rejuvenate log levels using setting 2

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/FeatureSpecificTestSuiteBuilder.java
@@ -173,12 +173,12 @@ public abstract class FeatureSpecificTestSuiteBuilder<
   public TestSuite createTestSuite() {
     checkCanCreate();
 
-    logger.fine(" Testing: " + name);
-    logger.fine("Features: " + formatFeatureSet(features));
+    logger.finest(" Testing: " + name);
+    logger.finest("Features: " + formatFeatureSet(features));
 
     FeatureUtil.addImpliedFeatures(features);
 
-    logger.fine("Expanded: " + formatFeatureSet(features));
+    logger.finest("Expanded: " + formatFeatureSet(features));
 
     // Class parameters must be raw.
     List<Class<? extends AbstractTester>> testers = getTesters();

--- a/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/PerCollectionSizeTestSuiteBuilder.java
@@ -61,7 +61,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     Set<Feature<?>> features = Helpers.copyToSet(getFeatures());
     List<Class<? extends AbstractTester>> testers = getTesters();
 
-    logger.fine(" Testing: " + name);
+    logger.finer(" Testing: " + name);
 
     // Split out all the specified sizes.
     Set<Feature<?>> sizesToTest = Helpers.<Feature<?>>copyToSet(CollectionSize.values());
@@ -72,7 +72,7 @@ public abstract class PerCollectionSizeTestSuiteBuilder<
     sizesToTest.retainAll(
         Arrays.asList(CollectionSize.ZERO, CollectionSize.ONE, CollectionSize.SEVERAL));
 
-    logger.fine("   Sizes: " + formatFeatureSet(sizesToTest));
+    logger.finer("   Sizes: " + formatFeatureSet(sizesToTest));
 
     if (sizesToTest.isEmpty()) {
       throw new IllegalStateException(

--- a/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
+++ b/guava-testlib/src/com/google/common/testing/ArbitraryInstances.java
@@ -393,7 +393,7 @@ public final class ArbitraryInstances {
     } catch (IllegalAccessException impossible) {
       throw new AssertionError(impossible);
     } catch (InvocationTargetException e) {
-      logger.log(Level.WARNING, "Exception while invoking default constructor.", e.getCause());
+      logger.log(Level.SEVERE, "Exception while invoking default constructor.", e.getCause());
       return arbitraryConstantInstanceOrNull(type);
     }
   }

--- a/guava-testlib/src/com/google/common/testing/TearDownStack.java
+++ b/guava-testlib/src/com/google/common/testing/TearDownStack.java
@@ -74,7 +74,7 @@ public class TearDownStack implements TearDownAccepter {
         tearDown.tearDown();
       } catch (Throwable t) {
         if (suppressThrows) {
-          logger.log(Level.INFO, "exception thrown during tearDown", t);
+          logger.log(Level.SEVERE, "exception thrown during tearDown", t);
         } else {
           exceptions.add(t);
         }


### PR DESCRIPTION
Thank you for your feedback in our previous PR (https://github.com/google/guava/pull/3713)! That PR has a setting that only transforms log levels below `INFO`. I rerun our tool with the new settings as mentioned below to make this PR. This PR has two additional transformations that we think they are reasonable.

Settings
---
The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: 71de4064ac005e1d283b8a6d4153aab834903720

These are CSV files generated by our tool.
[CSV_files_c_1000.tar.gz](https://github.com/google/guava/files/3871921/CSV_files_c_1000.tar.gz) (updated)

