### PR TITLE
MOE Sync 2019-12-18

### DIFF
--- a/android/guava/src/com/google/common/io/FileBackedOutputStream.java
+++ b/android/guava/src/com/google/common/io/FileBackedOutputStream.java
@@ -17,6 +17,7 @@ package com.google.common.io;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -31,6 +32,17 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * An {@link OutputStream} that starts buffering to a byte array, but switches to file buffering
  * once the data reaches a configurable size.
  *
+ * <p>Temporary files created by this stream may live in the local filesystem until either:
+ *
+ * <ul>
+ *   <li>{@link #reset} is called (removing the data in this stream and deleting the file), or...
+ *   <li>this stream (or, more precisely, its {@link #asByteSource} view) is finalized during
+ *       garbage collection, <strong>AND</strong> this stream was not constructed with {@linkplain
+ *       #FileBackedOutputStream(int) the 1-arg constructor} or the {@linkplain
+ *       #FileBackedOutputStream(int, boolean) 2-arg constructor} passing {@code false} in the
+ *       second parameter.
+ * </ul>
+ *
  * <p>This class is thread-safe.
  *
  * @author Chris Nokleberg
@@ -39,14 +51,20 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 @Beta
 @GwtIncompatible
 public final class FileBackedOutputStream extends OutputStream {
-
   private final int fileThreshold;
   private final boolean resetOnFinalize;
   private final ByteSource source;
+  @NullableDecl private final File parentDirectory;
 
+  @GuardedBy("this")
   private OutputStream out;
+
+  @GuardedBy("this")
   private MemoryOutput memory;
-  @NullableDecl private File file;
+
+  @GuardedBy("this")
+  @NullableDecl
+  private File file;
 
   /** ByteArrayOutputStream that exposes its internals. */
   private static class MemoryOutput extends ByteArrayOutputStream {
@@ -81,11 +99,17 @@ public final class FileBackedOutputStream extends OutputStream {
    *
    * @param fileThreshold the number of bytes before the stream should switch to buffering to a file
    * @param resetOnFinalize if true, the {@link #reset} method will be called when the {@link
-   *     ByteSource} returned by {@link #asByteSource} is finalized
+   *     ByteSource} returned by {@link #asByteSource} is finalized.
    */
   public FileBackedOutputStream(int fileThreshold, boolean resetOnFinalize) {
+    this(fileThreshold, resetOnFinalize, null);
+  }
+
+  private FileBackedOutputStream(
+      int fileThreshold, boolean resetOnFinalize, @NullableDecl File parentDirectory) {
     this.fileThreshold = fileThreshold;
     this.resetOnFinalize = resetOnFinalize;
+    this.parentDirectory = parentDirectory;
     memory = new MemoryOutput();
     out = memory;
 
@@ -191,9 +215,10 @@ public final class FileBackedOutputStream extends OutputStream {
    * Checks if writing {@code len} bytes would go over threshold, and switches to file buffering if
    * so.
    */
+  @GuardedBy("this")
   private void update(int len) throws IOException {
     if (file == null && (memory.getCount() + len > fileThreshold)) {
-      File temp = File.createTempFile("FileBackedOutputStream", null);
+      File temp = File.createTempFile("FileBackedOutputStream", null, parentDirectory);
       if (resetOnFinalize) {
         // Finalizers are not guaranteed to be called on system shutdown;
         // this is insurance.

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/ListenableFuture.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/ListenableFuture.java
@@ -37,8 +37,8 @@ public interface ListenableFuture<V> extends Future<V>, Thenable<V> {
   @JsMethod
   @Override
   default <R> IThenable<R> then(
-      IThenable.ThenOnFulfilledCallbackFn<? super V, ? extends R> onFulfilled,
-      @JsOptional IThenable.ThenOnRejectedCallbackFn<? extends R> onRejected) {
+      @JsOptional ThenOnFulfilledCallbackFn<? super V, ? extends R> onFulfilled,
+      @JsOptional ThenOnRejectedCallbackFn<? extends R> onRejected) {
     return new Promise<V>(
             (resolve, reject) -> {
               Futures.addCallback(
@@ -56,7 +56,9 @@ public interface ListenableFuture<V> extends Future<V>, Thenable<V> {
                   },
                   MoreExecutors.directExecutor());
             })
-        .then(onFulfilled, onRejected);
+        .then(
+            (IThenable.ThenOnFulfilledCallbackFn) onFulfilled,
+            (IThenable.ThenOnRejectedCallbackFn) onRejected);
   }
 
   // TODO(b/141673833): If this would work, it would allow us to implement IThenable properly:

--- a/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/Thenable.java
+++ b/guava-gwt/src-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/Thenable.java
@@ -17,6 +17,7 @@
 package com.google.common.util.concurrent;
 
 import elemental2.promise.IThenable;
+import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
@@ -25,9 +26,19 @@ import jsinterop.annotations.JsType;
  * Subset of the elemental2 IThenable interface without the single-parameter overload, which allows
  * us to implement it using a default implementation in J2cl ListenableFuture.
  */
-@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "IThenable")
 interface Thenable<T> {
   <V> IThenable<V> then(
-      IThenable.ThenOnFulfilledCallbackFn<? super T, ? extends V> onFulfilled,
-      @JsOptional IThenable.ThenOnRejectedCallbackFn<? extends V> onRejected);
+      @JsOptional ThenOnFulfilledCallbackFn<? super T, ? extends V> onFulfilled,
+      @JsOptional ThenOnRejectedCallbackFn<? extends V> onRejected);
+
+  @JsFunction
+  interface ThenOnFulfilledCallbackFn<T, V> {
+    V onInvoke(T p0);
+  }
+
+  @JsFunction
+  interface ThenOnRejectedCallbackFn<V> {
+    V onInvoke(Object p0);
+  }
 }

--- a/guava/src/com/google/common/io/FileBackedOutputStream.java
+++ b/guava/src/com/google/common/io/FileBackedOutputStream.java
@@ -17,6 +17,7 @@ package com.google.common.io;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -31,6 +32,17 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * An {@link OutputStream} that starts buffering to a byte array, but switches to file buffering
  * once the data reaches a configurable size.
  *
+ * <p>Temporary files created by this stream may live in the local filesystem until either:
+ *
+ * <ul>
+ *   <li>{@link #reset} is called (removing the data in this stream and deleting the file), or...
+ *   <li>this stream (or, more precisely, its {@link #asByteSource} view) is finalized during
+ *       garbage collection, <strong>AND</strong> this stream was not constructed with {@linkplain
+ *       #FileBackedOutputStream(int) the 1-arg constructor} or the {@linkplain
+ *       #FileBackedOutputStream(int, boolean) 2-arg constructor} passing {@code false} in the
+ *       second parameter.
+ * </ul>
+ *
  * <p>This class is thread-safe.
  *
  * @author Chris Nokleberg
@@ -39,14 +51,20 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @Beta
 @GwtIncompatible
 public final class FileBackedOutputStream extends OutputStream {
-
   private final int fileThreshold;
   private final boolean resetOnFinalize;
   private final ByteSource source;
+  @Nullable private final File parentDirectory;
 
+  @GuardedBy("this")
   private OutputStream out;
+
+  @GuardedBy("this")
   private MemoryOutput memory;
-  private @Nullable File file;
+
+  @GuardedBy("this")
+  @Nullable
+  private File file;
 
   /** ByteArrayOutputStream that exposes its internals. */
   private static class MemoryOutput extends ByteArrayOutputStream {
@@ -81,11 +99,17 @@ public final class FileBackedOutputStream extends OutputStream {
    *
    * @param fileThreshold the number of bytes before the stream should switch to buffering to a file
    * @param resetOnFinalize if true, the {@link #reset} method will be called when the {@link
-   *     ByteSource} returned by {@link #asByteSource} is finalized
+   *     ByteSource} returned by {@link #asByteSource} is finalized.
    */
   public FileBackedOutputStream(int fileThreshold, boolean resetOnFinalize) {
+    this(fileThreshold, resetOnFinalize, null);
+  }
+
+  private FileBackedOutputStream(
+      int fileThreshold, boolean resetOnFinalize, @Nullable File parentDirectory) {
     this.fileThreshold = fileThreshold;
     this.resetOnFinalize = resetOnFinalize;
+    this.parentDirectory = parentDirectory;
     memory = new MemoryOutput();
     out = memory;
 
@@ -191,9 +215,10 @@ public final class FileBackedOutputStream extends OutputStream {
    * Checks if writing {@code len} bytes would go over threshold, and switches to file buffering if
    * so.
    */
+  @GuardedBy("this")
   private void update(int len) throws IOException {
     if (file == null && (memory.getCount() + len > fileThreshold)) {
-      File temp = File.createTempFile("FileBackedOutputStream", null);
+      File temp = File.createTempFile("FileBackedOutputStream", null, parentDirectory);
       if (resetOnFinalize) {
         // Finalizers are not guaranteed to be called on system shutdown;
         // this is insurance.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Actually map Thenable helper interface to JS IThenable. The name is different to avoid a clash with elemental2 IThenable.

8207e996f569381719eff09ee836509136734cc0

-------

<p> Use Error Prone's @GuardedBy enforcement to make sure that mutable state is appropriately synchronized.

f6d239520285c399978597c4a6665bf41fe8395d