### PR TITLE
Update to errorprone 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
Errorprone 2.3.3 was missing classes such as `DoNotMock` . This didn't affect Guava, but it led to dependency conflicts for people using both Guava and Lombok.

Version 2.3.4 adss `DoNotMock` back, which solves this issue.