### PR TITLE
MOE Sync 2019-12-16

### DIFF
--- a/android/guava/src/com/google/common/hash/HashFunction.java
+++ b/android/guava/src/com/google/common/hash/HashFunction.java
@@ -16,7 +16,6 @@ package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
 import com.google.common.primitives.Ints;
-import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -117,7 +116,6 @@ import java.nio.charset.Charset;
  * @since 11.0
  */
 @Beta
-@DoNotMock("Use a real instance from Hashing")
 @Immutable
 public interface HashFunction {
   /**

--- a/guava/src/com/google/common/hash/HashFunction.java
+++ b/guava/src/com/google/common/hash/HashFunction.java
@@ -16,7 +16,6 @@ package com.google.common.hash;
 
 import com.google.common.annotations.Beta;
 import com.google.common.primitives.Ints;
-import com.google.errorprone.annotations.DoNotMock;
 import com.google.errorprone.annotations.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -117,7 +116,6 @@ import java.nio.charset.Charset;
  * @since 11.0
  */
 @Beta
-@DoNotMock("Use a real instance from Hashing")
 @Immutable
 public interface HashFunction {
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove @DoNotMock from HashFunction.

Users need some kind of way to, e.g., easily produce collisions in cases in which collisions should be rare.
Maybe we can provide a better way to do this, but for now, let's at least not forbid using mocking frameworks.

c9ae0d314031ac9521d57aab8743ddba0c5f4717