### PR TITLE
MOE Sync 2019-12-06

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -470,6 +470,7 @@ public abstract class AbstractGraphTest {
 
     putEdge(N1, N2);
     addNode(N3);
+
     assertThat(graphAsMutableGraph.removeEdge(N1, N3)).isFalse();
     assertThat(graph.successors(N1)).contains(N2);
   }

--- a/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -97,13 +97,13 @@ public abstract class AbstractGraphTest {
   @CanIgnoreReturnValue
   abstract boolean putEdge(Integer n1, Integer n2);
 
-  final boolean graphIsMutable() {
-    return graphAsMutableGraph != null;
-  }
-
   @CanIgnoreReturnValue
   final boolean putEdge(EndpointPair<Integer> endpoints) {
     return putEdge(endpoints.nodeU(), endpoints.nodeV());
+  }
+
+  final boolean graphIsMutable() {
+    return graphAsMutableGraph != null;
   }
 
   @Before

--- a/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -25,7 +25,6 @@ import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.After;
@@ -81,25 +80,18 @@ public abstract class AbstractGraphTest {
    * A proxy method that adds the node {@code n} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
    * this node.
-   *
-   * @return {@code true} iff the graph was modified as a result of this call
    */
-  @CanIgnoreReturnValue
-  abstract boolean addNode(Integer n);
+  abstract void addNode(Integer n);
 
   /**
    * A proxy method that adds the edge {@code e} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
    * this edge.
-   *
-   * @return {@code true} iff the graph was modified as a result of this call
    */
-  @CanIgnoreReturnValue
-  abstract boolean putEdge(Integer n1, Integer n2);
+  abstract void putEdge(Integer n1, Integer n2);
 
-  @CanIgnoreReturnValue
-  final boolean putEdge(EndpointPair<Integer> endpoints) {
-    return putEdge(endpoints.nodeU(), endpoints.nodeV());
+  final void putEdge(EndpointPair<Integer> endpoints) {
+    putEdge(endpoints.nodeU(), endpoints.nodeV());
   }
 
   final boolean graphIsMutable() {

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -334,15 +334,16 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     // modifications to proxy methods)
     addNode(N1);
     addNode(N2);
-    assertThat(putEdge(N1, N2)).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
   }
 
   @Test
   public void putEdge_existingEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
 
-    assertThat(putEdge(N1, N2)).isTrue();
-    assertThat(putEdge(N1, N2)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isFalse();
   }
 
   @Test
@@ -356,6 +357,59 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains(ENDPOINTS_MISMATCH);
     }
+  }
+
+  /**
+   * Tests that the method {@code putEdge} will silently add the missing nodes to the graph, then
+   * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
+   * putEdge} when the end-points are not elements of the graph.
+   */
+  @Test
+  public void putEdge_nodesNotInGraph() {
+    assume().that(graphIsMutable()).isTrue();
+
+    graphAsMutableGraph.addNode(N1);
+    assertTrue(graphAsMutableGraph.putEdge(N1, N5));
+    assertTrue(graphAsMutableGraph.putEdge(N4, N1));
+    assertTrue(graphAsMutableGraph.putEdge(N2, N3));
+    assertThat(graph.nodes()).containsExactly(N1, N5, N4, N2, N3).inOrder();
+    assertThat(graph.successors(N1)).containsExactly(N5);
+    assertThat(graph.successors(N2)).containsExactly(N3);
+    assertThat(graph.successors(N3)).isEmpty();
+    assertThat(graph.successors(N4)).containsExactly(N1);
+    assertThat(graph.successors(N5)).isEmpty();
+  }
+
+  @Test
+  public void putEdge_doesntAllowSelfLoops() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isFalse();
+
+    try {
+      graphAsMutableGraph.putEdge(N1, N1);
+      fail(ERROR_ADDED_SELF_LOOP);
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().contains(ERROR_SELF_LOOP);
+    }
+  }
+
+  @Test
+  public void putEdge_allowsSelfLoops() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isTrue();
+    assertThat(graph.successors(N1)).containsExactly(N1);
+    assertThat(graph.predecessors(N1)).containsExactly(N1);
+  }
+
+  @Test
+  public void putEdge_existingSelfLoopEdgeBetweenSameNodes() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isTrue();
+
+    graphAsMutableGraph.putEdge(N1, N1);
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isFalse();
   }
 
   @Test
@@ -388,59 +442,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains(ENDPOINTS_MISMATCH);
     }
-  }
-
-  /**
-   * Tests that the method {@code addEdge} will silently add the missing nodes to the graph, then
-   * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
-   * addEdge} when the end-points are not elements of the graph.
-   */
-  @Test
-  public void addEdge_nodesNotInGraph() {
-    assume().that(graphIsMutable()).isTrue();
-
-    graphAsMutableGraph.addNode(N1);
-    assertTrue(graphAsMutableGraph.putEdge(N1, N5));
-    assertTrue(graphAsMutableGraph.putEdge(N4, N1));
-    assertTrue(graphAsMutableGraph.putEdge(N2, N3));
-    assertThat(graph.nodes()).containsExactly(N1, N5, N4, N2, N3).inOrder();
-    assertThat(graph.successors(N1)).containsExactly(N5);
-    assertThat(graph.successors(N2)).containsExactly(N3);
-    assertThat(graph.successors(N3)).isEmpty();
-    assertThat(graph.successors(N4)).containsExactly(N1);
-    assertThat(graph.successors(N5)).isEmpty();
-  }
-
-  @Test
-  public void addEdge_doesntAllowSelfLoops() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isFalse();
-
-    try {
-      putEdge(N1, N1);
-      fail(ERROR_ADDED_SELF_LOOP);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains(ERROR_SELF_LOOP);
-    }
-  }
-
-  @Test
-  public void addEdge_allowsSelfLoops() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isTrue();
-
-    assertThat(putEdge(N1, N1)).isTrue();
-    assertThat(graph.successors(N1)).containsExactly(N1);
-    assertThat(graph.predecessors(N1)).containsExactly(N1);
-  }
-
-  @Test
-  public void addEdge_existingSelfLoopEdgeBetweenSameNodes() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isTrue();
-
-    putEdge(N1, N1);
-    assertThat(putEdge(N1, N1)).isFalse();
   }
 
   @Test

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -245,44 +245,33 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   // Element Mutation
 
   @Test
-  public void addEdge_existingNodes() {
+  public void putEdge_existingNodes() {
     assume().that(graphIsMutable()).isTrue();
 
     // Adding nodes initially for safety (insulating from possible future
     // modifications to proxy methods)
     addNode(N1);
     addNode(N2);
-    assertThat(putEdge(N1, N2)).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
   }
 
   @Test
-  public void addEdge_existingEdgeBetweenSameNodes() {
+  public void putEdge_existingEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
 
     putEdge(N1, N2);
-    assertThat(putEdge(N2, N1)).isFalse();
-  }
 
-  @Test
-  public void removeEdge_antiparallelEdges() {
-    assume().that(graphIsMutable()).isTrue();
-
-    putEdge(N1, N2);
-    putEdge(N2, N1); // no-op
-
-    assertThat(graphAsMutableGraph.removeEdge(N1, N2)).isTrue();
-    assertThat(graph.adjacentNodes(N1)).isEmpty();
-    assertThat(graph.edges()).isEmpty();
-    assertThat(graphAsMutableGraph.removeEdge(N2, N1)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N2, N1)).isFalse();
   }
 
   /**
-   * Tests that the method {@code addEdge} will silently add the missing nodes to the graph, then
+   * Tests that the method {@code putEdge} will silently add the missing nodes to the graph, then
    * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
-   * addEdge} when the end-points are not elements of the graph.
+   * putEdge} when the end-points are not elements of the graph.
    */
   @Test
-  public void addEdge_nodesNotInGraph() {
+  public void putEdge_nodesNotInGraph() {
     assume().that(graphIsMutable()).isTrue();
 
     graphAsMutableGraph.addNode(N1);
@@ -298,7 +287,7 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   }
 
   @Test
-  public void addEdge_doesntAllowSelfLoops() {
+  public void putEdge_doesntAllowSelfLoops() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isFalse();
 
@@ -311,21 +300,34 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   }
 
   @Test
-  public void addEdge_allowsSelfLoops() {
+  public void putEdge_allowsSelfLoops() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isTrue();
 
-    assertThat(putEdge(N1, N1)).isTrue();
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isTrue();
     assertThat(graph.adjacentNodes(N1)).containsExactly(N1);
   }
 
   @Test
-  public void addEdge_existingSelfLoopEdgeBetweenSameNodes() {
+  public void putEdge_existingSelfLoopEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isTrue();
 
     putEdge(N1, N1);
-    assertThat(putEdge(N1, N1)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isFalse();
+  }
+
+  @Test
+  public void removeEdge_antiparallelEdges() {
+    assume().that(graphIsMutable()).isTrue();
+
+    putEdge(N1, N2);
+    putEdge(N2, N1); // no-op
+
+    assertThat(graphAsMutableGraph.removeEdge(N1, N2)).isTrue();
+    assertThat(graph.adjacentNodes(N1)).isEmpty();
+    assertThat(graph.edges()).isEmpty();
+    assertThat(graphAsMutableGraph.removeEdge(N2, N1)).isFalse();
   }
 
   @Test

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -34,12 +33,14 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
         new Object[][] {
           {false, ElementOrder.unordered()},
           {true, ElementOrder.unordered()},
-          // TODO(b/142723300): Add ElementOrder.stable() once it is supported
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()}
         });
   }
 
   private final boolean allowsSelfLoops;
   private final ElementOrder<Integer> incidentEdgeOrder;
+  private ImmutableGraph.Builder<Integer> graphBuilder;
 
   public StandardImmutableDirectedGraphTest(
       boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
@@ -59,28 +60,23 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
 
   @Override
   public Graph<Integer> createGraph() {
-    return GraphBuilder.directed()
-        .allowsSelfLoops(allowsSelfLoops())
-        .incidentEdgeOrder(incidentEdgeOrder)
-        .immutable()
-        .build();
+    graphBuilder =
+        GraphBuilder.directed()
+            .allowsSelfLoops(allowsSelfLoops())
+            .incidentEdgeOrder(incidentEdgeOrder)
+            .immutable();
+    return graphBuilder.build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    MutableGraph<Integer> mutableGraph = Graphs.copyOf(graph);
-    boolean somethingChanged = mutableGraph.addNode(n);
-    graph = ImmutableGraph.copyOf(mutableGraph);
-    return somethingChanged;
+  final void addNode(Integer n) {
+    graphBuilder.addNode(n);
+    graph = graphBuilder.build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    MutableGraph<Integer> mutableGraph = Graphs.copyOf(graph);
-    boolean somethingChanged = mutableGraph.putEdge(n1, n2);
-    graph = ImmutableGraph.copyOf(mutableGraph);
-    return somethingChanged;
+  final void putEdge(Integer n1, Integer n2) {
+    graphBuilder.putEdge(n1, n2);
+    graph = graphBuilder.build();
   }
 }

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -66,15 +65,13 @@ public final class StandardMutableDirectedGraphTest extends AbstractStandardDire
         .build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    return graphAsMutableGraph.addNode(n);
+  final void addNode(Integer n) {
+    graphAsMutableGraph.addNode(n);
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    return graphAsMutableGraph.putEdge(n1, n2);
+  final void putEdge(Integer n1, Integer n2) {
+    graphAsMutableGraph.putEdge(n1, n2);
   }
 }

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -52,15 +51,13 @@ public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirect
     return GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    return graphAsMutableGraph.addNode(n);
+  final void addNode(Integer n) {
+    graphAsMutableGraph.addNode(n);
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    return graphAsMutableGraph.putEdge(n1, n2);
+  final void putEdge(Integer n1, Integer n2) {
+    graphAsMutableGraph.putEdge(n1, n2);
   }
 }

--- a/android/guava-tests/test/com/google/common/net/InetAddressesTest.java
+++ b/android/guava-tests/test/com/google/common/net/InetAddressesTest.java
@@ -770,7 +770,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv4BigIntegerThrowsLessThanZero() {
     try {
-      InetAddresses.fromIpv4BigInteger(BigInteger.valueOf(-1L));
+      InetAddresses.fromIPv4BigInteger(BigInteger.valueOf(-1L));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals("BigInteger must be greater than or equal to 0", expected.getMessage());
@@ -779,7 +779,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv6BigIntegerThrowsLessThanZero() {
     try {
-      InetAddresses.fromIpv6BigInteger(BigInteger.valueOf(-1L));
+      InetAddresses.fromIPv6BigInteger(BigInteger.valueOf(-1L));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals("BigInteger must be greater than or equal to 0", expected.getMessage());
@@ -810,7 +810,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv4BigIntegerInputTooLarge() {
     try {
-      InetAddresses.fromIpv4BigInteger(BigInteger.ONE.shiftLeft(32).add(BigInteger.ONE));
+      InetAddresses.fromIPv4BigInteger(BigInteger.ONE.shiftLeft(32).add(BigInteger.ONE));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals(
@@ -822,7 +822,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv6BigIntegerInputTooLarge() {
     try {
-      InetAddresses.fromIpv6BigInteger(BigInteger.ONE.shiftLeft(128).add(BigInteger.ONE));
+      InetAddresses.fromIPv6BigInteger(BigInteger.ONE.shiftLeft(128).add(BigInteger.ONE));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals(
@@ -840,7 +840,7 @@ public class InetAddressesTest extends TestCase {
     assertEquals(
         address,
         isIpv6
-            ? InetAddresses.fromIpv6BigInteger(bigIntegerIp)
-            : InetAddresses.fromIpv4BigInteger(bigIntegerIp));
+            ? InetAddresses.fromIPv6BigInteger(bigIntegerIp)
+            : InetAddresses.fromIPv4BigInteger(bigIntegerIp));
   }
 }

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -84,11 +84,12 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return nodeConnections.build();
   }
 
+  @SuppressWarnings("unchecked")
   private static <N> GraphConnections<N, Presence> connectionsOf(Graph<N> graph, N node) {
-    Function<Object, Presence> edgeValueFn = Functions.constant(Presence.EDGE_EXISTS);
+    Function<N, Presence> edgeValueFn =
+        (Function<N, Presence>) Functions.constant(Presence.EDGE_EXISTS);
     return graph.isDirected()
-        ? DirectedGraphConnections.ofImmutable(
-            graph.predecessors(node), Maps.asMap(graph.successors(node), edgeValueFn))
+        ? DirectedGraphConnections.ofImmutable(node, graph.incidentEdges(node), edgeValueFn)
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), edgeValueFn));
   }

--- a/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -94,7 +94,7 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
         };
     return graph.isDirected()
         ? DirectedGraphConnections.ofImmutable(
-            graph.predecessors(node), Maps.asMap(graph.successors(node), successorNodeToValueFn))
+            node, graph.incidentEdges(node), successorNodeToValueFn)
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), successorNodeToValueFn));
   }

--- a/android/guava/src/com/google/common/net/InetAddresses.java
+++ b/android/guava/src/com/google/common/net/InetAddresses.java
@@ -941,7 +941,7 @@ public final class InetAddresses {
    * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^32-1
    * @since NEXT
    */
-  public static Inet4Address fromIpv4BigInteger(BigInteger address) {
+  public static Inet4Address fromIPv4BigInteger(BigInteger address) {
     return (Inet4Address) fromBigInteger(address, false);
   }
   /**
@@ -952,7 +952,7 @@ public final class InetAddresses {
    * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^128-1
    * @since NEXT
    */
-  public static Inet6Address fromIpv6BigInteger(BigInteger address) {
+  public static Inet6Address fromIPv6BigInteger(BigInteger address) {
     return (Inet6Address) fromBigInteger(address, true);
   }
 

--- a/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
+++ b/guava-gwt/src-super/com/google/common/cache/super/com/google/common/cache/LocalCache.java
@@ -231,6 +231,7 @@ public class LocalCache<K, V> implements ConcurrentMap<K, V> {
     return expireWrite || expireAccess;
   }
 
+  @SuppressWarnings("GoodTime")
   private long currentTimeNanos() {
     return ticker.read();
   }

--- a/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -470,6 +470,7 @@ public abstract class AbstractGraphTest {
 
     putEdge(N1, N2);
     addNode(N3);
+
     assertThat(graphAsMutableGraph.removeEdge(N1, N3)).isFalse();
     assertThat(graph.successors(N1)).contains(N2);
   }

--- a/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -97,13 +97,13 @@ public abstract class AbstractGraphTest {
   @CanIgnoreReturnValue
   abstract boolean putEdge(Integer n1, Integer n2);
 
-  final boolean graphIsMutable() {
-    return graphAsMutableGraph != null;
-  }
-
   @CanIgnoreReturnValue
   final boolean putEdge(EndpointPair<Integer> endpoints) {
     return putEdge(endpoints.nodeU(), endpoints.nodeV());
+  }
+
+  final boolean graphIsMutable() {
+    return graphAsMutableGraph != null;
   }
 
   @Before

--- a/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -25,7 +25,6 @@ import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.After;
@@ -81,25 +80,18 @@ public abstract class AbstractGraphTest {
    * A proxy method that adds the node {@code n} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
    * this node.
-   *
-   * @return {@code true} iff the graph was modified as a result of this call
    */
-  @CanIgnoreReturnValue
-  abstract boolean addNode(Integer n);
+  abstract void addNode(Integer n);
 
   /**
    * A proxy method that adds the edge {@code e} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
    * this edge.
-   *
-   * @return {@code true} iff the graph was modified as a result of this call
    */
-  @CanIgnoreReturnValue
-  abstract boolean putEdge(Integer n1, Integer n2);
+  abstract void putEdge(Integer n1, Integer n2);
 
-  @CanIgnoreReturnValue
-  final boolean putEdge(EndpointPair<Integer> endpoints) {
-    return putEdge(endpoints.nodeU(), endpoints.nodeV());
+  final void putEdge(EndpointPair<Integer> endpoints) {
+    putEdge(endpoints.nodeU(), endpoints.nodeV());
   }
 
   final boolean graphIsMutable() {

--- a/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -334,15 +334,16 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     // modifications to proxy methods)
     addNode(N1);
     addNode(N2);
-    assertThat(putEdge(N1, N2)).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
   }
 
   @Test
   public void putEdge_existingEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
 
-    assertThat(putEdge(N1, N2)).isTrue();
-    assertThat(putEdge(N1, N2)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isFalse();
   }
 
   @Test
@@ -356,6 +357,59 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains(ENDPOINTS_MISMATCH);
     }
+  }
+
+  /**
+   * Tests that the method {@code putEdge} will silently add the missing nodes to the graph, then
+   * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
+   * putEdge} when the end-points are not elements of the graph.
+   */
+  @Test
+  public void putEdge_nodesNotInGraph() {
+    assume().that(graphIsMutable()).isTrue();
+
+    graphAsMutableGraph.addNode(N1);
+    assertTrue(graphAsMutableGraph.putEdge(N1, N5));
+    assertTrue(graphAsMutableGraph.putEdge(N4, N1));
+    assertTrue(graphAsMutableGraph.putEdge(N2, N3));
+    assertThat(graph.nodes()).containsExactly(N1, N5, N4, N2, N3).inOrder();
+    assertThat(graph.successors(N1)).containsExactly(N5);
+    assertThat(graph.successors(N2)).containsExactly(N3);
+    assertThat(graph.successors(N3)).isEmpty();
+    assertThat(graph.successors(N4)).containsExactly(N1);
+    assertThat(graph.successors(N5)).isEmpty();
+  }
+
+  @Test
+  public void putEdge_doesntAllowSelfLoops() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isFalse();
+
+    try {
+      graphAsMutableGraph.putEdge(N1, N1);
+      fail(ERROR_ADDED_SELF_LOOP);
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().contains(ERROR_SELF_LOOP);
+    }
+  }
+
+  @Test
+  public void putEdge_allowsSelfLoops() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isTrue();
+    assertThat(graph.successors(N1)).containsExactly(N1);
+    assertThat(graph.predecessors(N1)).containsExactly(N1);
+  }
+
+  @Test
+  public void putEdge_existingSelfLoopEdgeBetweenSameNodes() {
+    assume().that(graphIsMutable()).isTrue();
+    assume().that(allowsSelfLoops()).isTrue();
+
+    graphAsMutableGraph.putEdge(N1, N1);
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isFalse();
   }
 
   @Test
@@ -388,59 +442,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().contains(ENDPOINTS_MISMATCH);
     }
-  }
-
-  /**
-   * Tests that the method {@code addEdge} will silently add the missing nodes to the graph, then
-   * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
-   * addEdge} when the end-points are not elements of the graph.
-   */
-  @Test
-  public void addEdge_nodesNotInGraph() {
-    assume().that(graphIsMutable()).isTrue();
-
-    graphAsMutableGraph.addNode(N1);
-    assertTrue(graphAsMutableGraph.putEdge(N1, N5));
-    assertTrue(graphAsMutableGraph.putEdge(N4, N1));
-    assertTrue(graphAsMutableGraph.putEdge(N2, N3));
-    assertThat(graph.nodes()).containsExactly(N1, N5, N4, N2, N3).inOrder();
-    assertThat(graph.successors(N1)).containsExactly(N5);
-    assertThat(graph.successors(N2)).containsExactly(N3);
-    assertThat(graph.successors(N3)).isEmpty();
-    assertThat(graph.successors(N4)).containsExactly(N1);
-    assertThat(graph.successors(N5)).isEmpty();
-  }
-
-  @Test
-  public void addEdge_doesntAllowSelfLoops() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isFalse();
-
-    try {
-      putEdge(N1, N1);
-      fail(ERROR_ADDED_SELF_LOOP);
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains(ERROR_SELF_LOOP);
-    }
-  }
-
-  @Test
-  public void addEdge_allowsSelfLoops() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isTrue();
-
-    assertThat(putEdge(N1, N1)).isTrue();
-    assertThat(graph.successors(N1)).containsExactly(N1);
-    assertThat(graph.predecessors(N1)).containsExactly(N1);
-  }
-
-  @Test
-  public void addEdge_existingSelfLoopEdgeBetweenSameNodes() {
-    assume().that(graphIsMutable()).isTrue();
-    assume().that(allowsSelfLoops()).isTrue();
-
-    putEdge(N1, N1);
-    assertThat(putEdge(N1, N1)).isFalse();
   }
 
   @Test

--- a/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -245,44 +245,33 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   // Element Mutation
 
   @Test
-  public void addEdge_existingNodes() {
+  public void putEdge_existingNodes() {
     assume().that(graphIsMutable()).isTrue();
 
     // Adding nodes initially for safety (insulating from possible future
     // modifications to proxy methods)
     addNode(N1);
     addNode(N2);
-    assertThat(putEdge(N1, N2)).isTrue();
+
+    assertThat(graphAsMutableGraph.putEdge(N1, N2)).isTrue();
   }
 
   @Test
-  public void addEdge_existingEdgeBetweenSameNodes() {
+  public void putEdge_existingEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
 
     putEdge(N1, N2);
-    assertThat(putEdge(N2, N1)).isFalse();
-  }
 
-  @Test
-  public void removeEdge_antiparallelEdges() {
-    assume().that(graphIsMutable()).isTrue();
-
-    putEdge(N1, N2);
-    putEdge(N2, N1); // no-op
-
-    assertThat(graphAsMutableGraph.removeEdge(N1, N2)).isTrue();
-    assertThat(graph.adjacentNodes(N1)).isEmpty();
-    assertThat(graph.edges()).isEmpty();
-    assertThat(graphAsMutableGraph.removeEdge(N2, N1)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N2, N1)).isFalse();
   }
 
   /**
-   * Tests that the method {@code addEdge} will silently add the missing nodes to the graph, then
+   * Tests that the method {@code putEdge} will silently add the missing nodes to the graph, then
    * add the edge connecting them. We are not using the proxy methods here as we want to test {@code
-   * addEdge} when the end-points are not elements of the graph.
+   * putEdge} when the end-points are not elements of the graph.
    */
   @Test
-  public void addEdge_nodesNotInGraph() {
+  public void putEdge_nodesNotInGraph() {
     assume().that(graphIsMutable()).isTrue();
 
     graphAsMutableGraph.addNode(N1);
@@ -298,7 +287,7 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   }
 
   @Test
-  public void addEdge_doesntAllowSelfLoops() {
+  public void putEdge_doesntAllowSelfLoops() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isFalse();
 
@@ -311,21 +300,34 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
   }
 
   @Test
-  public void addEdge_allowsSelfLoops() {
+  public void putEdge_allowsSelfLoops() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isTrue();
 
-    assertThat(putEdge(N1, N1)).isTrue();
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isTrue();
     assertThat(graph.adjacentNodes(N1)).containsExactly(N1);
   }
 
   @Test
-  public void addEdge_existingSelfLoopEdgeBetweenSameNodes() {
+  public void putEdge_existingSelfLoopEdgeBetweenSameNodes() {
     assume().that(graphIsMutable()).isTrue();
     assume().that(allowsSelfLoops()).isTrue();
 
     putEdge(N1, N1);
-    assertThat(putEdge(N1, N1)).isFalse();
+    assertThat(graphAsMutableGraph.putEdge(N1, N1)).isFalse();
+  }
+
+  @Test
+  public void removeEdge_antiparallelEdges() {
+    assume().that(graphIsMutable()).isTrue();
+
+    putEdge(N1, N2);
+    putEdge(N2, N1); // no-op
+
+    assertThat(graphAsMutableGraph.removeEdge(N1, N2)).isTrue();
+    assertThat(graph.adjacentNodes(N1)).isEmpty();
+    assertThat(graph.edges()).isEmpty();
+    assertThat(graphAsMutableGraph.removeEdge(N2, N1)).isFalse();
   }
 
   @Test

--- a/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -34,12 +33,14 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
         new Object[][] {
           {false, ElementOrder.unordered()},
           {true, ElementOrder.unordered()},
-          // TODO(b/142723300): Add ElementOrder.stable() once it is supported
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()}
         });
   }
 
   private final boolean allowsSelfLoops;
   private final ElementOrder<Integer> incidentEdgeOrder;
+  private ImmutableGraph.Builder<Integer> graphBuilder;
 
   public StandardImmutableDirectedGraphTest(
       boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
@@ -59,28 +60,23 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
 
   @Override
   public Graph<Integer> createGraph() {
-    return GraphBuilder.directed()
-        .allowsSelfLoops(allowsSelfLoops())
-        .incidentEdgeOrder(incidentEdgeOrder)
-        .immutable()
-        .build();
+    graphBuilder =
+        GraphBuilder.directed()
+            .allowsSelfLoops(allowsSelfLoops())
+            .incidentEdgeOrder(incidentEdgeOrder)
+            .immutable();
+    return graphBuilder.build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    MutableGraph<Integer> mutableGraph = Graphs.copyOf(graph);
-    boolean somethingChanged = mutableGraph.addNode(n);
-    graph = ImmutableGraph.copyOf(mutableGraph);
-    return somethingChanged;
+  final void addNode(Integer n) {
+    graphBuilder.addNode(n);
+    graph = graphBuilder.build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    MutableGraph<Integer> mutableGraph = Graphs.copyOf(graph);
-    boolean somethingChanged = mutableGraph.putEdge(n1, n2);
-    graph = ImmutableGraph.copyOf(mutableGraph);
-    return somethingChanged;
+  final void putEdge(Integer n1, Integer n2) {
+    graphBuilder.putEdge(n1, n2);
+    graph = graphBuilder.build();
   }
 }

--- a/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -66,15 +65,13 @@ public final class StandardMutableDirectedGraphTest extends AbstractStandardDire
         .build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    return graphAsMutableGraph.addNode(n);
+  final void addNode(Integer n) {
+    graphAsMutableGraph.addNode(n);
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    return graphAsMutableGraph.putEdge(n1, n2);
+  final void putEdge(Integer n1, Integer n2) {
+    graphAsMutableGraph.putEdge(n1, n2);
   }
 }

--- a/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -16,7 +16,6 @@
 
 package com.google.common.graph;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runner.RunWith;
@@ -52,15 +51,13 @@ public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirect
     return GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).build();
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean addNode(Integer n) {
-    return graphAsMutableGraph.addNode(n);
+  final void addNode(Integer n) {
+    graphAsMutableGraph.addNode(n);
   }
 
-  @CanIgnoreReturnValue
   @Override
-  final boolean putEdge(Integer n1, Integer n2) {
-    return graphAsMutableGraph.putEdge(n1, n2);
+  final void putEdge(Integer n1, Integer n2) {
+    graphAsMutableGraph.putEdge(n1, n2);
   }
 }

--- a/guava-tests/test/com/google/common/net/InetAddressesTest.java
+++ b/guava-tests/test/com/google/common/net/InetAddressesTest.java
@@ -770,7 +770,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv4BigIntegerThrowsLessThanZero() {
     try {
-      InetAddresses.fromIpv4BigInteger(BigInteger.valueOf(-1L));
+      InetAddresses.fromIPv4BigInteger(BigInteger.valueOf(-1L));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals("BigInteger must be greater than or equal to 0", expected.getMessage());
@@ -779,7 +779,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv6BigIntegerThrowsLessThanZero() {
     try {
-      InetAddresses.fromIpv6BigInteger(BigInteger.valueOf(-1L));
+      InetAddresses.fromIPv6BigInteger(BigInteger.valueOf(-1L));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals("BigInteger must be greater than or equal to 0", expected.getMessage());
@@ -810,7 +810,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv4BigIntegerInputTooLarge() {
     try {
-      InetAddresses.fromIpv4BigInteger(BigInteger.ONE.shiftLeft(32).add(BigInteger.ONE));
+      InetAddresses.fromIPv4BigInteger(BigInteger.ONE.shiftLeft(32).add(BigInteger.ONE));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals(
@@ -822,7 +822,7 @@ public class InetAddressesTest extends TestCase {
 
   public void testFromIpv6BigIntegerInputTooLarge() {
     try {
-      InetAddresses.fromIpv6BigInteger(BigInteger.ONE.shiftLeft(128).add(BigInteger.ONE));
+      InetAddresses.fromIPv6BigInteger(BigInteger.ONE.shiftLeft(128).add(BigInteger.ONE));
       fail();
     } catch (IllegalArgumentException expected) {
       assertEquals(
@@ -840,7 +840,7 @@ public class InetAddressesTest extends TestCase {
     assertEquals(
         address,
         isIpv6
-            ? InetAddresses.fromIpv6BigInteger(bigIntegerIp)
-            : InetAddresses.fromIpv4BigInteger(bigIntegerIp));
+            ? InetAddresses.fromIPv6BigInteger(bigIntegerIp)
+            : InetAddresses.fromIPv4BigInteger(bigIntegerIp));
   }
 }

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -84,11 +84,12 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return nodeConnections.build();
   }
 
+  @SuppressWarnings("unchecked")
   private static <N> GraphConnections<N, Presence> connectionsOf(Graph<N> graph, N node) {
-    Function<Object, Presence> edgeValueFn = Functions.constant(Presence.EDGE_EXISTS);
+    Function<N, Presence> edgeValueFn =
+        (Function<N, Presence>) Functions.constant(Presence.EDGE_EXISTS);
     return graph.isDirected()
-        ? DirectedGraphConnections.ofImmutable(
-            graph.predecessors(node), Maps.asMap(graph.successors(node), edgeValueFn))
+        ? DirectedGraphConnections.ofImmutable(node, graph.incidentEdges(node), edgeValueFn)
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), edgeValueFn));
   }

--- a/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -94,7 +94,7 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
         };
     return graph.isDirected()
         ? DirectedGraphConnections.ofImmutable(
-            graph.predecessors(node), Maps.asMap(graph.successors(node), successorNodeToValueFn))
+            node, graph.incidentEdges(node), successorNodeToValueFn)
         : UndirectedGraphConnections.ofImmutable(
             Maps.asMap(graph.adjacentNodes(node), successorNodeToValueFn));
   }

--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -936,7 +936,7 @@ public final class InetAddresses {
    * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^32-1
    * @since NEXT
    */
-  public static Inet4Address fromIpv4BigInteger(BigInteger address) {
+  public static Inet4Address fromIPv4BigInteger(BigInteger address) {
     return (Inet4Address) fromBigInteger(address, false);
   }
   /**
@@ -947,7 +947,7 @@ public final class InetAddresses {
    * @throws IllegalArgumentException if the BigInteger is not between 0 and 2^128-1
    * @since NEXT
    */
-  public static Inet6Address fromIpv6BigInteger(BigInteger address) {
+  public static Inet6Address fromIPv6BigInteger(BigInteger address) {
     return (Inet6Address) fromBigInteger(address, true);
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use "IPv4" instead of "Ipv4" for consistency.

This CL goes against the style guide, but we should be consistent within the file. We could instead rename the existing, lightly used methods to match the style guide, but I don't think this will be the best use of someone's time.

4a627d3ea2ac16e7e970f78939df6a163335df1c

-------

<p> Add @SuppressWarnings("GoodTime") to GWT supersource for LocalCache operating in primitive millis.

95e7e1af8ef059e874f4c00230b010f651322e71

-------

<p> The Graph tests now consistently call graphAsMutableGraph.foo() when testing foo(), rather than proxy methods

1fc1f11779159183f0b4daeb388c6def36a4a2e3

-------

<p> Make equally named putEdge() method adjacent

9a1f2e28f76a623501e8178262359202055139c2

-------

<p> Support stable incident edge order for directed Immutable[Value]Graphs.

2608ca43cf15c4b2a7ad21a900550358f5e6fc76