### PR TITLE
MOE Sync 2019-11-27

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/ConfigurableDirectedGraphWithStableOrderTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ConfigurableDirectedGraphWithStableOrderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2014 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for a directed {@link ConfigurableMutableGraph} with stable incident edge order. */
+@RunWith(JUnit4.class)
+public class ConfigurableDirectedGraphWithStableOrderTest
+    extends ConfigurableSimpleDirectedGraphTest {
+
+  @Override
+  public MutableGraph<Integer> createGraph() {
+    return GraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void edges_returnsInStableOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.edges())
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 4),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2),
+            EndpointPair.ordered(3, 1),
+            EndpointPair.ordered(5, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void adjacentNodes_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3, 5).inOrder();
+  }
+
+  @Test
+  public void predecessors_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.predecessors(1)).containsExactly(2, 5, 3).inOrder();
+  }
+
+  @Test
+  public void successors_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void incidentEdges_returnsInStableOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(5, 1),
+            EndpointPair.ordered(3, 1),
+            EndpointPair.ordered(1, 4),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  /**
+   * Populates the given graph with nodes and edges in a star shape with node `1` in the middle.
+   *
+   * <p>Note that the edges are added in a shuffled order to properly test the effect of the
+   * insertion order.
+   */
+  private static void populateStarShapedGraph(MutableGraph<Integer> graph) {
+    graph.putEdge(2, 1);
+    graph.putEdge(1, 4);
+    graph.putEdge(1, 3);
+    graph.putEdge(5, 1);
+    graph.putEdge(1, 2);
+    graph.putEdge(3, 1);
+  }
+}

--- a/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -41,9 +41,12 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N, V>
     implements MutableValueGraph<N, V> {
 
+  private final ElementOrder<N> incidentEdgeOrder;
+
   /** Constructs a mutable graph with the properties specified in {@code builder}. */
   ConfigurableMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
     super(builder);
+    incidentEdgeOrder = builder.incidentEdgeOrder.cast();
   }
 
   @Override
@@ -167,7 +170,7 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
 
   private GraphConnections<N, V> newConnections() {
     return isDirected()
-        ? DirectedGraphConnections.<N, V>of()
+        ? DirectedGraphConnections.<N, V>of(incidentEdgeOrder)
         : UndirectedGraphConnections.<N, V>of();
   }
 }

--- a/android/guava/src/com/google/common/graph/DirectedGraphConnections.java
+++ b/android/guava/src/com/google/common/graph/DirectedGraphConnections.java
@@ -27,9 +27,12 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.UnmodifiableIterator;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -39,6 +42,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * An implementation of {@link GraphConnections} for directed graphs.
  *
  * @author James Sexton
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
@@ -55,18 +59,88 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     }
   }
 
+  /**
+   * A value class representing single connection between the origin node and another node.
+   *
+   * <p>There can be two types of connections (predecessor and successor), which is represented by
+   * the two implementations.
+   */
+  private abstract static class NodeConnection<N> {
+    final N node;
+
+    NodeConnection(N node) {
+      this.node = checkNotNull(node);
+    }
+
+    static final class Pred<N> extends NodeConnection<N> {
+      Pred(N node) {
+        super(node);
+      }
+
+      @Override
+      public boolean equals(Object that) {
+        if (that instanceof Pred) {
+          return this.node.equals(((Pred<?>) that).node);
+        } else {
+          return false;
+        }
+      }
+
+      @Override
+      public int hashCode() {
+        // Adding the class hashCode to avoid a clash with Succ instances.
+        return Pred.class.hashCode() + node.hashCode();
+      }
+    }
+
+    static final class Succ<N> extends NodeConnection<N> {
+      Succ(N node) {
+        super(node);
+      }
+
+      @Override
+      public boolean equals(Object that) {
+        if (that instanceof Succ) {
+          return this.node.equals(((Succ<?>) that).node);
+        } else {
+          return false;
+        }
+      }
+
+      @Override
+      public int hashCode() {
+        // Adding the class hashCode to avoid a clash with Pred instances.
+        return Succ.class.hashCode() + node.hashCode();
+      }
+    }
+  }
+
   private static final Object PRED = new Object();
 
   // Every value in this map must either be an instance of PredAndSucc with a successorValue of
   // type V, PRED (representing predecessor), or an instance of type V (representing successor).
   private final Map<N, Object> adjacentNodeValues;
 
+  /**
+   * All node connections in this graph, in edge insertion order.
+   *
+   * <p>Note: This field and {@link #adjacentNodeValues} cannot be combined into a single
+   * LinkedHashMap because one target node may be mapped to both a predecessor and a successor. A
+   * LinkedHashMap combines two such edges into a single node-value pair, even though the edges may
+   * not have been inserted consecutively.
+   */
+  @NullableDecl private final List<NodeConnection<N>> orderedNodeConnections;
+
   private int predecessorCount;
   private int successorCount;
 
   private DirectedGraphConnections(
-      Map<N, Object> adjacentNodeValues, int predecessorCount, int successorCount) {
+      Map<N, Object> adjacentNodeValues,
+      @NullableDecl List<NodeConnection<N>> orderedNodeConnections,
+      int predecessorCount,
+      int successorCount) {
     this.adjacentNodeValues = checkNotNull(adjacentNodeValues);
+    this.orderedNodeConnections = orderedNodeConnections;
     this.predecessorCount = checkNonNegative(predecessorCount);
     this.successorCount = checkNonNegative(successorCount);
     checkState(
@@ -74,11 +148,27 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
             && successorCount <= adjacentNodeValues.size());
   }
 
-  static <N, V> DirectedGraphConnections<N, V> of() {
+  static <N, V> DirectedGraphConnections<N, V> of(ElementOrder<N> incidentEdgeOrder) {
     // We store predecessors and successors in the same map, so double the initial capacity.
     int initialCapacity = INNER_CAPACITY * 2;
-    return new DirectedGraphConnections<>(
-        new HashMap<N, Object>(initialCapacity, INNER_LOAD_FACTOR), 0, 0);
+
+    List<NodeConnection<N>> orderedNodeConnections;
+    switch (incidentEdgeOrder.type()) {
+      case UNORDERED:
+        orderedNodeConnections = null;
+        break;
+      case STABLE:
+        orderedNodeConnections = new ArrayList<NodeConnection<N>>();
+        break;
+      default:
+        throw new AssertionError(incidentEdgeOrder.type());
+    }
+
+    return new DirectedGraphConnections<N, V>(
+        /* adjacentNodeValues = */ new HashMap<N, Object>(initialCapacity, INNER_LOAD_FACTOR),
+        orderedNodeConnections,
+        /* predecessorCount = */ 0,
+        /* successorCount = */ 0);
   }
 
   static <N, V> DirectedGraphConnections<N, V> ofImmutable(
@@ -92,12 +182,49 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
       }
     }
     return new DirectedGraphConnections<>(
-        ImmutableMap.copyOf(adjacentNodeValues), predecessors.size(), successorValues.size());
+        /* adjacentNodeValues = */ ImmutableMap.copyOf(adjacentNodeValues),
+        // TODO(b/142723300): Pass in an ImmutableList here with the ordered node connections
+        /* orderedNodeConnections = */ null,
+        /* predecessorCount = */ predecessors.size(),
+        /* successorCount = */ successorValues.size());
   }
 
   @Override
   public Set<N> adjacentNodes() {
-    return Collections.unmodifiableSet(adjacentNodeValues.keySet());
+    if (orderedNodeConnections == null) {
+      return Collections.unmodifiableSet(adjacentNodeValues.keySet());
+    } else {
+      return new AbstractSet<N>() {
+        @Override
+        public UnmodifiableIterator<N> iterator() {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          final Set<N> seenNodes = new HashSet<>();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                boolean added = seenNodes.add(nodeConnection.node);
+                if (added) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
+
+        @Override
+        public int size() {
+          return adjacentNodeValues.size();
+        }
+
+        @Override
+        public boolean contains(@NullableDecl Object obj) {
+          return adjacentNodeValues.containsKey(obj);
+        }
+      };
+    }
   }
 
   @Override
@@ -105,19 +232,35 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     return new AbstractSet<N>() {
       @Override
       public UnmodifiableIterator<N> iterator() {
-        final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
-        return new AbstractIterator<N>() {
-          @Override
-          protected N computeNext() {
-            while (entries.hasNext()) {
-              Entry<N, Object> entry = entries.next();
-              if (isPredecessor(entry.getValue())) {
-                return entry.getKey();
+        if (orderedNodeConnections == null) {
+          final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (entries.hasNext()) {
+                Entry<N, Object> entry = entries.next();
+                if (isPredecessor(entry.getValue())) {
+                  return entry.getKey();
+                }
               }
+              return endOfData();
             }
-            return endOfData();
-          }
-        };
+          };
+        } else {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                if (nodeConnection instanceof NodeConnection.Pred) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
       }
 
       @Override
@@ -137,19 +280,35 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     return new AbstractSet<N>() {
       @Override
       public UnmodifiableIterator<N> iterator() {
-        final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
-        return new AbstractIterator<N>() {
-          @Override
-          protected N computeNext() {
-            while (entries.hasNext()) {
-              Entry<N, Object> entry = entries.next();
-              if (isSuccessor(entry.getValue())) {
-                return entry.getKey();
+        if (orderedNodeConnections == null) {
+          final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (entries.hasNext()) {
+                Entry<N, Object> entry = entries.next();
+                if (isSuccessor(entry.getValue())) {
+                  return entry.getKey();
+                }
               }
+              return endOfData();
             }
-            return endOfData();
-          }
-        };
+          };
+        } else {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                if (nodeConnection instanceof NodeConnection.Succ) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
       }
 
       @Override
@@ -181,12 +340,24 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public void removePredecessor(N node) {
     Object previousValue = adjacentNodeValues.get(node);
+    boolean removedPredecessor;
+
     if (previousValue == PRED) {
       adjacentNodeValues.remove(node);
-      checkNonNegative(--predecessorCount);
+      removedPredecessor = true;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put((N) node, ((PredAndSucc) previousValue).successorValue);
+      removedPredecessor = true;
+    } else {
+      removedPredecessor = false;
+    }
+
+    if (removedPredecessor) {
       checkNonNegative(--predecessorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.remove(new NodeConnection.Pred<>(node));
+      }
     }
   }
 
@@ -194,31 +365,54 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public V removeSuccessor(Object node) {
     Object previousValue = adjacentNodeValues.get(node);
+    Object removedValue;
+
     if (previousValue == null || previousValue == PRED) {
-      return null;
+      removedValue = null;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put((N) node, PRED);
-      checkNonNegative(--successorCount);
-      return (V) ((PredAndSucc) previousValue).successorValue;
+      removedValue = ((PredAndSucc) previousValue).successorValue;
     } else { // successor
       adjacentNodeValues.remove(node);
-      checkNonNegative(--successorCount);
-      return (V) previousValue;
+      removedValue = previousValue;
     }
+
+    if (removedValue != null) {
+      checkNonNegative(--successorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.remove(new NodeConnection.Succ<>((N) node));
+      }
+    }
+
+    return (V) removedValue;
   }
 
   @Override
   public void addPredecessor(N node, V unused) {
     Object previousValue = adjacentNodeValues.put(node, PRED);
+    boolean addedPredecessor;
+
     if (previousValue == null) {
-      checkPositive(++predecessorCount);
+      addedPredecessor = true;
     } else if (previousValue instanceof PredAndSucc) {
       // Restore previous PredAndSucc object.
       adjacentNodeValues.put(node, previousValue);
+      addedPredecessor = false;
     } else if (previousValue != PRED) { // successor
       // Do NOT use method parameter value 'unused'. In directed graphs, successors store the value.
       adjacentNodeValues.put(node, new PredAndSucc(previousValue));
+      addedPredecessor = true;
+    } else {
+      addedPredecessor = false;
+    }
+
+    if (addedPredecessor) {
       checkPositive(++predecessorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.add(new NodeConnection.Pred<>(node));
+      }
     }
   }
 
@@ -226,19 +420,29 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public V addSuccessor(N node, V value) {
     Object previousValue = adjacentNodeValues.put(node, value);
+    Object previousSuccessor;
+
     if (previousValue == null) {
-      checkPositive(++successorCount);
-      return null;
+      previousSuccessor = null;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put(node, new PredAndSucc(value));
-      return (V) ((PredAndSucc) previousValue).successorValue;
+      previousSuccessor = ((PredAndSucc) previousValue).successorValue;
     } else if (previousValue == PRED) {
       adjacentNodeValues.put(node, new PredAndSucc(value));
-      checkPositive(++successorCount);
-      return null;
+      previousSuccessor = null;
     } else { // successor
-      return (V) previousValue;
+      previousSuccessor = previousValue;
     }
+
+    if (previousSuccessor == null) {
+      checkPositive(++successorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.add(new NodeConnection.Succ<>(node));
+      }
+    }
+
+    return (V) previousSuccessor;
   }
 
   private static boolean isPredecessor(@NullableDecl Object value) {

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -29,6 +29,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.CollectionFuture.ListFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateCancelledFuture;
 import com.google.common.util.concurrent.ImmediateFuture.ImmediateFailedFuture;
+import com.google.common.util.concurrent.internal.InternalFutureFailureAccess;
+import com.google.common.util.concurrent.internal.InternalFutures;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
 import java.util.List;
@@ -1022,6 +1024,14 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
 
     @Override
     public void run() {
+      if (future instanceof InternalFutureFailureAccess) {
+        Throwable failure =
+            InternalFutures.tryInternalFastPathGetFailure((InternalFutureFailureAccess) future);
+        if (failure != null) {
+          callback.onFailure(failure);
+          return;
+        }
+      }
       final V value;
       try {
         value = getDone(future);

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/AbstractFuture.java
@@ -219,7 +219,10 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
 
   @Override
   protected final Throwable tryInternalFastPathGetFailure() {
-    return state == State.FAILURE ? throwable : null;
+    if (this instanceof Trusted) {
+      return state == State.FAILURE ? throwable : null;
+    }
+    return null;
   }
 
   final Throwable trustedGetException() {

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/ListenableFuture.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/ListenableFuture.java
@@ -19,6 +19,7 @@ import elemental2.promise.Promise;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsOptional;
 
 /**
  * Java super source for ListenableFuture, implementing a structural thenable via a default method.
@@ -37,7 +38,7 @@ public interface ListenableFuture<V> extends Future<V>, Thenable<V> {
   @Override
   default <R> IThenable<R> then(
       IThenable.ThenOnFulfilledCallbackFn<? super V, ? extends R> onFulfilled,
-      IThenable.ThenOnRejectedCallbackFn<? extends R> onRejected) {
+      @JsOptional IThenable.ThenOnRejectedCallbackFn<? extends R> onRejected) {
     return new Promise<V>(
             (resolve, reject) -> {
               Futures.addCallback(

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/Thenable.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/Thenable.java
@@ -17,6 +17,7 @@
 package com.google.common.util.concurrent;
 
 import elemental2.promise.IThenable;
+import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
@@ -28,5 +29,5 @@ import jsinterop.annotations.JsType;
 interface Thenable<T> {
   <V> IThenable<V> then(
       IThenable.ThenOnFulfilledCallbackFn<? super T, ? extends V> onFulfilled,
-      IThenable.ThenOnRejectedCallbackFn<? extends V> onRejected);
+      @JsOptional IThenable.ThenOnRejectedCallbackFn<? extends V> onRejected);
 }

--- a/guava-tests/test/com/google/common/graph/ConfigurableDirectedGraphWithStableOrderTest.java
+++ b/guava-tests/test/com/google/common/graph/ConfigurableDirectedGraphWithStableOrderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2014 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for a directed {@link ConfigurableMutableGraph} with stable incident edge order. */
+@RunWith(JUnit4.class)
+public class ConfigurableDirectedGraphWithStableOrderTest
+    extends ConfigurableSimpleDirectedGraphTest {
+
+  @Override
+  public MutableGraph<Integer> createGraph() {
+    return GraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void edges_returnsInStableOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.edges())
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 4),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2),
+            EndpointPair.ordered(3, 1),
+            EndpointPair.ordered(5, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void adjacentNodes_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3, 5).inOrder();
+  }
+
+  @Test
+  public void predecessors_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.predecessors(1)).containsExactly(2, 5, 3).inOrder();
+  }
+
+  @Test
+  public void successors_returnsInConnectingEdgeInsertionOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void incidentEdges_returnsInStableOrder() {
+    populateStarShapedGraph(graph);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(5, 1),
+            EndpointPair.ordered(3, 1),
+            EndpointPair.ordered(1, 4),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  /**
+   * Populates the given graph with nodes and edges in a star shape with node `1` in the middle.
+   *
+   * <p>Note that the edges are added in a shuffled order to properly test the effect of the
+   * insertion order.
+   */
+  private static void populateStarShapedGraph(MutableGraph<Integer> graph) {
+    graph.putEdge(2, 1);
+    graph.putEdge(1, 4);
+    graph.putEdge(1, 3);
+    graph.putEdge(5, 1);
+    graph.putEdge(1, 2);
+    graph.putEdge(3, 1);
+  }
+}

--- a/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -41,9 +41,12 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N, V>
     implements MutableValueGraph<N, V> {
 
+  private final ElementOrder<N> incidentEdgeOrder;
+
   /** Constructs a mutable graph with the properties specified in {@code builder}. */
   ConfigurableMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
     super(builder);
+    incidentEdgeOrder = builder.incidentEdgeOrder.cast();
   }
 
   @Override
@@ -167,7 +170,7 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
 
   private GraphConnections<N, V> newConnections() {
     return isDirected()
-        ? DirectedGraphConnections.<N, V>of()
+        ? DirectedGraphConnections.<N, V>of(incidentEdgeOrder)
         : UndirectedGraphConnections.<N, V>of();
   }
 }

--- a/guava/src/com/google/common/graph/DirectedGraphConnections.java
+++ b/guava/src/com/google/common/graph/DirectedGraphConnections.java
@@ -27,9 +27,12 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.UnmodifiableIterator;
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -39,6 +42,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * An implementation of {@link GraphConnections} for directed graphs.
  *
  * @author James Sexton
+ * @author Jens Nyman
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
@@ -55,18 +59,88 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     }
   }
 
+  /**
+   * A value class representing single connection between the origin node and another node.
+   *
+   * <p>There can be two types of connections (predecessor and successor), which is represented by
+   * the two implementations.
+   */
+  private abstract static class NodeConnection<N> {
+    final N node;
+
+    NodeConnection(N node) {
+      this.node = checkNotNull(node);
+    }
+
+    static final class Pred<N> extends NodeConnection<N> {
+      Pred(N node) {
+        super(node);
+      }
+
+      @Override
+      public boolean equals(Object that) {
+        if (that instanceof Pred) {
+          return this.node.equals(((Pred<?>) that).node);
+        } else {
+          return false;
+        }
+      }
+
+      @Override
+      public int hashCode() {
+        // Adding the class hashCode to avoid a clash with Succ instances.
+        return Pred.class.hashCode() + node.hashCode();
+      }
+    }
+
+    static final class Succ<N> extends NodeConnection<N> {
+      Succ(N node) {
+        super(node);
+      }
+
+      @Override
+      public boolean equals(Object that) {
+        if (that instanceof Succ) {
+          return this.node.equals(((Succ<?>) that).node);
+        } else {
+          return false;
+        }
+      }
+
+      @Override
+      public int hashCode() {
+        // Adding the class hashCode to avoid a clash with Pred instances.
+        return Succ.class.hashCode() + node.hashCode();
+      }
+    }
+  }
+
   private static final Object PRED = new Object();
 
   // Every value in this map must either be an instance of PredAndSucc with a successorValue of
   // type V, PRED (representing predecessor), or an instance of type V (representing successor).
   private final Map<N, Object> adjacentNodeValues;
 
+  /**
+   * All node connections in this graph, in edge insertion order.
+   *
+   * <p>Note: This field and {@link #adjacentNodeValues} cannot be combined into a single
+   * LinkedHashMap because one target node may be mapped to both a predecessor and a successor. A
+   * LinkedHashMap combines two such edges into a single node-value pair, even though the edges may
+   * not have been inserted consecutively.
+   */
+  @Nullable private final List<NodeConnection<N>> orderedNodeConnections;
+
   private int predecessorCount;
   private int successorCount;
 
   private DirectedGraphConnections(
-      Map<N, Object> adjacentNodeValues, int predecessorCount, int successorCount) {
+      Map<N, Object> adjacentNodeValues,
+      @Nullable List<NodeConnection<N>> orderedNodeConnections,
+      int predecessorCount,
+      int successorCount) {
     this.adjacentNodeValues = checkNotNull(adjacentNodeValues);
+    this.orderedNodeConnections = orderedNodeConnections;
     this.predecessorCount = checkNonNegative(predecessorCount);
     this.successorCount = checkNonNegative(successorCount);
     checkState(
@@ -74,11 +148,27 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
             && successorCount <= adjacentNodeValues.size());
   }
 
-  static <N, V> DirectedGraphConnections<N, V> of() {
+  static <N, V> DirectedGraphConnections<N, V> of(ElementOrder<N> incidentEdgeOrder) {
     // We store predecessors and successors in the same map, so double the initial capacity.
     int initialCapacity = INNER_CAPACITY * 2;
-    return new DirectedGraphConnections<>(
-        new HashMap<N, Object>(initialCapacity, INNER_LOAD_FACTOR), 0, 0);
+
+    List<NodeConnection<N>> orderedNodeConnections;
+    switch (incidentEdgeOrder.type()) {
+      case UNORDERED:
+        orderedNodeConnections = null;
+        break;
+      case STABLE:
+        orderedNodeConnections = new ArrayList<NodeConnection<N>>();
+        break;
+      default:
+        throw new AssertionError(incidentEdgeOrder.type());
+    }
+
+    return new DirectedGraphConnections<N, V>(
+        /* adjacentNodeValues = */ new HashMap<N, Object>(initialCapacity, INNER_LOAD_FACTOR),
+        orderedNodeConnections,
+        /* predecessorCount = */ 0,
+        /* successorCount = */ 0);
   }
 
   static <N, V> DirectedGraphConnections<N, V> ofImmutable(
@@ -92,12 +182,49 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
       }
     }
     return new DirectedGraphConnections<>(
-        ImmutableMap.copyOf(adjacentNodeValues), predecessors.size(), successorValues.size());
+        /* adjacentNodeValues = */ ImmutableMap.copyOf(adjacentNodeValues),
+        // TODO(b/142723300): Pass in an ImmutableList here with the ordered node connections
+        /* orderedNodeConnections = */ null,
+        /* predecessorCount = */ predecessors.size(),
+        /* successorCount = */ successorValues.size());
   }
 
   @Override
   public Set<N> adjacentNodes() {
-    return Collections.unmodifiableSet(adjacentNodeValues.keySet());
+    if (orderedNodeConnections == null) {
+      return Collections.unmodifiableSet(adjacentNodeValues.keySet());
+    } else {
+      return new AbstractSet<N>() {
+        @Override
+        public UnmodifiableIterator<N> iterator() {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          final Set<N> seenNodes = new HashSet<>();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                boolean added = seenNodes.add(nodeConnection.node);
+                if (added) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
+
+        @Override
+        public int size() {
+          return adjacentNodeValues.size();
+        }
+
+        @Override
+        public boolean contains(@Nullable Object obj) {
+          return adjacentNodeValues.containsKey(obj);
+        }
+      };
+    }
   }
 
   @Override
@@ -105,19 +232,35 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     return new AbstractSet<N>() {
       @Override
       public UnmodifiableIterator<N> iterator() {
-        final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
-        return new AbstractIterator<N>() {
-          @Override
-          protected N computeNext() {
-            while (entries.hasNext()) {
-              Entry<N, Object> entry = entries.next();
-              if (isPredecessor(entry.getValue())) {
-                return entry.getKey();
+        if (orderedNodeConnections == null) {
+          final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (entries.hasNext()) {
+                Entry<N, Object> entry = entries.next();
+                if (isPredecessor(entry.getValue())) {
+                  return entry.getKey();
+                }
               }
+              return endOfData();
             }
-            return endOfData();
-          }
-        };
+          };
+        } else {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                if (nodeConnection instanceof NodeConnection.Pred) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
       }
 
       @Override
@@ -137,19 +280,35 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     return new AbstractSet<N>() {
       @Override
       public UnmodifiableIterator<N> iterator() {
-        final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
-        return new AbstractIterator<N>() {
-          @Override
-          protected N computeNext() {
-            while (entries.hasNext()) {
-              Entry<N, Object> entry = entries.next();
-              if (isSuccessor(entry.getValue())) {
-                return entry.getKey();
+        if (orderedNodeConnections == null) {
+          final Iterator<Entry<N, Object>> entries = adjacentNodeValues.entrySet().iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (entries.hasNext()) {
+                Entry<N, Object> entry = entries.next();
+                if (isSuccessor(entry.getValue())) {
+                  return entry.getKey();
+                }
               }
+              return endOfData();
             }
-            return endOfData();
-          }
-        };
+          };
+        } else {
+          final Iterator<NodeConnection<N>> nodeConnections = orderedNodeConnections.iterator();
+          return new AbstractIterator<N>() {
+            @Override
+            protected N computeNext() {
+              while (nodeConnections.hasNext()) {
+                NodeConnection<N> nodeConnection = nodeConnections.next();
+                if (nodeConnection instanceof NodeConnection.Succ) {
+                  return nodeConnection.node;
+                }
+              }
+              return endOfData();
+            }
+          };
+        }
       }
 
       @Override
@@ -181,12 +340,24 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public void removePredecessor(N node) {
     Object previousValue = adjacentNodeValues.get(node);
+    boolean removedPredecessor;
+
     if (previousValue == PRED) {
       adjacentNodeValues.remove(node);
-      checkNonNegative(--predecessorCount);
+      removedPredecessor = true;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put((N) node, ((PredAndSucc) previousValue).successorValue);
+      removedPredecessor = true;
+    } else {
+      removedPredecessor = false;
+    }
+
+    if (removedPredecessor) {
       checkNonNegative(--predecessorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.remove(new NodeConnection.Pred<>(node));
+      }
     }
   }
 
@@ -194,31 +365,54 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public V removeSuccessor(Object node) {
     Object previousValue = adjacentNodeValues.get(node);
+    Object removedValue;
+
     if (previousValue == null || previousValue == PRED) {
-      return null;
+      removedValue = null;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put((N) node, PRED);
-      checkNonNegative(--successorCount);
-      return (V) ((PredAndSucc) previousValue).successorValue;
+      removedValue = ((PredAndSucc) previousValue).successorValue;
     } else { // successor
       adjacentNodeValues.remove(node);
-      checkNonNegative(--successorCount);
-      return (V) previousValue;
+      removedValue = previousValue;
     }
+
+    if (removedValue != null) {
+      checkNonNegative(--successorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.remove(new NodeConnection.Succ<>((N) node));
+      }
+    }
+
+    return (V) removedValue;
   }
 
   @Override
   public void addPredecessor(N node, V unused) {
     Object previousValue = adjacentNodeValues.put(node, PRED);
+    boolean addedPredecessor;
+
     if (previousValue == null) {
-      checkPositive(++predecessorCount);
+      addedPredecessor = true;
     } else if (previousValue instanceof PredAndSucc) {
       // Restore previous PredAndSucc object.
       adjacentNodeValues.put(node, previousValue);
+      addedPredecessor = false;
     } else if (previousValue != PRED) { // successor
       // Do NOT use method parameter value 'unused'. In directed graphs, successors store the value.
       adjacentNodeValues.put(node, new PredAndSucc(previousValue));
+      addedPredecessor = true;
+    } else {
+      addedPredecessor = false;
+    }
+
+    if (addedPredecessor) {
       checkPositive(++predecessorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.add(new NodeConnection.Pred<>(node));
+      }
     }
   }
 
@@ -226,19 +420,29 @@ final class DirectedGraphConnections<N, V> implements GraphConnections<N, V> {
   @Override
   public V addSuccessor(N node, V value) {
     Object previousValue = adjacentNodeValues.put(node, value);
+    Object previousSuccessor;
+
     if (previousValue == null) {
-      checkPositive(++successorCount);
-      return null;
+      previousSuccessor = null;
     } else if (previousValue instanceof PredAndSucc) {
       adjacentNodeValues.put(node, new PredAndSucc(value));
-      return (V) ((PredAndSucc) previousValue).successorValue;
+      previousSuccessor = ((PredAndSucc) previousValue).successorValue;
     } else if (previousValue == PRED) {
       adjacentNodeValues.put(node, new PredAndSucc(value));
-      checkPositive(++successorCount);
-      return null;
+      previousSuccessor = null;
     } else { // successor
-      return (V) previousValue;
+      previousSuccessor = previousValue;
     }
+
+    if (previousSuccessor == null) {
+      checkPositive(++successorCount);
+
+      if (orderedNodeConnections != null) {
+        orderedNodeConnections.add(new NodeConnection.Succ<>(node));
+      }
+    }
+
+    return (V) previousSuccessor;
   }
 
   private static boolean isPredecessor(@Nullable Object value) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use internal fast path for getting failure without allocating a wrapper ExecutionException

Also fix GWT AbstractFuture so that it respects the trusted interface. (More motivation for https://github.com/google/guava/issues/2934)

RELNOTES=N/A

736b09299f7ce844fdf28c5675eb126ea6b43e02

-------

<p> Support incidentEdgeOrder for directed Graphs

fd2255edf013f6592b83ee17432d0997d8db74d5

-------

<p> Add @JsOptional annotations to the 2nd parameter of the 'then' method, since the second parameter is actually optional. This satisfies JsCompiler type checking.

73be65bd36e498f133549ddc24523176152aa8dc