### PR TITLE
MOE Sync 2019-12-09

### DIFF
--- a/android/guava-testlib/src/com/google/common/testing/GcFinalization.java
+++ b/android/guava-testlib/src/com/google/common/testing/GcFinalization.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -241,6 +242,7 @@ public final class GcFinalization {
    *   <li>enqueuing weak references to unreachable referents in their reference queue
    * </ul>
    */
+  @DoNotMock("Implement with a lambda")
   public interface FinalizationPredicate {
     boolean isDone();
   }

--- a/android/guava-testlib/src/com/google/common/testing/TearDownAccepter.java
+++ b/android/guava-testlib/src/com/google/common/testing/TearDownAccepter.java
@@ -17,6 +17,7 @@
 package com.google.common.testing;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.common.annotations.GwtCompatible;
 
 /**
@@ -26,6 +27,7 @@ import com.google.common.annotations.GwtCompatible;
  * @since 10.0
  */
 @Beta
+@DoNotMock("Implement with a lambda")
 @GwtCompatible
 public interface TearDownAccepter {
   /**

--- a/android/guava/src/com/google/common/base/CaseFormat.java
+++ b/android/guava/src/com/google/common/base/CaseFormat.java
@@ -135,7 +135,7 @@ public enum CaseFormat {
     while ((j = wordBoundary.indexIn(s, ++j)) != -1) {
       if (i == 0) {
         // include some extra space for separators
-        out = new StringBuilder(s.length() + 4 * wordSeparator.length());
+        out = new StringBuilder(s.length() + 4 * format.wordSeparator.length());
         out.append(format.normalizeFirstWord(s.substring(i, j)));
       } else {
         out.append(format.normalizeWord(s.substring(i, j)));

--- a/android/guava/src/com/google/common/base/FinalizableReference.java
+++ b/android/guava/src/com/google/common/base/FinalizableReference.java
@@ -15,6 +15,7 @@
 package com.google.common.base;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * Implemented by references that have code to run after garbage collection of their referents.
@@ -23,6 +24,7 @@ import com.google.common.annotations.GwtIncompatible;
  * @author Bob Lee
  * @since 2.0
  */
+@DoNotMock("Use an instance of one of the Finalizable*Reference classes")
 @GwtIncompatible
 public interface FinalizableReference {
   /**

--- a/android/guava/src/com/google/common/base/Optional.java
+++ b/android/guava/src/com/google/common/base/Optional.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Set;
@@ -79,6 +80,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kevin Bourrillion
  * @since 10.0
  */
+@DoNotMock("Use Optional.of(value) or Optional.absent()")
 @GwtCompatible(serializable = true)
 public abstract class Optional<T> implements Serializable {
   /**

--- a/android/guava/src/com/google/common/cache/Cache.java
+++ b/android/guava/src/com/google/common/cache/Cache.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +37,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Charles Fry
  * @since 10.0
  */
+@DoNotMock("Use CacheBuilder.newBuilder().build()")
 @GwtCompatible
 public interface Cache<K, V> {
 

--- a/android/guava/src/com/google/common/collect/ClassToInstanceMap.java
+++ b/android/guava/src/com/google/common/collect/ClassToInstanceMap.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -40,6 +41,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use ImmutableClassToInstanceMap or MutableClassToInstanceMap")
 @GwtCompatible
 public interface ClassToInstanceMap<B> extends Map<Class<? extends B>, B> {
   /**

--- a/android/guava/src/com/google/common/collect/ImmutableCollection.java
+++ b/android/guava/src/com/google/common/collect/ImmutableCollection.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.ObjectArrays.checkElementsNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.Arrays;
@@ -157,6 +158,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * @since 2.0
  */
+@DoNotMock("Use ImmutableList.of or another implementation")
 @GwtCompatible(emulated = true)
 @SuppressWarnings("serial") // we're overriding default serialization
 // TODO(kevinb): I think we should push everything down to "BaseImmutableCollection" or something,
@@ -340,6 +342,7 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
    *
    * @since 10.0
    */
+  @DoNotMock
   public abstract static class Builder<E> {
     static final int DEFAULT_INITIAL_CAPACITY = 4;
 

--- a/android/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMap.java
@@ -24,6 +24,7 @@ import static com.google.common.collect.CollectPreconditions.checkNonnegative;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.RetainedWith;
 import com.google.j2objc.annotations.WeakOuter;
@@ -51,6 +52,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use ImmutableMap.of or another implementation")
 @GwtCompatible(serializable = true, emulated = true)
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
@@ -208,6 +210,7 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    *
    * @since 2.0
    */
+  @DoNotMock
   public static class Builder<K, V> {
     @MonotonicNonNullDecl Comparator<? super V> valueComparator;
     Object[] alternatingKeysAndValues;

--- a/android/guava/src/com/google/common/collect/ImmutableMultimap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMultimap.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.j2objc.annotations.Weak;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.Serializable;
@@ -136,6 +137,7 @@ public abstract class ImmutableMultimap<K, V> extends BaseImmutableMultimap<K, V
    *
    * @since 2.0
    */
+  @DoNotMock
   public static class Builder<K, V> {
     Map<K, Collection<V>> builderMap;
     @MonotonicNonNullDecl Comparator<? super K> keyComparator;

--- a/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.SortedLists.KeyAbsentBehavior;
 import com.google.common.collect.SortedLists.KeyPresentBehavior;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -82,6 +83,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
    *
    * @since 14.0
    */
+  @DoNotMock
   public static final class Builder<K extends Comparable<?>, V> {
     private final List<Entry<Range<K>, V>> entries;
 

--- a/android/guava/src/com/google/common/collect/ImmutableTable.java
+++ b/android/guava/src/com/google/common/collect/ImmutableTable.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -131,6 +132,7 @@ public abstract class ImmutableTable<R, C, V> extends AbstractTable<R, C, V>
    *
    * @since 11.0
    */
+  @DoNotMock
   public static final class Builder<R, C, V> {
     private final List<Cell<R, C, V>> cells = Lists.newArrayList();
     @MonotonicNonNullDecl private Comparator<? super R> rowComparator;

--- a/android/guava/src/com/google/common/collect/Interner.java
+++ b/android/guava/src/com/google/common/collect/Interner.java
@@ -19,6 +19,7 @@ package com.google.common.collect;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * Provides equivalent behavior to {@link String#intern} for other immutable types. Common
@@ -28,6 +29,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
  * @since 3.0
  */
 @Beta
+@DoNotMock("Use Interners.new*Interner")
 @GwtIncompatible
 public interface Interner<E> {
   /**

--- a/android/guava/src/com/google/common/collect/MapDifference.java
+++ b/android/guava/src/com/google/common/collect/MapDifference.java
@@ -17,6 +17,7 @@
 package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -26,6 +27,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use Maps.difference")
 @GwtCompatible
 public interface MapDifference<K, V> {
   /**
@@ -84,6 +86,7 @@ public interface MapDifference<K, V> {
    *
    * @since 2.0
    */
+  @DoNotMock("Use Maps.difference")
   interface ValueDifference<V> {
     /** Returns the value from the left map (possibly null). */
     V leftValue();

--- a/android/guava/src/com/google/common/collect/Multimap.java
+++ b/android/guava/src/com/google/common/collect/Multimap.java
@@ -19,6 +19,7 @@ package com.google.common.collect;
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -155,6 +156,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @author Jared Levy
  * @since 2.0
  */
+@DoNotMock("Use ImmutableMultimap, HashMultimap, or another implementation")
 @GwtCompatible
 public interface Multimap<K, V> {
   // Query Operations

--- a/android/guava/src/com/google/common/collect/PeekingIterator.java
+++ b/android/guava/src/com/google/common/collect/PeekingIterator.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -31,6 +32,7 @@ import java.util.NoSuchElementException;
  * @author Mick Killianey
  * @since 2.0
  */
+@DoNotMock("Use Iterators.peekingIterator")
 @GwtCompatible
 public interface PeekingIterator<E> extends Iterator<E> {
   /**

--- a/android/guava/src/com/google/common/collect/RangeMap.java
+++ b/android/guava/src/com/google/common/collect/RangeMap.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,6 +36,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 14.0
  */
 @Beta
+@DoNotMock("Use ImmutableRangeMap or TreeRangeMap")
 @GwtIncompatible
 public interface RangeMap<K extends Comparable, V> {
   /**

--- a/android/guava/src/com/google/common/collect/RangeSet.java
+++ b/android/guava/src/com/google/common/collect/RangeSet.java
@@ -16,6 +16,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -49,6 +50,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 14.0
  */
 @Beta
+@DoNotMock("Use ImmutableRangeSet or TreeRangeSet")
 @GwtIncompatible
 public interface RangeSet<C extends Comparable> {
 

--- a/android/guava/src/com/google/common/collect/Table.java
+++ b/android/guava/src/com/google/common/collect/Table.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +53,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @param <V> the type of the mapped values
  * @since 7.0
  */
+@DoNotMock("Use ImmutableTable, HashBasedTable, or another implementation")
 @GwtCompatible
 public interface Table<R, C, V> {
   // TODO(jlevy): Consider adding methods similar to ConcurrentMap methods.

--- a/android/guava/src/com/google/common/escape/Escaper.java
+++ b/android/guava/src/com/google/common/escape/Escaper.java
@@ -16,6 +16,7 @@ package com.google.common.escape;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Function;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * An object that converts literal text into a format safe for inclusion in a particular context
@@ -53,6 +54,7 @@ import com.google.common.base.Function;
  * @author David Beaumont
  * @since 15.0
  */
+@DoNotMock("Use Escapers.nullEscaper() or another methods from the *Escapers classes")
 @GwtCompatible
 public abstract class Escaper {
   // TODO(dbeaumont): evaluate custom implementations, considering package private constructor.

--- a/android/guava/src/com/google/common/graph/Graph.java
+++ b/android/guava/src/com/google/common/graph/Graph.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Set;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -101,6 +102,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 20.0
  */
 @Beta
+@DoNotMock("Use GraphBuilder to create a real instance")
 public interface Graph<N> extends BaseGraph<N> {
   //
   // Graph-level accessors

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -22,6 +22,7 @@ import static com.google.common.graph.Graphs.checkNonNegative;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A builder for constructing instances of {@link MutableGraph} or {@link ImmutableGraph} with
@@ -62,6 +63,7 @@ import com.google.common.base.Optional;
  * @since 20.0
  */
 @Beta
+@DoNotMock
 public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
 
   /** Creates a new instance with the specified edge directionality. */

--- a/android/guava/src/com/google/common/graph/Network.java
+++ b/android/guava/src/com/google/common/graph/Network.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Set;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -101,6 +102,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 20.0
  */
 @Beta
+@DoNotMock("Use NetworkBuilder to create a real instance")
 public interface Network<N, E> extends SuccessorsFunction<N>, PredecessorsFunction<N> {
   //
   // Network-level accessors

--- a/android/guava/src/com/google/common/graph/PredecessorsFunction.java
+++ b/android/guava/src/com/google/common/graph/PredecessorsFunction.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A functional interface for <a
@@ -78,6 +79,7 @@ import com.google.common.annotations.Beta;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Implement with a lambda, or use GraphBuilder to build a Graph with the desired edges")
 public interface PredecessorsFunction<N> {
 
   /**

--- a/android/guava/src/com/google/common/graph/SuccessorsFunction.java
+++ b/android/guava/src/com/google/common/graph/SuccessorsFunction.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A functional interface for <a
@@ -78,6 +79,7 @@ import com.google.common.annotations.Beta;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Implement with a lambda, or use GraphBuilder to build a Graph with the desired edges")
 public interface SuccessorsFunction<N> {
 
   /**

--- a/android/guava/src/com/google/common/hash/Funnel.java
+++ b/android/guava/src/com/google/common/hash/Funnel.java
@@ -15,6 +15,7 @@
 package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 
 /**
@@ -41,6 +42,7 @@ import java.io.Serializable;
  * @since 11.0
  */
 @Beta
+@DoNotMock("Implement with a lambda")
 public interface Funnel<T> extends Serializable {
 
   /**

--- a/android/guava/src/com/google/common/hash/HashFunction.java
+++ b/android/guava/src/com/google/common/hash/HashFunction.java
@@ -16,6 +16,7 @@ package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
 import com.google.common.primitives.Ints;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -116,6 +117,7 @@ import java.nio.charset.Charset;
  * @since 11.0
  */
 @Beta
+@DoNotMock("Use a real instance from Hashing")
 @Immutable
 public interface HashFunction {
   /**

--- a/android/guava/src/com/google/common/io/ByteProcessor.java
+++ b/android/guava/src/com/google/common/io/ByteProcessor.java
@@ -17,6 +17,7 @@ package com.google.common.io;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.IOException;
 
 /**
@@ -29,6 +30,7 @@ import java.io.IOException;
  * @since 1.0
  */
 @Beta
+@DoNotMock("Implement it normally")
 @GwtIncompatible
 public interface ByteProcessor<T> {
   /**

--- a/android/guava/src/com/google/common/reflect/TypeToInstanceMap.java
+++ b/android/guava/src/com/google/common/reflect/TypeToInstanceMap.java
@@ -16,6 +16,7 @@ package com.google.common.reflect;
 
 import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -39,6 +40,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 13.0
  */
 @Beta
+@DoNotMock("Use ImmutableTypeToInstanceMap or MutableTypeToInstanceMap")
 public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -69,6 +70,7 @@ import java.util.concurrent.TimeoutException;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Use FluentFuture.from(Futures.immediate*Future) or SettableFuture")
 @GwtCompatible(emulated = true)
 public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecialization<V> {
 

--- a/android/guava/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -14,6 +14,7 @@
 
 package com.google.common.util.concurrent;
 
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -98,6 +99,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @author Nishant Thakkar
  * @since 1.0
  */
+@DoNotMock("Use the methods in Futures (like immediateFuture) or SettableFuture")
 public interface ListenableFuture<V> extends Future<V> {
   /**
    * Registers a listener to be {@linkplain Executor#execute(Runnable) run} on the given executor.

--- a/android/guava/src/com/google/common/util/concurrent/ListeningExecutorService.java
+++ b/android/guava/src/com/google/common/util/concurrent/ListeningExecutorService.java
@@ -15,6 +15,7 @@
 package com.google.common.util.concurrent;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -31,6 +32,9 @@ import java.util.concurrent.TimeUnit;
  * @author Chris Povirk
  * @since 10.0
  */
+@DoNotMock(
+    "Use TestingExecutors.sameThreadScheduledExecutor, or wrap a real Executor from "
+        + "java.util.concurrent.Executors with MoreExecutors.listeningDecorator")
 @GwtIncompatible
 public interface ListeningExecutorService extends ExecutorService {
   /**

--- a/android/guava/src/com/google/common/util/concurrent/Service.java
+++ b/android/guava/src/com/google/common/util/concurrent/Service.java
@@ -15,6 +15,7 @@
 package com.google.common.util.concurrent;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.concurrent.Executor;
@@ -52,6 +53,7 @@ import java.util.concurrent.TimeoutException;
  * @since 9.0 (in 1.0 as {@code com.google.common.base.Service})
  */
 @Beta
+@DoNotMock("Create an AbstractIdleService")
 @GwtIncompatible
 public interface Service {
   /**

--- a/android/guava/src/com/google/common/util/concurrent/TimeLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/TimeLimiter.java
@@ -17,6 +17,7 @@ package com.google.common.util.concurrent;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeoutException;
  * @since 1.0
  */
 @Beta
+@DoNotMock("Use FakeTimeLimiter")
 @GwtIncompatible
 @SuppressWarnings("GoodTime") // should have java.time.Duration overloads
 public interface TimeLimiter {

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -256,7 +256,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>

--- a/futures/listenablefuture1/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/futures/listenablefuture1/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -14,6 +14,7 @@
 
 package com.google.common.util.concurrent;
 
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -98,6 +99,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @author Nishant Thakkar
  * @since 1.0
  */
+@DoNotMock("Use the methods in Futures (like immediateFuture) or SettableFuture")
 public interface ListenableFuture<V> extends Future<V> {
   /**
    * Registers a listener to be {@linkplain Executor#execute(Runnable) run} on the given executor.

--- a/guava-testlib/src/com/google/common/testing/GcFinalization.java
+++ b/guava-testlib/src/com/google/common/testing/GcFinalization.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -241,6 +242,7 @@ public final class GcFinalization {
    *   <li>enqueuing weak references to unreachable referents in their reference queue
    * </ul>
    */
+  @DoNotMock("Implement with a lambda")
   public interface FinalizationPredicate {
     boolean isDone();
   }

--- a/guava-testlib/src/com/google/common/testing/TearDownAccepter.java
+++ b/guava-testlib/src/com/google/common/testing/TearDownAccepter.java
@@ -17,6 +17,7 @@
 package com.google.common.testing;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.common.annotations.GwtCompatible;
 
 /**
@@ -26,6 +27,7 @@ import com.google.common.annotations.GwtCompatible;
  * @since 10.0
  */
 @Beta
+@DoNotMock("Implement with a lambda")
 @GwtCompatible
 public interface TearDownAccepter {
   /**

--- a/guava/src/com/google/common/base/CaseFormat.java
+++ b/guava/src/com/google/common/base/CaseFormat.java
@@ -135,7 +135,7 @@ public enum CaseFormat {
     while ((j = wordBoundary.indexIn(s, ++j)) != -1) {
       if (i == 0) {
         // include some extra space for separators
-        out = new StringBuilder(s.length() + 4 * wordSeparator.length());
+        out = new StringBuilder(s.length() + 4 * format.wordSeparator.length());
         out.append(format.normalizeFirstWord(s.substring(i, j)));
       } else {
         out.append(format.normalizeWord(s.substring(i, j)));

--- a/guava/src/com/google/common/base/FinalizableReference.java
+++ b/guava/src/com/google/common/base/FinalizableReference.java
@@ -15,6 +15,7 @@
 package com.google.common.base;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * Implemented by references that have code to run after garbage collection of their referents.
@@ -23,6 +24,7 @@ import com.google.common.annotations.GwtIncompatible;
  * @author Bob Lee
  * @since 2.0
  */
+@DoNotMock("Use an instance of one of the Finalizable*Reference classes")
 @GwtIncompatible
 public interface FinalizableReference {
   /**

--- a/guava/src/com/google/common/base/Optional.java
+++ b/guava/src/com/google/common/base/Optional.java
@@ -15,6 +15,7 @@
 package com.google.common.base;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.errorprone.annotations.DoNotMock;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -79,6 +80,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Kevin Bourrillion
  * @since 10.0
  */
+@DoNotMock("Use Optional.of(value) or Optional.absent()")
 @GwtCompatible(serializable = true)
 public abstract class Optional<T> implements Serializable {
   /**

--- a/guava/src/com/google/common/cache/Cache.java
+++ b/guava/src/com/google/common/cache/Cache.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +37,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Charles Fry
  * @since 10.0
  */
+@DoNotMock("Use CacheBuilder.newBuilder().build()")
 @GwtCompatible
 public interface Cache<K, V> {
 

--- a/guava/src/com/google/common/collect/ClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ClassToInstanceMap.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -40,6 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use ImmutableClassToInstanceMap or MutableClassToInstanceMap")
 @GwtCompatible
 public interface ClassToInstanceMap<B> extends Map<Class<? extends B>, B> {
   /**

--- a/guava/src/com/google/common/collect/ImmutableCollection.java
+++ b/guava/src/com/google/common/collect/ImmutableCollection.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.Collection;
@@ -157,6 +158,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @since 2.0
  */
+@DoNotMock("Use ImmutableList.of or another implementation")
 @GwtCompatible(emulated = true)
 @SuppressWarnings("serial") // we're overriding default serialization
 // TODO(kevinb): I think we should push everything down to "BaseImmutableCollection" or something,
@@ -372,6 +374,7 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
    *
    * @since 10.0
    */
+  @DoNotMock
   public abstract static class Builder<E> {
     static final int DEFAULT_INITIAL_CAPACITY = 4;
 

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.RetainedWith;
 import com.google.j2objc.annotations.WeakOuter;
@@ -60,6 +61,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use ImmutableMap.of or another implementation")
 @GwtCompatible(serializable = true, emulated = true)
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
@@ -244,6 +246,7 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    *
    * @since 2.0
    */
+  @DoNotMock
   public static class Builder<K, V> {
     @MonotonicNonNull Comparator<? super V> valueComparator;
     Entry<K, V>[] entries;

--- a/guava/src/com/google/common/collect/ImmutableMultimap.java
+++ b/guava/src/com/google/common/collect/ImmutableMultimap.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.j2objc.annotations.Weak;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.Serializable;
@@ -138,6 +139,7 @@ public abstract class ImmutableMultimap<K, V> extends BaseImmutableMultimap<K, V
    *
    * @since 2.0
    */
+  @DoNotMock
   public static class Builder<K, V> {
     Map<K, Collection<V>> builderMap;
     @MonotonicNonNull Comparator<? super K> keyComparator;

--- a/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.SortedLists.KeyAbsentBehavior;
 import com.google.common.collect.SortedLists.KeyPresentBehavior;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
    *
    * @since 14.0
    */
+  @DoNotMock
   public static final class Builder<K extends Comparable<?>, V> {
     private final List<Entry<Range<K>, V>> entries;
 

--- a/guava/src/com/google/common/collect/ImmutableTable.java
+++ b/guava/src/com/google/common/collect/ImmutableTable.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Tables.AbstractCell;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -263,6 +264,7 @@ public abstract class ImmutableTable<R, C, V> extends AbstractTable<R, C, V>
    *
    * @since 11.0
    */
+  @DoNotMock
   public static final class Builder<R, C, V> {
     private final List<Cell<R, C, V>> cells = Lists.newArrayList();
     @MonotonicNonNull private Comparator<? super R> rowComparator;

--- a/guava/src/com/google/common/collect/Interner.java
+++ b/guava/src/com/google/common/collect/Interner.java
@@ -19,6 +19,7 @@ package com.google.common.collect;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * Provides equivalent behavior to {@link String#intern} for other immutable types. Common
@@ -28,6 +29,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
  * @since 3.0
  */
 @Beta
+@DoNotMock("Use Interners.new*Interner")
 @GwtIncompatible
 public interface Interner<E> {
   /**

--- a/guava/src/com/google/common/collect/MapDifference.java
+++ b/guava/src/com/google/common/collect/MapDifference.java
@@ -17,6 +17,7 @@
 package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -26,6 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Kevin Bourrillion
  * @since 2.0
  */
+@DoNotMock("Use Maps.difference")
 @GwtCompatible
 public interface MapDifference<K, V> {
   /**
@@ -84,6 +86,7 @@ public interface MapDifference<K, V> {
    *
    * @since 2.0
    */
+  @DoNotMock("Use Maps.difference")
   interface ValueDifference<V> {
     /** Returns the value from the left map (possibly null). */
     V leftValue();

--- a/guava/src/com/google/common/collect/Multimap.java
+++ b/guava/src/com/google/common/collect/Multimap.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +159,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Jared Levy
  * @since 2.0
  */
+@DoNotMock("Use ImmutableMultimap, HashMultimap, or another implementation")
 @GwtCompatible
 public interface Multimap<K, V> {
   // Query Operations

--- a/guava/src/com/google/common/collect/PeekingIterator.java
+++ b/guava/src/com/google/common/collect/PeekingIterator.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -31,6 +32,7 @@ import java.util.NoSuchElementException;
  * @author Mick Killianey
  * @since 2.0
  */
+@DoNotMock("Use Iterators.peekingIterator")
 @GwtCompatible
 public interface PeekingIterator<E> extends Iterator<E> {
   /**

--- a/guava/src/com/google/common/collect/RangeMap.java
+++ b/guava/src/com/google/common/collect/RangeMap.java
@@ -18,6 +18,7 @@ package com.google.common.collect;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -36,6 +37,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 14.0
  */
 @Beta
+@DoNotMock("Use ImmutableRangeMap or TreeRangeMap")
 @GwtIncompatible
 public interface RangeMap<K extends Comparable, V> {
   /**

--- a/guava/src/com/google/common/collect/RangeSet.java
+++ b/guava/src/com/google/common/collect/RangeSet.java
@@ -15,6 +15,7 @@
 package com.google.common.collect;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.common.annotations.GwtIncompatible;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -49,6 +50,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 14.0
  */
 @Beta
+@DoNotMock("Use ImmutableRangeSet or TreeRangeSet")
 @GwtIncompatible
 public interface RangeSet<C extends Comparable> {
   // TODO(lowasser): consider adding default implementations of some of these methods

--- a/guava/src/com/google/common/collect/Table.java
+++ b/guava/src/com/google/common/collect/Table.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Objects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CompatibleWith;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +53,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <V> the type of the mapped values
  * @since 7.0
  */
+@DoNotMock("Use ImmutableTable, HashBasedTable, or another implementation")
 @GwtCompatible
 public interface Table<R, C, V> {
   // TODO(jlevy): Consider adding methods similar to ConcurrentMap methods.

--- a/guava/src/com/google/common/escape/Escaper.java
+++ b/guava/src/com/google/common/escape/Escaper.java
@@ -16,6 +16,7 @@ package com.google.common.escape;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Function;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * An object that converts literal text into a format safe for inclusion in a particular context
@@ -53,6 +54,7 @@ import com.google.common.base.Function;
  * @author David Beaumont
  * @since 15.0
  */
+@DoNotMock("Use Escapers.nullEscaper() or another methods from the *Escapers classes")
 @GwtCompatible
 public abstract class Escaper {
   // TODO(dbeaumont): evaluate custom implementations, considering package private constructor.

--- a/guava/src/com/google/common/graph/Graph.java
+++ b/guava/src/com/google/common/graph/Graph.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -101,6 +102,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 20.0
  */
 @Beta
+@DoNotMock("Use GraphBuilder to create a real instance")
 public interface Graph<N> extends BaseGraph<N> {
   //
   // Graph-level accessors

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -22,6 +22,7 @@ import static com.google.common.graph.Graphs.checkNonNegative;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A builder for constructing instances of {@link MutableGraph} or {@link ImmutableGraph} with
@@ -62,6 +63,7 @@ import com.google.common.base.Optional;
  * @since 20.0
  */
 @Beta
+@DoNotMock
 public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
 
   /** Creates a new instance with the specified edge directionality. */

--- a/guava/src/com/google/common/graph/Network.java
+++ b/guava/src/com/google/common/graph/Network.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Optional;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -102,6 +103,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 20.0
  */
 @Beta
+@DoNotMock("Use NetworkBuilder to create a real instance")
 public interface Network<N, E> extends SuccessorsFunction<N>, PredecessorsFunction<N> {
   //
   // Network-level accessors

--- a/guava/src/com/google/common/graph/PredecessorsFunction.java
+++ b/guava/src/com/google/common/graph/PredecessorsFunction.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A functional interface for <a
@@ -78,6 +79,7 @@ import com.google.common.annotations.Beta;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Implement with a lambda, or use GraphBuilder to build a Graph with the desired edges")
 public interface PredecessorsFunction<N> {
 
   /**

--- a/guava/src/com/google/common/graph/SuccessorsFunction.java
+++ b/guava/src/com/google/common/graph/SuccessorsFunction.java
@@ -17,6 +17,7 @@
 package com.google.common.graph;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 
 /**
  * A functional interface for <a
@@ -78,6 +79,7 @@ import com.google.common.annotations.Beta;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Implement with a lambda, or use GraphBuilder to build a Graph with the desired edges")
 public interface SuccessorsFunction<N> {
 
   /**

--- a/guava/src/com/google/common/hash/Funnel.java
+++ b/guava/src/com/google/common/hash/Funnel.java
@@ -15,6 +15,7 @@
 package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.Serializable;
 
 /**
@@ -41,6 +42,7 @@ import java.io.Serializable;
  * @since 11.0
  */
 @Beta
+@DoNotMock("Implement with a lambda")
 public interface Funnel<T> extends Serializable {
 
   /**

--- a/guava/src/com/google/common/hash/HashFunction.java
+++ b/guava/src/com/google/common/hash/HashFunction.java
@@ -16,6 +16,7 @@ package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
 import com.google.common.primitives.Ints;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -116,6 +117,7 @@ import java.nio.charset.Charset;
  * @since 11.0
  */
 @Beta
+@DoNotMock("Use a real instance from Hashing")
 @Immutable
 public interface HashFunction {
   /**

--- a/guava/src/com/google/common/io/ByteProcessor.java
+++ b/guava/src/com/google/common/io/ByteProcessor.java
@@ -17,6 +17,7 @@ package com.google.common.io;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.io.IOException;
 
 /**
@@ -29,6 +30,7 @@ import java.io.IOException;
  * @since 1.0
  */
 @Beta
+@DoNotMock("Implement it normally")
 @GwtIncompatible
 public interface ByteProcessor<T> {
   /**

--- a/guava/src/com/google/common/reflect/TypeToInstanceMap.java
+++ b/guava/src/com/google/common/reflect/TypeToInstanceMap.java
@@ -16,6 +16,7 @@ package com.google.common.reflect;
 
 import com.google.common.annotations.Beta;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -39,6 +40,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 13.0
  */
 @Beta
+@DoNotMock("Use ImmutableTypeToInstanceMap or MutableTypeToInstanceMap")
 public interface TypeToInstanceMap<B> extends Map<TypeToken<? extends B>, B> {
 
   /**

--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -71,6 +72,7 @@ import java.util.concurrent.TimeoutException;
  * @since 23.0
  */
 @Beta
+@DoNotMock("Use FluentFuture.from(Futures.immediate*Future) or SettableFuture")
 @GwtCompatible(emulated = true)
 public abstract class FluentFuture<V> extends GwtFluentFutureCatchingSpecialization<V> {
 

--- a/guava/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -14,6 +14,7 @@
 
 package com.google.common.util.concurrent;
 
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -98,6 +99,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @author Nishant Thakkar
  * @since 1.0
  */
+@DoNotMock("Use the methods in Futures (like immediateFuture) or SettableFuture")
 public interface ListenableFuture<V> extends Future<V> {
   /**
    * Registers a listener to be {@linkplain Executor#execute(Runnable) run} on the given executor.

--- a/guava/src/com/google/common/util/concurrent/ListeningExecutorService.java
+++ b/guava/src/com/google/common/util/concurrent/ListeningExecutorService.java
@@ -15,6 +15,7 @@
 package com.google.common.util.concurrent;
 
 import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -31,6 +32,9 @@ import java.util.concurrent.TimeUnit;
  * @author Chris Povirk
  * @since 10.0
  */
+@DoNotMock(
+    "Use TestingExecutors.sameThreadScheduledExecutor, or wrap a real Executor from "
+        + "java.util.concurrent.Executors with MoreExecutors.listeningDecorator")
 @GwtIncompatible
 public interface ListeningExecutorService extends ExecutorService {
   /**

--- a/guava/src/com/google/common/util/concurrent/Service.java
+++ b/guava/src/com/google/common/util/concurrent/Service.java
@@ -17,6 +17,7 @@ package com.google.common.util.concurrent;
 import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 
 import com.google.common.annotations.Beta;
+import com.google.errorprone.annotations.DoNotMock;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.time.Duration;
@@ -55,6 +56,7 @@ import java.util.concurrent.TimeoutException;
  * @since 9.0 (in 1.0 as {@code com.google.common.base.Service})
  */
 @Beta
+@DoNotMock("Create an AbstractIdleService")
 @GwtIncompatible
 public interface Service {
   /**

--- a/guava/src/com/google/common/util/concurrent/TimeLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/TimeLimiter.java
@@ -19,6 +19,7 @@ import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotMock;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeoutException;
  * @since 1.0
  */
 @Beta
+@DoNotMock("Use FakeTimeLimiter")
 @GwtIncompatible
 public interface TimeLimiter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add @DoNotMock to several com.google.common types

Relnotes:
  - Add @DoNotMock to several com.google.common types.

dbd97473cab26185e48620b7916159915621bb14

-------

<p> Add @DoNotMock to ListenableFuture

Remove @DoNotMock from AbstractFuture, as it is now covered by @DoNotMock on ListenableFuture

RELNOTES=N/A

ad9d3eae25e3f7a8bb07a0b00105ec4426beab88

-------

<p> Fix small error with how CaseFormat calculates the StringBuilder size when converting one format to another.

Fixes https://github.com/google/guava/pull/3730

0dc680192f18b7664f900304576736c1914d14ba