### PR TITLE
MOE Sync 2019-12-23

### DIFF
--- a/android/guava-tests/benchmark/com/google/common/cache/ChainBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/cache/ChainBenchmark.java
@@ -35,6 +35,7 @@ public class ChainBenchmark {
   private ReferenceEntry<Object, Object> head;
   private ReferenceEntry<Object, Object> chain;
 
+  @SuppressWarnings("GuardedBy")
   @BeforeExperiment
   void setUp() {
     LocalCache<Object, Object> cache =
@@ -43,6 +44,8 @@ public class ChainBenchmark {
     chain = null;
     for (int i = 0; i < length; i++) {
       Object key = new Object();
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       chain = segment.newEntry(key, cache.hash(key), chain);
       if (i == 0) {
         head = chain;
@@ -50,10 +53,13 @@ public class ChainBenchmark {
     }
   }
 
+  @SuppressWarnings("GuardedBy")
   @Benchmark
   int time(int reps) {
     int dummy = 0;
     for (int i = 0; i < reps; i++) {
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       segment.removeEntryFromChain(chain, head);
       dummy += segment.count;
     }

--- a/android/guava-tests/benchmark/com/google/common/cache/SegmentBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/cache/SegmentBenchmark.java
@@ -50,11 +50,14 @@ public class SegmentBenchmark {
     checkState(segment.table.length() == capacity);
   }
 
+  @SuppressWarnings("GuardedBy")
   @Benchmark
   int time(int reps) {
     int dummy = 0;
     AtomicReferenceArray<ReferenceEntry<Object, Object>> oldTable = segment.table;
     for (int i = 0; i < reps; i++) {
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       segment.expand();
       segment.table = oldTable;
       dummy += segment.count;

--- a/android/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
@@ -575,4 +575,7 @@ public class ImmutableBiMapTest extends TestCase {
       assertEquals(alternatingKeysAndValues[i++], entry.getValue());
     }
   }
+
+  /** No-op test so that the class has at least one method, making Maven's test runner happy. */
+  public void testNoop() {}
 }

--- a/android/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
@@ -604,6 +604,7 @@ public class MapMakerInternalMapTest extends TestCase {
     assertNull(segment.get(key, hash));
   }
 
+  @SuppressWarnings("GuardedBy")
   public void testExpand() {
     MapMakerInternalMap<Object, Object, ?, ?> map =
         makeMap(createMapMaker().concurrencyLevel(1).initialCapacity(1));
@@ -629,6 +630,8 @@ public class MapMakerInternalMapTest extends TestCase {
 
     for (int i = 1; i <= originalCount * 2; i *= 2) {
       if (i > 1) {
+        // TODO(b/145386688): This access should be guarded by 'segment', which is not currently
+        // held
         segment.expand();
       }
       assertEquals(i, segment.table.length());
@@ -687,6 +690,7 @@ public class MapMakerInternalMapTest extends TestCase {
     assertNull(newFirst.getNext());
   }
 
+  @SuppressWarnings("GuardedBy")
   public void testExpand_cleanup() {
     MapMakerInternalMap<Object, Object, ?, ?> map =
         makeMap(createMapMaker().concurrencyLevel(1).initialCapacity(1));
@@ -719,6 +723,8 @@ public class MapMakerInternalMapTest extends TestCase {
 
     for (int i = 1; i <= originalCount * 2; i *= 2) {
       if (i > 1) {
+        // TODO(b/145386688): This access should be guarded by 'segment', which is not currently
+        // held
         segment.expand();
       }
       assertEquals(i, segment.table.length());

--- a/android/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactHashMap.java
@@ -111,7 +111,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   static final double HASH_FLOODING_FPP = 0.001;
 
   /**
-   * Maximum allowed length of a hash table bucket before falling back to a j.u.HashMap based
+   * Maximum allowed length of a hash table bucket before falling back to a j.u.LinkedHashMap-based
    * implementation. Experimentally determined.
    */
   private static final int MAX_HASH_BUCKET_LENGTH = 9;

--- a/android/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactHashMap.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.IOException;
@@ -38,6 +39,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
@@ -100,14 +103,39 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   private static final Object NOT_FOUND = new Object();
 
   /**
-   * The hashtable. Its values are indexes to the keys, values, and entries arrays.
-   *
-   * <p>Currently, the UNSET value means "null pointer", and any positive value x is the actual
-   * index + 1.
-   *
-   * <p>Its size must be a power of two.
+   * Maximum allowed false positive probability of detecting a hash flooding attack given random
+   * input.
    */
-  @MonotonicNonNullDecl private transient Object table;
+  @VisibleForTesting(
+      )
+  static final double HASH_FLOODING_FPP = 0.001;
+
+  /**
+   * Maximum allowed length of a hash table bucket before falling back to a j.u.HashMap based
+   * implementation. Experimentally determined.
+   */
+  private static final int MAX_HASH_BUCKET_LENGTH = 9;
+
+  /**
+   * The hashtable object. This can be either:
+   *
+   * <ul>
+   *   <li>a byte[], short[], or int[], with size a power of two, created by
+   *       CompactHashing.createTable, whose values are either
+   *       <ul>
+   *         <li>UNSET, meaning "null pointer"
+   *         <li>one plus an index into the keys, values, and entries arrays
+   *       </ul>
+   *   <li>another java.util.Map delegate implementation. In most modern JDKs, normal java.util hash
+   *       collections intelligently fall back to a binary search tree if hash table collisions are
+   *       detected. Rather than going to all the trouble of reimplementing this ourselves, we
+   *       simply switch over to use the JDK implementation wholesale if probable hash flooding is
+   *       detected, sacrificing the compactness guarantee in very rare cases in exchange for much
+   *       more reliable worst-case behavior.
+   *   <li>null, if no entries have yet been added to the map
+   * </ul>
+   */
+  @NullableDecl private transient Object table;
 
   /**
    * Contains the logical entries, in the range of [0, size()). The high bits of each int are the
@@ -124,19 +152,19 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    *
    * <p>The pointers in [size(), entries.length) are all "null" (UNSET).
    */
-  @VisibleForTesting @MonotonicNonNullDecl transient int[] entries;
+  @VisibleForTesting @NullableDecl transient int[] entries;
 
   /**
    * The keys of the entries in the map, in the range of [0, size()). The keys in [size(),
    * keys.length) are all {@code null}.
    */
-  @VisibleForTesting @MonotonicNonNullDecl transient Object[] keys;
+  @VisibleForTesting @NullableDecl transient Object[] keys;
 
   /**
    * The values of the entries in the map, in the range of [0, size()). The values in [size(),
    * values.length) are all {@code null}.
    */
-  @VisibleForTesting @MonotonicNonNullDecl transient Object[] values;
+  @VisibleForTesting @NullableDecl transient Object[] values;
 
   /**
    * Keeps track of metadata like the number of hash table bits and modifications of this data
@@ -194,6 +222,36 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     return expectedSize;
   }
 
+  @SuppressWarnings("unchecked")
+  @VisibleForTesting
+  @NullableDecl
+  Map<K, V> delegateOrNull() {
+    if (table instanceof Map) {
+      return (Map<K, V>) table;
+    }
+    return null;
+  }
+
+  Map<K, V> createHashFloodingResistantDelegate(int tableSize) {
+    return new LinkedHashMap<>(tableSize, 1.0f);
+  }
+
+  @SuppressWarnings("unchecked")
+  @VisibleForTesting
+  @CanIgnoreReturnValue
+  Map<K, V> convertToHashFloodingResistantImplementation() {
+    Map<K, V> newDelegate = createHashFloodingResistantDelegate(hashTableMask() + 1);
+    for (int i = firstEntryIndex(); i >= 0; i = getSuccessor(i)) {
+      newDelegate.put((K) keys[i], (V) values[i]);
+    }
+    this.table = newDelegate;
+    this.entries = null;
+    this.keys = null;
+    this.values = null;
+    incrementModCount();
+    return newDelegate;
+  }
+
   /** Stores the hash table mask as the number of bits needed to represent an index. */
   private void setHashTableMask(int mask) {
     int hashTableBits = Integer.SIZE - Integer.numberOfLeadingZeros(mask);
@@ -225,6 +283,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     if (needsAllocArrays()) {
       allocArrays();
     }
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.put(key, value);
+    }
     int[] entries = this.entries;
     Object[] keys = this.keys;
     Object[] values = this.values;
@@ -246,6 +308,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
       int entryIndex;
       int entry;
       int hashPrefix = CompactHashing.getHashPrefix(hash, mask);
+      int bucketLength = 0;
       do {
         entryIndex = next - 1;
         entry = entries[entryIndex];
@@ -260,7 +323,13 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
           return oldValue;
         }
         next = CompactHashing.getNext(entry, mask);
+        bucketLength++;
       } while (next != UNSET);
+
+      if (bucketLength >= MAX_HASH_BUCKET_LENGTH) {
+        return convertToHashFloodingResistantImplementation().put(key, value);
+      }
+
       if (newSize > mask) {
         // Resize and add new entry
         mask = resizeTable(mask, CompactHashing.newCapacity(mask), hash, newEntryIndex);
@@ -369,12 +438,17 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
   @Override
   public boolean containsKey(@NullableDecl Object key) {
-    return indexOf(key) != -1;
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    return (delegate != null) ? delegate.containsKey(key) : indexOf(key) != -1;
   }
 
   @SuppressWarnings("unchecked") // known to be a V
   @Override
   public V get(@NullableDecl Object key) {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.get(key);
+    }
     int index = indexOf(key);
     if (index == -1) {
       return null;
@@ -388,6 +462,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   @Override
   @NullableDecl
   public V remove(@NullableDecl Object key) {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.remove(key);
+    }
     Object oldValue = removeHelper(key);
     return (oldValue == NOT_FOUND) ? null : (V) oldValue;
   }
@@ -534,7 +612,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   class KeySetView extends AbstractSet<K> {
     @Override
     public int size() {
-      return size;
+      return CompactHashMap.this.size();
     }
 
     @Override
@@ -544,7 +622,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
     @Override
     public boolean remove(@NullableDecl Object o) {
-      return CompactHashMap.this.removeHelper(o) != NOT_FOUND;
+      @NullableDecl Map<K, V> delegate = delegateOrNull();
+      return (delegate != null)
+          ? delegate.keySet().remove(o)
+          : CompactHashMap.this.removeHelper(o) != NOT_FOUND;
     }
 
     @Override
@@ -559,6 +640,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   Iterator<K> keySetIterator() {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.keySet().iterator();
+    }
     return new Itr<K>() {
       @SuppressWarnings("unchecked") // known to be a K
       @Override
@@ -584,7 +669,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
     @Override
     public int size() {
-      return size;
+      return CompactHashMap.this.size();
     }
 
     @Override
@@ -599,7 +684,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
     @Override
     public boolean contains(@NullableDecl Object o) {
-      if (o instanceof Entry) {
+      @NullableDecl Map<K, V> delegate = delegateOrNull();
+      if (delegate != null) {
+        return delegate.entrySet().contains(o);
+      } else if (o instanceof Entry) {
         Entry<?, ?> entry = (Entry<?, ?>) o;
         int index = indexOf(entry.getKey());
         return index != -1 && Objects.equal(values[index], entry.getValue());
@@ -609,7 +697,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
     @Override
     public boolean remove(@NullableDecl Object o) {
-      if (o instanceof Entry) {
+      @NullableDecl Map<K, V> delegate = delegateOrNull();
+      if (delegate != null) {
+        return delegate.entrySet().remove(o);
+      } else if (o instanceof Entry) {
         Entry<?, ?> entry = (Entry<?, ?>) o;
         if (needsAllocArrays()) {
           return false;
@@ -633,6 +724,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   Iterator<Entry<K, V>> entrySetIterator() {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.entrySet().iterator();
+    }
     return new Itr<Entry<K, V>>() {
       @Override
       Entry<K, V> getOutput(int entry) {
@@ -670,6 +765,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     @NullableDecl
     @Override
     public V getValue() {
+      @NullableDecl Map<K, V> delegate = delegateOrNull();
+      if (delegate != null) {
+        return delegate.get(key);
+      }
       updateLastKnownIndex();
       return (lastKnownIndex == -1) ? null : (V) values[lastKnownIndex];
     }
@@ -677,6 +776,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
     @SuppressWarnings("unchecked") // known to be a V
     @Override
     public V setValue(V value) {
+      @NullableDecl Map<K, V> delegate = delegateOrNull();
+      if (delegate != null) {
+        return delegate.put(key, value);
+      }
       updateLastKnownIndex();
       if (lastKnownIndex == -1) {
         put(key, value);
@@ -691,16 +794,21 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
 
   @Override
   public int size() {
-    return size;
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    return (delegate != null) ? delegate.size() : size;
   }
 
   @Override
   public boolean isEmpty() {
-    return size == 0;
+    return size() == 0;
   }
 
   @Override
   public boolean containsValue(@NullableDecl Object value) {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.containsValue(value);
+    }
     for (int i = 0; i < size; i++) {
       if (Objects.equal(value, values[i])) {
         return true;
@@ -724,7 +832,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   class ValuesView extends AbstractCollection<V> {
     @Override
     public int size() {
-      return size;
+      return CompactHashMap.this.size();
     }
 
     @Override
@@ -739,6 +847,10 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   }
 
   Iterator<V> valuesIterator() {
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      return delegate.values().iterator();
+    }
     return new Itr<V>() {
       @SuppressWarnings("unchecked") // known to be a V
       @Override
@@ -754,6 +866,13 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
    */
   public void trimToSize() {
     if (needsAllocArrays()) {
+      return;
+    }
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      Map<K, V> newDelegate = createHashFloodingResistantDelegate(size());
+      newDelegate.putAll(delegate);
+      this.table = newDelegate;
       return;
     }
     int size = this.size;
@@ -773,19 +892,29 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
       return;
     }
     incrementModCount();
-    Arrays.fill(keys, 0, size, null);
-    Arrays.fill(values, 0, size, null);
-    CompactHashing.tableClear(table);
-    Arrays.fill(entries, 0, size, 0);
-    this.size = 0;
+    @NullableDecl Map<K, V> delegate = delegateOrNull();
+    if (delegate != null) {
+      metadata =
+          Ints.constrainToRange(size(), CompactHashing.DEFAULT_SIZE, CompactHashing.MAX_SIZE);
+      table = null;
+      size = 0;
+    } else {
+      Arrays.fill(keys, 0, size, null);
+      Arrays.fill(values, 0, size, null);
+      CompactHashing.tableClear(table);
+      Arrays.fill(entries, 0, size, 0);
+      this.size = 0;
+    }
   }
 
   private void writeObject(ObjectOutputStream stream) throws IOException {
     stream.defaultWriteObject();
-    stream.writeInt(size);
-    for (int i = firstEntryIndex(); i >= 0; i = getSuccessor(i)) {
-      stream.writeObject(keys[i]);
-      stream.writeObject(values[i]);
+    stream.writeInt(size());
+    Iterator<Entry<K, V>> entryIterator = entrySetIterator();
+    while (entryIterator.hasNext()) {
+      Entry<K, V> e = entryIterator.next();
+      stream.writeObject(e.getKey());
+      stream.writeObject(e.getValue());
     }
   }
 

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -18,7 +18,10 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.checkerframework.checker.nullness.compatqual.MonotonicNonNullDecl;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -112,6 +115,19 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     return expectedSize;
   }
 
+  @Override
+  Map<K, V> createHashFloodingResistantDelegate(int tableSize) {
+    return new LinkedHashMap<K, V>(tableSize, 1.0f, accessOrder);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  Map<K, V> convertToHashFloodingResistantImplementation() {
+    Map<K, V> result = super.convertToHashFloodingResistantImplementation();
+    links = null;
+    return result;
+  }
+
   private int getPredecessor(int entry) {
     return ((int) (links[entry] >>> 32)) - 1;
   }
@@ -200,7 +216,9 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     }
     this.firstEntry = ENDPOINT;
     this.lastEntry = ENDPOINT;
-    Arrays.fill(links, 0, size(), 0);
+    if (links != null) {
+      Arrays.fill(links, 0, size(), 0);
+    }
     super.clear();
   }
 }

--- a/guava-gwt/test/com/google/common/collect/AbstractHashFloodingTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/AbstractHashFloodingTest_gwt.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.collect;
+public class AbstractHashFloodingTest_gwt extends com.google.gwt.junit.client.GWTTestCase {
+@Override public String getModuleName() {
+  return "com.google.common.collect.testModule";
+}
+}

--- a/guava-gwt/test/com/google/common/collect/ImmutableBiMapTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/ImmutableBiMapTest_gwt.java
@@ -18,6 +18,11 @@ public class ImmutableBiMapTest_gwt extends com.google.gwt.junit.client.GWTTestC
 @Override public String getModuleName() {
   return "com.google.common.collect.testModule";
 }
+public void testNoop() throws Exception {
+  com.google.common.collect.ImmutableBiMapTest testCase = new com.google.common.collect.ImmutableBiMapTest();
+  testCase.testNoop();
+}
+
 public void testDoubleInverse__BiMapSpecificTests() throws Exception {
   com.google.common.collect.ImmutableBiMapTest.BiMapSpecificTests testCase = new com.google.common.collect.ImmutableBiMapTest.BiMapSpecificTests();
   testCase.testDoubleInverse();

--- a/guava-tests/benchmark/com/google/common/cache/ChainBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/cache/ChainBenchmark.java
@@ -35,6 +35,7 @@ public class ChainBenchmark {
   private ReferenceEntry<Object, Object> head;
   private ReferenceEntry<Object, Object> chain;
 
+  @SuppressWarnings("GuardedBy")
   @BeforeExperiment
   void setUp() {
     LocalCache<Object, Object> cache =
@@ -43,6 +44,8 @@ public class ChainBenchmark {
     chain = null;
     for (int i = 0; i < length; i++) {
       Object key = new Object();
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       chain = segment.newEntry(key, cache.hash(key), chain);
       if (i == 0) {
         head = chain;
@@ -50,10 +53,13 @@ public class ChainBenchmark {
     }
   }
 
+  @SuppressWarnings("GuardedBy")
   @Benchmark
   int time(int reps) {
     int dummy = 0;
     for (int i = 0; i < reps; i++) {
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       segment.removeEntryFromChain(chain, head);
       dummy += segment.count;
     }

--- a/guava-tests/benchmark/com/google/common/cache/SegmentBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/cache/SegmentBenchmark.java
@@ -50,11 +50,14 @@ public class SegmentBenchmark {
     checkState(segment.table.length() == capacity);
   }
 
+  @SuppressWarnings("GuardedBy")
   @Benchmark
   int time(int reps) {
     int dummy = 0;
     AtomicReferenceArray<ReferenceEntry<Object, Object>> oldTable = segment.table;
     for (int i = 0; i < reps; i++) {
+      // TODO(b/145386688): This access should be guarded by 'this.segment', which is not currently
+      // held
       segment.expand();
       segment.table = oldTable;
       dummy += segment.count;

--- a/guava-tests/test/com/google/common/collect/AbstractHashFloodingTest.java
+++ b/guava-tests/test/com/google/common/collect/AbstractHashFloodingTest.java
@@ -35,12 +35,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * performance.
  */
 @GwtCompatible
-public class AbstractHashFloodingTest<T> extends TestCase {
+public abstract class AbstractHashFloodingTest<T> extends TestCase {
   private final List<Construction<T>> constructions;
   private final IntToDoubleFunction constructionAsymptotics;
   private final List<QueryOp<T>> queries;
 
-  public AbstractHashFloodingTest(
+  AbstractHashFloodingTest(
       List<Construction<T>> constructions,
       IntToDoubleFunction constructionAsymptotics,
       List<QueryOp<T>> queries) {

--- a/guava-tests/test/com/google/common/collect/AbstractHashFloodingTest.java
+++ b/guava-tests/test/com/google/common/collect/AbstractHashFloodingTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.common.collect;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.IntToDoubleFunction;
+import java.util.function.Supplier;
+import junit.framework.TestCase;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Abstract superclass for tests that hash flooding a collection has controlled worst-case
+ * performance.
+ */
+@GwtCompatible
+public class AbstractHashFloodingTest<T> extends TestCase {
+  private final List<Construction<T>> constructions;
+  private final IntToDoubleFunction constructionAsymptotics;
+  private final List<QueryOp<T>> queries;
+
+  public AbstractHashFloodingTest(
+      List<Construction<T>> constructions,
+      IntToDoubleFunction constructionAsymptotics,
+      List<QueryOp<T>> queries) {
+    this.constructions = constructions;
+    this.constructionAsymptotics = constructionAsymptotics;
+    this.queries = queries;
+  }
+
+  /**
+   * A Comparable wrapper around a String which executes callbacks on calls to hashCode, equals, and
+   * compareTo.
+   */
+  private static class CountsHashCodeAndEquals implements Comparable<CountsHashCodeAndEquals> {
+    private final String delegateString;
+    private final Runnable onHashCode;
+    private final Runnable onEquals;
+    private final Runnable onCompareTo;
+
+    CountsHashCodeAndEquals(
+        String delegateString, Runnable onHashCode, Runnable onEquals, Runnable onCompareTo) {
+      this.delegateString = delegateString;
+      this.onHashCode = onHashCode;
+      this.onEquals = onEquals;
+      this.onCompareTo = onCompareTo;
+    }
+
+    @Override
+    public int hashCode() {
+      onHashCode.run();
+      return delegateString.hashCode();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+      onEquals.run();
+      return other instanceof CountsHashCodeAndEquals
+          && delegateString.equals(((CountsHashCodeAndEquals) other).delegateString);
+    }
+
+    @Override
+    public int compareTo(CountsHashCodeAndEquals o) {
+      onCompareTo.run();
+      return delegateString.compareTo(o.delegateString);
+    }
+  }
+
+  /** A holder of counters for calls to hashCode, equals, and compareTo. */
+  private static final class CallsCounter {
+    long hashCode;
+    long equals;
+    long compareTo;
+
+    long total() {
+      return hashCode + equals + compareTo;
+    }
+
+    void zero() {
+      hashCode = 0;
+      equals = 0;
+      compareTo = 0;
+    }
+  }
+
+  @FunctionalInterface
+  interface Construction<T> {
+    @CanIgnoreReturnValue
+    abstract T create(List<?> keys);
+
+    static Construction<Map<Object, Object>> mapFromKeys(
+        Supplier<Map<Object, Object>> mutableSupplier) {
+      return keys -> {
+        Map<Object, Object> map = mutableSupplier.get();
+        for (Object key : keys) {
+          map.put(key, new Object());
+        }
+        return map;
+      };
+    }
+  }
+
+  abstract static class QueryOp<T> {
+    static <T> QueryOp<T> create(
+        String name, BiConsumer<T, Object> queryLambda, IntToDoubleFunction asymptotic) {
+      return new QueryOp<T>() {
+        @Override
+        void apply(T collection, Object query) {
+          queryLambda.accept(collection, query);
+        }
+
+        @Override
+        double expectedAsymptotic(int n) {
+          return asymptotic.applyAsDouble(n);
+        }
+
+        @Override
+        public String toString() {
+          return name;
+        }
+      };
+    }
+
+    static final QueryOp<Map<Object, Object>> MAP_GET =
+        QueryOp.create("Map.get", Map::get, Math::log);
+
+    abstract void apply(T collection, Object query);
+
+    abstract double expectedAsymptotic(int n);
+  }
+
+  /**
+   * Returns a list of objects with the same hash code, of size 2^power, counting calls to equals,
+   * hashCode, and compareTo in counter.
+   */
+  static List<CountsHashCodeAndEquals> createAdversarialInput(int power, CallsCounter counter) {
+    String str1 = "Aa";
+    String str2 = "BB";
+    assertEquals(str1.hashCode(), str2.hashCode());
+    List<String> haveSameHashes2 = Arrays.asList(str1, str2);
+    List<CountsHashCodeAndEquals> result =
+        Lists.newArrayList(
+            Lists.transform(
+                Lists.cartesianProduct(Collections.nCopies(power, haveSameHashes2)),
+                strs ->
+                    new CountsHashCodeAndEquals(
+                        String.join("", strs),
+                        () -> counter.hashCode++,
+                        () -> counter.equals++,
+                        () -> counter.compareTo++)));
+    assertEquals(
+        result.get(0).delegateString.hashCode(),
+        result.get(result.size() - 1).delegateString.hashCode());
+    return result;
+  }
+
+  @GwtIncompatible
+  public void testResistsHashFloodingInConstruction() {
+    CallsCounter smallCounter = new CallsCounter();
+    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
+    int smallSize = haveSameHashesSmall.size();
+
+    CallsCounter largeCounter = new CallsCounter();
+    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
+    int largeSize = haveSameHashesLarge.size();
+
+    for (Construction<T> pathway : constructions) {
+      smallCounter.zero();
+      pathway.create(haveSameHashesSmall);
+      long smallOps = smallCounter.total();
+
+      largeCounter.zero();
+      pathway.create(haveSameHashesLarge);
+      long largeOps = largeCounter.total();
+
+      double ratio = (double) largeOps / smallOps;
+      assertWithMessage(
+              "ratio of equals/hashCode/compareTo operations to build with %s entries versus %s"
+                  + " entries",
+              largeSize, smallSize)
+          .that(ratio)
+          .isAtMost(
+              2
+                  * constructionAsymptotics.applyAsDouble(largeSize)
+                  / constructionAsymptotics.applyAsDouble(smallSize));
+      // allow up to 2x wobble in the constant factors
+    }
+  }
+
+  @GwtIncompatible
+  public void testResistsHashFloodingOnQuery() {
+    CallsCounter smallCounter = new CallsCounter();
+    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
+    int smallSize = haveSameHashesSmall.size();
+
+    CallsCounter largeCounter = new CallsCounter();
+    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
+    int largeSize = haveSameHashesLarge.size();
+
+    for (QueryOp<T> query : queries) {
+      for (Construction<T> pathway : constructions) {
+        long worstSmallOps = getWorstCaseOps(smallCounter, haveSameHashesSmall, query, pathway);
+        long worstLargeOps = getWorstCaseOps(largeCounter, haveSameHashesLarge, query, pathway);
+
+        double ratio = (double) worstLargeOps / worstSmallOps;
+        assertWithMessage(
+                "ratio of equals/hashCode/compareTo operations to query %s with %s entries versus"
+                    + " %s entries",
+                query, largeSize, smallSize)
+            .that(ratio)
+            .isAtMost(
+                2 * query.expectedAsymptotic(largeSize) / query.expectedAsymptotic(smallSize));
+        // allow up to 2x wobble in the constant factors
+      }
+    }
+  }
+
+  private long getWorstCaseOps(
+      CallsCounter counter,
+      List<CountsHashCodeAndEquals> haveSameHashes,
+      QueryOp<T> query,
+      Construction<T> pathway) {
+    T collection = pathway.create(haveSameHashes);
+    long worstOps = 0;
+    for (Object o : haveSameHashes) {
+      counter.zero();
+      query.apply(collection, o);
+      worstOps = Math.max(worstOps, counter.total());
+    }
+    return worstOps;
+  }
+}

--- a/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactHashMapTest.java
@@ -58,7 +58,30 @@ public class CompactHashMapTest extends TestCase {
                 CollectionFeature.SERIALIZABLE,
                 CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
             .createTestSuite());
+    suite.addTest(
+        MapTestSuiteBuilder.using(
+                new TestStringMapGenerator() {
+                  @Override
+                  protected Map<String, String> create(Entry<String, String>[] entries) {
+                    CompactHashMap<String, String> map = CompactHashMap.create();
+                    map.convertToHashFloodingResistantImplementation();
+                    for (Entry<String, String> entry : entries) {
+                      map.put(entry.getKey(), entry.getValue());
+                    }
+                    return map;
+                  }
+                })
+            .named("CompactHashMap with flooding resistance")
+            .withFeatures(
+                CollectionSize.ANY,
+                MapFeature.GENERAL_PURPOSE,
+                MapFeature.ALLOWS_NULL_KEYS,
+                MapFeature.ALLOWS_NULL_VALUES,
+                CollectionFeature.SERIALIZABLE,
+                CollectionFeature.SUPPORTS_ITERATOR_REMOVE)
+            .createTestSuite());
     suite.addTestSuite(CompactHashMapTest.class);
+    suite.addTestSuite(FloodingTest.class);
     return suite;
   }
 
@@ -114,6 +137,15 @@ public class CompactHashMapTest extends TestCase {
       assertThat(map.entries).hasLength(expectedSize);
       assertThat(map.keys).hasLength(expectedSize);
       assertThat(map.values).hasLength(expectedSize);
+    }
+  }
+
+  public static class FloodingTest extends AbstractHashFloodingTest<Map<Object, Object>> {
+    public FloodingTest() {
+      super(
+          ImmutableList.of(Construction.mapFromKeys(CompactHashMap::create)),
+          n -> n * Math.log(n),
+          ImmutableList.of(QueryOp.MAP_GET));
     }
   }
 }

--- a/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
+++ b/guava-tests/test/com/google/common/collect/CompactLinkedHashMapTest.java
@@ -57,7 +57,31 @@ public class CompactLinkedHashMapTest extends TestCase {
                 CollectionFeature.SERIALIZABLE,
                 CollectionFeature.KNOWN_ORDER)
             .createTestSuite());
+    suite.addTest(
+        MapTestSuiteBuilder.using(
+                new TestStringMapGenerator() {
+                  @Override
+                  protected Map<String, String> create(Entry<String, String>[] entries) {
+                    CompactLinkedHashMap<String, String> map = CompactLinkedHashMap.create();
+                    map.convertToHashFloodingResistantImplementation();
+                    for (Entry<String, String> entry : entries) {
+                      map.put(entry.getKey(), entry.getValue());
+                    }
+                    return map;
+                  }
+                })
+            .named("CompactLinkedHashMap with flooding resistance")
+            .withFeatures(
+                CollectionSize.ANY,
+                CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                MapFeature.GENERAL_PURPOSE,
+                MapFeature.ALLOWS_NULL_KEYS,
+                MapFeature.ALLOWS_NULL_VALUES,
+                CollectionFeature.SERIALIZABLE,
+                CollectionFeature.KNOWN_ORDER)
+            .createTestSuite());
     suite.addTestSuite(CompactLinkedHashMapTest.class);
+    suite.addTestSuite(FloodingTest.class);
     return suite;
   }
 
@@ -174,6 +198,15 @@ public class CompactLinkedHashMapTest extends TestCase {
       assertThat(map.keys).hasLength(expectedSize);
       assertThat(map.values).hasLength(expectedSize);
       assertThat(map.links).hasLength(expectedSize);
+    }
+  }
+
+  public static class FloodingTest extends AbstractHashFloodingTest<Map<Object, Object>> {
+    public FloodingTest() {
+      super(
+          ImmutableList.of(Construction.mapFromKeys(CompactLinkedHashMap::create)),
+          n -> n * Math.log(n),
+          ImmutableList.of(QueryOp.MAP_GET));
     }
   }
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
@@ -18,8 +18,6 @@ package com.google.common.collect;
 
 import static com.google.common.collect.testing.Helpers.mapEntry;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
-import static java.util.stream.Collectors.toList;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -41,6 +39,7 @@ import com.google.common.testing.SerializableTester;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,6 @@ import java.util.stream.Stream;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Tests for {@link ImmutableBiMap}.
@@ -71,6 +69,7 @@ public class ImmutableBiMapTest extends TestCase {
     suite.addTestSuite(InverseMapTests.class);
     suite.addTestSuite(CreationTests.class);
     suite.addTestSuite(BiMapSpecificTests.class);
+    suite.addTestSuite(FloodingTest.class);
 
     suite.addTest(
         BiMapTestSuiteBuilder.using(new ImmutableBiMapGenerator())
@@ -123,6 +122,7 @@ public class ImmutableBiMapTest extends TestCase {
                 MapFeature.ALLOWS_ANY_NULL_QUERIES)
             .suppressing(BiMapInverseTester.getInverseSameAfterSerializingMethods())
             .createTestSuite());
+    suite.addTestSuite(ImmutableBiMapTest.class);
 
     return suite;
   }
@@ -632,300 +632,90 @@ public class ImmutableBiMapTest extends TestCase {
     }
   }
 
-  /**
-   * A Comparable wrapper around a String which executes callbacks on calls to hashCode, equals, and
-   * compareTo.
-   */
-  private static class CountsHashCodeAndEquals implements Comparable<CountsHashCodeAndEquals> {
-    private final String delegateString;
-    private final Runnable onHashCode;
-    private final Runnable onEquals;
-    private final Runnable onCompareTo;
-
-    CountsHashCodeAndEquals(
-        String delegateString, Runnable onHashCode, Runnable onEquals, Runnable onCompareTo) {
-      this.delegateString = delegateString;
-      this.onHashCode = onHashCode;
-      this.onEquals = onEquals;
-      this.onCompareTo = onCompareTo;
+  public static class FloodingTest extends AbstractHashFloodingTest<BiMap<Object, Object>> {
+    public FloodingTest() {
+      super(
+          EnumSet.allOf(ConstructionPathway.class).stream()
+              .flatMap(
+                  path ->
+                      Stream.<Construction<BiMap<Object, Object>>>of(
+                          keys ->
+                              path.create(
+                                  Lists.transform(
+                                      keys, key -> Maps.immutableEntry(key, new Object()))),
+                          keys ->
+                              path.create(
+                                  Lists.transform(
+                                      keys, key -> Maps.immutableEntry(new Object(), key))),
+                          keys ->
+                              path.create(
+                                  Lists.transform(keys, key -> Maps.immutableEntry(key, key)))))
+              .collect(ImmutableList.toImmutableList()),
+          n -> n * Math.log(n),
+          ImmutableList.of(
+              QueryOp.create("BiMap.get", BiMap::get, Math::log),
+              QueryOp.create("BiMap.inverse.get", (bm, o) -> bm.inverse().get(o), Math::log)));
     }
 
-    @Override
-    public int hashCode() {
-      onHashCode.run();
-      return delegateString.hashCode();
-    }
-
-    @Override
-    public boolean equals(@Nullable Object other) {
-      onEquals.run();
-      return other instanceof CountsHashCodeAndEquals
-          && delegateString.equals(((CountsHashCodeAndEquals) other).delegateString);
-    }
-
-    @Override
-    public int compareTo(CountsHashCodeAndEquals o) {
-      onCompareTo.run();
-      return delegateString.compareTo(o.delegateString);
-    }
-  }
-
-  /** A holder of counters for calls to hashCode, equals, and compareTo. */
-  private static final class CallsCounter {
-    long hashCode;
-    long equals;
-    long compareTo;
-
-    long total() {
-      return hashCode + equals + compareTo;
-    }
-
-    void zero() {
-      hashCode = 0;
-      equals = 0;
-      compareTo = 0;
-    }
-  }
-
-  /** All the ways to create an ImmutableBiMap. */
-  enum ConstructionPathway {
-    COPY_OF_MAP {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        Map<Object, Object> sourceMap = new LinkedHashMap<>();
-        for (Entry<?, ?> entry : entries) {
-          if (sourceMap.put(entry.getKey(), entry.getValue()) != null) {
-            throw new UnsupportedOperationException("duplicate key");
+    /** All the ways to create an ImmutableBiMap. */
+    enum ConstructionPathway {
+      COPY_OF_MAP {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          Map<Object, Object> sourceMap = new LinkedHashMap<>();
+          for (Map.Entry<?, ?> entry : entries) {
+            if (sourceMap.put(entry.getKey(), entry.getValue()) != null) {
+              throw new UnsupportedOperationException("duplicate key");
+            }
           }
+          return ImmutableBiMap.copyOf(sourceMap);
         }
-        counter.zero();
-        return ImmutableBiMap.copyOf(sourceMap);
-      }
-    },
-    COPY_OF_ENTRIES {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        return ImmutableBiMap.copyOf(entries);
-      }
-    },
-    BUILDER_PUT_ONE_BY_ONE {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
-        for (Entry<?, ?> entry : entries) {
-          builder.put(entry.getKey(), entry.getValue());
+      },
+      COPY_OF_ENTRIES {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          return ImmutableBiMap.copyOf(entries);
         }
-        return builder.build();
-      }
-    },
-    BUILDER_PUT_ENTRY_ONE_BY_ONE {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
-        for (Entry<?, ?> entry : entries) {
-          builder.put(entry);
-        }
-        return builder.build();
-      }
-    },
-    BUILDER_PUT_ALL_MAP {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        Map<Object, Object> sourceMap = new LinkedHashMap<>();
-        for (Entry<?, ?> entry : entries) {
-          if (sourceMap.put(entry.getKey(), entry.getValue()) != null) {
-            throw new UnsupportedOperationException("duplicate key");
+      },
+      BUILDER_PUT_ONE_BY_ONE {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
+          for (Map.Entry<?, ?> entry : entries) {
+            builder.put(entry.getKey(), entry.getValue());
           }
+          return builder.build();
         }
-        counter.zero();
-        ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
-        builder.putAll(sourceMap);
-        return builder.build();
-      }
-    },
-    BUILDER_PUT_ALL_ENTRIES {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
-        builder.putAll(entries);
-        return builder.build();
-      }
-    },
-    FORCE_JDK {
-      @Override
-      ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter) {
-        ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
-        builder.putAll(entries);
-        return builder.buildJdkBacked();
-      }
-    };
+      },
+      BUILDER_PUT_ALL_MAP {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          Map<Object, Object> sourceMap = new LinkedHashMap<>();
+          for (Map.Entry<?, ?> entry : entries) {
+            if (sourceMap.put(entry.getKey(), entry.getValue()) != null) {
+              throw new UnsupportedOperationException("duplicate key");
+            }
+          }
+          ImmutableBiMap.Builder<Object, Object> builder = ImmutableBiMap.builder();
+          builder.putAll(sourceMap);
+          return builder.build();
+        }
+      },
+      BUILDER_PUT_ALL_ENTRIES {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          return ImmutableBiMap.builder().putAll(entries).build();
+        }
+      },
+      FORCE_JDK {
+        @Override
+        public ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries) {
+          return ImmutableBiMap.builder().putAll(entries).buildJdkBacked();
+        }
+      };
 
-    @CanIgnoreReturnValue
-    abstract ImmutableBiMap<?, ?> create(List<? extends Entry<?, ?>> entries, CallsCounter counter);
-  }
-
-  /**
-   * Returns a list of objects with the same hash code, of size 2^power, counting calls to equals,
-   * hashCode, and compareTo in counter.
-   */
-  static List<CountsHashCodeAndEquals> createAdversarialObjects(int power, CallsCounter counter) {
-    String str1 = "Aa";
-    String str2 = "BB";
-    assertEquals(str1.hashCode(), str2.hashCode());
-    List<String> haveSameHashes2 = Arrays.asList(str1, str2);
-    List<CountsHashCodeAndEquals> result =
-        Lists.newArrayList(
-            Lists.transform(
-                Lists.cartesianProduct(Collections.nCopies(power, haveSameHashes2)),
-                strs ->
-                    new CountsHashCodeAndEquals(
-                        String.join("", strs),
-                        () -> counter.hashCode++,
-                        () -> counter.equals++,
-                        () -> counter.compareTo++)));
-    assertEquals(
-        result.get(0).delegateString.hashCode(),
-        result.get(result.size() - 1).delegateString.hashCode());
-    return result;
-  }
-
-  enum AdversaryType {
-    ADVERSARIAL_KEYS {
-      @Override
-      List<? extends Entry<?, ?>> createAdversarialEntries(int power, CallsCounter counter) {
-        return createAdversarialObjects(power, counter).stream()
-            .map(k -> Maps.immutableEntry(k, new Object()))
-            .collect(toList());
-      }
-    },
-    ADVERSARIAL_VALUES {
-      @Override
-      List<? extends Entry<?, ?>> createAdversarialEntries(int power, CallsCounter counter) {
-        return createAdversarialObjects(power, counter).stream()
-            .map(k -> Maps.immutableEntry(new Object(), k))
-            .collect(toList());
-      }
-    },
-    ADVERSARIAL_KEYS_AND_VALUES {
-      @Override
-      List<? extends Entry<?, ?>> createAdversarialEntries(int power, CallsCounter counter) {
-        List<?> keys = createAdversarialObjects(power, counter);
-        List<?> values = createAdversarialObjects(power, counter);
-        return Streams.zip(keys.stream(), values.stream(), Maps::immutableEntry).collect(toList());
-      }
-    };
-
-    abstract List<? extends Entry<?, ?>> createAdversarialEntries(int power, CallsCounter counter);
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingInConstruction() {
-    for (AdversaryType adversary : AdversaryType.values()) {
-      CallsCounter smallCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> smallEntries =
-          adversary.createAdversarialEntries(10, smallCounter);
-      int smallSize = smallEntries.size();
-
-      CallsCounter largeCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> largeEntries =
-          adversary.createAdversarialEntries(15, largeCounter);
-      int largeSize = largeEntries.size();
-
-      for (ConstructionPathway pathway : ConstructionPathway.values()) {
-        smallCounter.zero();
-        pathway.create(smallEntries, smallCounter);
-        long smallOps = smallCounter.total();
-
-        largeCounter.zero();
-        pathway.create(largeEntries, largeCounter);
-        long largeOps = largeCounter.total();
-
-        double ratio = (double) largeOps / smallOps;
-        assertWithMessage(
-                "ratio of equals/hashCode/compareTo operations to build an ImmutableBiMap with %s"
-                    + " via %s with %s entries versus %s entries",
-                adversary, pathway, largeSize, smallSize)
-            .that(ratio)
-            .isAtMost(2 * (largeSize * Math.log(largeSize)) / (smallSize * Math.log(smallSize)));
-        // allow up to 2x wobble in the constant factors
-      }
+      @CanIgnoreReturnValue
+      public abstract ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries);
     }
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingOnForwardGet() {
-    for (AdversaryType adversary : AdversaryType.values()) {
-      CallsCounter smallCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> smallEntries =
-          adversary.createAdversarialEntries(10, smallCounter);
-      ImmutableBiMap<?, ?> smallMap =
-          ConstructionPathway.COPY_OF_ENTRIES.create(smallEntries, smallCounter);
-      int smallSize = smallEntries.size();
-      long smallOps = worstCaseQueryOperations(smallMap, smallCounter);
-
-      CallsCounter largeCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> largeEntries =
-          adversary.createAdversarialEntries(15, largeCounter);
-      ImmutableBiMap<?, ?> largeMap =
-          ConstructionPathway.COPY_OF_ENTRIES.create(largeEntries, largeCounter);
-      int largeSize = largeEntries.size();
-      long largeOps = worstCaseQueryOperations(largeMap, largeCounter);
-
-      if (smallOps == 0 && largeOps == 0) {
-        continue; // no queries on the CHCAE objects
-      }
-
-      double ratio = (double) largeOps / smallOps;
-      assertWithMessage(
-              "Ratio of worst case get operations for an ImmutableBiMap with %s of size "
-                  + "%s versus %s",
-              adversary, largeSize, smallSize)
-          .that(ratio)
-          .isAtMost(2 * Math.log(largeSize) / Math.log(smallSize));
-      // allow up to 2x wobble in the constant factors
-    }
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingOnInverseGet() {
-    for (AdversaryType adversary : AdversaryType.values()) {
-      CallsCounter smallCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> smallEntries =
-          adversary.createAdversarialEntries(10, smallCounter);
-      ImmutableBiMap<?, ?> smallMap =
-          ConstructionPathway.COPY_OF_ENTRIES.create(smallEntries, smallCounter);
-      int smallSize = smallEntries.size();
-      long smallOps = worstCaseQueryOperations(smallMap.inverse(), smallCounter);
-
-      CallsCounter largeCounter = new CallsCounter();
-      List<? extends Entry<?, ?>> largeEntries =
-          adversary.createAdversarialEntries(15, largeCounter);
-      ImmutableBiMap<?, ?> largeMap =
-          ConstructionPathway.COPY_OF_ENTRIES.create(largeEntries, largeCounter);
-      int largeSize = largeEntries.size();
-      long largeOps = worstCaseQueryOperations(largeMap.inverse(), largeCounter);
-
-      if (smallOps == 0 && largeOps == 0) {
-        continue; // no queries on the CHCAE objects
-      }
-      double ratio = (double) largeOps / smallOps;
-      assertWithMessage(
-              "Ratio of worst case get operations for an ImmutableBiMap with %s of size "
-                  + "%s versus %s",
-              adversary, largeSize, smallSize)
-          .that(ratio)
-          .isAtMost(2 * Math.log(largeSize) / Math.log(smallSize));
-      // allow up to 2x wobble in the constant factors
-    }
-  }
-
-  private static long worstCaseQueryOperations(Map<?, ?> map, CallsCounter counter) {
-    long worstCalls = 0;
-    for (Object k : map.keySet()) {
-      counter.zero();
-      Object unused = map.get(k);
-      worstCalls = Math.max(worstCalls, counter.total());
-    }
-    return worstCalls;
   }
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
@@ -718,4 +718,7 @@ public class ImmutableBiMapTest extends TestCase {
       public abstract ImmutableBiMap<Object, Object> create(List<Map.Entry<?, ?>> entries);
     }
   }
+
+  /** No-op test so that the class has at least one method, making Maven's test runner happy. */
+  public void testNoop() {}
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -19,7 +19,6 @@ package com.google.common.collect;
 import static com.google.common.collect.testing.Helpers.mapEntry;
 import static com.google.common.testing.SerializableTester.reserialize;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -52,7 +51,6 @@ import com.google.common.testing.CollectorTester;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.SerializableTester;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -68,7 +66,6 @@ import java.util.stream.Stream;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Tests for {@link ImmutableMap}.
@@ -83,6 +80,7 @@ public class ImmutableMapTest extends TestCase {
   public static Test suite() {
     TestSuite suite = new TestSuite();
     suite.addTestSuite(ImmutableMapTest.class);
+    suite.addTestSuite(FloodingTest.class);
 
     suite.addTest(
         MapTestSuiteBuilder.using(new ImmutableMapGenerator())
@@ -847,230 +845,6 @@ public class ImmutableMapTest extends TestCase {
         .testEquals();
   }
 
-  /**
-   * A Comparable wrapper around a String which executes callbacks on calls to hashCode, equals, and
-   * compareTo.
-   */
-  private static class CountsHashCodeAndEquals implements Comparable<CountsHashCodeAndEquals> {
-    private final String delegateString;
-    private final Runnable onHashCode;
-    private final Runnable onEquals;
-    private final Runnable onCompareTo;
-
-    CountsHashCodeAndEquals(
-        String delegateString, Runnable onHashCode, Runnable onEquals, Runnable onCompareTo) {
-      this.delegateString = delegateString;
-      this.onHashCode = onHashCode;
-      this.onEquals = onEquals;
-      this.onCompareTo = onCompareTo;
-    }
-
-    @Override
-    public int hashCode() {
-      onHashCode.run();
-      return delegateString.hashCode();
-    }
-
-    @Override
-    public boolean equals(@Nullable Object other) {
-      onEquals.run();
-      return other instanceof CountsHashCodeAndEquals
-          && delegateString.equals(((CountsHashCodeAndEquals) other).delegateString);
-    }
-
-    @Override
-    public int compareTo(CountsHashCodeAndEquals o) {
-      onCompareTo.run();
-      return delegateString.compareTo(o.delegateString);
-    }
-  }
-
-  /** A holder of counters for calls to hashCode, equals, and compareTo. */
-  private static final class CallsCounter {
-    long hashCode;
-    long equals;
-    long compareTo;
-
-    long total() {
-      return hashCode + equals + compareTo;
-    }
-
-    void zero() {
-      hashCode = 0;
-      equals = 0;
-      compareTo = 0;
-    }
-  }
-
-  /** All the ways to create an ImmutableMap. */
-  enum ConstructionPathway {
-    COPY_OF_MAP {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        Map<Object, Object> sourceMap = new LinkedHashMap<>();
-        for (Object k : keys) {
-          if (sourceMap.put(k, value) != null) {
-            throw new UnsupportedOperationException("duplicate key");
-          }
-        }
-        counter.zero();
-        return ImmutableMap.copyOf(sourceMap);
-      }
-    },
-    COPY_OF_ENTRIES {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        return ImmutableMap.copyOf(Lists.transform(keys, k -> Maps.immutableEntry(k, value)));
-      }
-    },
-    BUILDER_PUT_ONE_BY_ONE {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
-        for (Object k : keys) {
-          builder.put(k, value);
-        }
-        return builder.build();
-      }
-    },
-    BUILDER_PUT_ENTRIES_ONE_BY_ONE {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
-        for (Object k : keys) {
-          builder.put(Maps.immutableEntry(k, value));
-        }
-        return builder.build();
-      }
-    },
-    BUILDER_PUT_ALL_MAP {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        Map<Object, Object> sourceMap = new LinkedHashMap<>();
-        for (Object k : keys) {
-          if (sourceMap.put(k, value) != null) {
-            throw new UnsupportedOperationException("duplicate key");
-          }
-        }
-        counter.zero();
-        return ImmutableMap.builder().putAll(sourceMap).build();
-      }
-    },
-    BUILDER_PUT_ALL_ENTRIES {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        return ImmutableMap.builder()
-            .putAll(Lists.transform(keys, k -> Maps.immutableEntry(k, value)))
-            .build();
-      }
-    },
-    FORCE_JDK {
-      @Override
-      ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter) {
-        ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
-        for (Object k : keys) {
-          builder.put(k, value);
-        }
-        return builder.buildJdkBacked();
-      }
-    };
-
-    @CanIgnoreReturnValue
-    abstract ImmutableMap<?, ?> create(List<?> keys, Object value, CallsCounter counter);
-  }
-
-  /**
-   * Returns a list of objects with the same hash code, of size 2^power, counting calls to equals,
-   * hashCode, and compareTo in counter.
-   */
-  static List<CountsHashCodeAndEquals> createAdversarialInput(int power, CallsCounter counter) {
-    String str1 = "Aa";
-    String str2 = "BB";
-    assertEquals(str1.hashCode(), str2.hashCode());
-    List<String> haveSameHashes2 = Arrays.asList(str1, str2);
-    List<CountsHashCodeAndEquals> result =
-        Lists.newArrayList(
-            Lists.transform(
-                Lists.cartesianProduct(Collections.nCopies(power, haveSameHashes2)),
-                strs ->
-                    new CountsHashCodeAndEquals(
-                        String.join("", strs),
-                        () -> counter.hashCode++,
-                        () -> counter.equals++,
-                        () -> counter.compareTo++)));
-    assertEquals(
-        result.get(0).delegateString.hashCode(),
-        result.get(result.size() - 1).delegateString.hashCode());
-    return result;
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingInConstruction() {
-    CallsCounter smallCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
-    int smallSize = haveSameHashesSmall.size();
-
-    CallsCounter largeCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
-    int largeSize = haveSameHashesLarge.size();
-
-    for (ConstructionPathway pathway : ConstructionPathway.values()) {
-      smallCounter.zero();
-      pathway.create(haveSameHashesSmall, "valueObject", smallCounter);
-      long smallOps = smallCounter.total();
-
-      largeCounter.zero();
-      pathway.create(haveSameHashesLarge, "valueObject", largeCounter);
-      long largeOps = largeCounter.total();
-
-      double ratio = (double) largeOps / smallOps;
-      assertWithMessage(
-              "ratio of equals/hashCode/compareTo operations to build an ImmutableMap via %s"
-                  + " with %s entries versus %s entries",
-              pathway, largeSize, smallSize)
-          .that(ratio)
-          .isAtMost(2 * (largeSize * Math.log(largeSize)) / (smallSize * Math.log(smallSize)));
-      // allow up to 2x wobble in the constant factors
-    }
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingOnGet() {
-    CallsCounter smallCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
-    int smallSize = haveSameHashesSmall.size();
-    ImmutableMap<?, ?> smallMap =
-        ConstructionPathway.BUILDER_PUT_ONE_BY_ONE.create(
-            haveSameHashesSmall, "valueObject", smallCounter);
-    long worstCaseQuerySmall = worstCaseQueryOperations(smallMap, smallCounter);
-
-    CallsCounter largeCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
-    int largeSize = haveSameHashesLarge.size();
-    ImmutableMap<?, ?> largeMap =
-        ConstructionPathway.BUILDER_PUT_ONE_BY_ONE.create(
-            haveSameHashesLarge, "valueObject", largeCounter);
-    long worstCaseQueryLarge = worstCaseQueryOperations(largeMap, largeCounter);
-
-    double ratio = (double) worstCaseQueryLarge / worstCaseQuerySmall;
-    assertWithMessage(
-            "Ratio of worst case query operations for an ImmutableMap of size %s versus %s",
-            largeSize, smallSize)
-        .that(ratio)
-        .isAtMost(2 * Math.log(largeSize) / Math.log(smallSize));
-    // allow up to 2x wobble in the constant factors
-  }
-
-  private static long worstCaseQueryOperations(Map<?, ?> map, CallsCounter counter) {
-    long worstCalls = 0;
-    for (Object k : map.keySet()) {
-      counter.zero();
-      Object unused = map.get(k);
-      worstCalls = Math.max(worstCalls, counter.total());
-    }
-    return worstCalls;
-  }
-
   public void testCopyOfMutableEntryList() {
     List<Entry<String, String>> entryList =
         Arrays.asList(
@@ -1101,5 +875,87 @@ public class ImmutableMapTest extends TestCase {
     assertThat(map).containsExactly("a", "1", "b", "2").inOrder();
     entryList.get(0).setValue("3");
     assertThat(map).containsExactly("a", "1", "b", "2").inOrder();
+  }
+
+  public static class FloodingTest extends AbstractHashFloodingTest<Map<Object, Object>> {
+    public FloodingTest() {
+      super(
+          Arrays.asList(ConstructionPathway.values()),
+          n -> n * Math.log(n),
+          ImmutableList.of(QueryOp.MAP_GET));
+    }
+
+    /** All the ways to create an ImmutableMap. */
+    enum ConstructionPathway implements Construction<Map<Object, Object>> {
+      COPY_OF_MAP {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          Map<Object, Object> sourceMap = new LinkedHashMap<>();
+          for (Object k : keys) {
+            if (sourceMap.put(k, "dummy value") != null) {
+              throw new UnsupportedOperationException("duplicate key");
+            }
+          }
+          return ImmutableMap.copyOf(sourceMap);
+        }
+      },
+      COPY_OF_ENTRIES {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          return ImmutableMap.copyOf(
+              Lists.transform(keys, k -> Maps.immutableEntry(k, "dummy value")));
+        }
+      },
+      BUILDER_PUT_ONE_BY_ONE {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
+          for (Object k : keys) {
+            builder.put(k, "dummy value");
+          }
+          return builder.build();
+        }
+      },
+      BUILDER_PUT_ENTRIES_ONE_BY_ONE {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
+          for (Object k : keys) {
+            builder.put(Maps.immutableEntry(k, "dummy value"));
+          }
+          return builder.build();
+        }
+      },
+      BUILDER_PUT_ALL_MAP {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          Map<Object, Object> sourceMap = new LinkedHashMap<>();
+          for (Object k : keys) {
+            if (sourceMap.put(k, "dummy value") != null) {
+              throw new UnsupportedOperationException("duplicate key");
+            }
+          }
+          return ImmutableMap.builder().putAll(sourceMap).build();
+        }
+      },
+      BUILDER_PUT_ALL_ENTRIES {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          return ImmutableMap.builder()
+              .putAll(Lists.transform(keys, k -> Maps.immutableEntry(k, "dummy value")))
+              .build();
+        }
+      },
+      FORCE_JDK {
+        @Override
+        public Map<Object, Object> create(List<?> keys) {
+          ImmutableMap.Builder<Object, Object> builder = ImmutableMap.builder();
+          for (Object k : keys) {
+            builder.put(k, "dummy value");
+          }
+          return builder.buildJdkBacked();
+        }
+      };
+    }
   }
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSetTest.java
@@ -17,7 +17,6 @@
 package com.google.common.collect;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -38,7 +37,6 @@ import com.google.common.collect.testing.google.SetGenerators.ImmutableSetUnsize
 import com.google.common.collect.testing.google.SetGenerators.ImmutableSetWithBadHashesGenerator;
 import com.google.common.testing.CollectorTester;
 import com.google.common.testing.EqualsTester;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,7 +47,6 @@ import java.util.function.BiPredicate;
 import java.util.stream.Collector;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Unit test for {@link ImmutableSet}.
@@ -163,6 +160,7 @@ public class ImmutableSetTest extends AbstractImmutableSetTest {
             .createTestSuite());
 
     suite.addTestSuite(ImmutableSetTest.class);
+    suite.addTestSuite(FloodingTest.class);
 
     return suite;
   }
@@ -380,214 +378,74 @@ public class ImmutableSetTest extends AbstractImmutableSetTest {
         .testEquals();
   }
 
-  /**
-   * A Comparable wrapper around a String which executes callbacks on calls to hashCode, equals, and
-   * compareTo.
-   */
-  private static class CountsHashCodeAndEquals implements Comparable<CountsHashCodeAndEquals> {
-    private final String delegateString;
-    private final Runnable onHashCode;
-    private final Runnable onEquals;
-    private final Runnable onCompareTo;
-
-    CountsHashCodeAndEquals(
-        String delegateString, Runnable onHashCode, Runnable onEquals, Runnable onCompareTo) {
-      this.delegateString = delegateString;
-      this.onHashCode = onHashCode;
-      this.onEquals = onEquals;
-      this.onCompareTo = onCompareTo;
-    }
-
-    @Override
-    public int hashCode() {
-      onHashCode.run();
-      return delegateString.hashCode();
-    }
-
-    @Override
-    public boolean equals(@Nullable Object other) {
-      onEquals.run();
-      return other instanceof CountsHashCodeAndEquals
-          && delegateString.equals(((CountsHashCodeAndEquals) other).delegateString);
-    }
-
-    @Override
-    public int compareTo(CountsHashCodeAndEquals o) {
-      onCompareTo.run();
-      return delegateString.compareTo(o.delegateString);
-    }
-  }
-
-  /** A holder of counters for calls to hashCode, equals, and compareTo. */
-  private static final class CallsCounter {
-    long hashCode;
-    long equals;
-    long compareTo;
-
-    long total() {
-      return hashCode + equals + compareTo;
-    }
-
-    void zero() {
-      hashCode = 0;
-      equals = 0;
-      compareTo = 0;
-    }
-  }
-
-  /** All the ways to construct an ImmutableSet. */
-  enum ConstructionPathway {
-    OF {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        Object o1 = list.get(0);
-        Object o2 = list.get(1);
-        Object o3 = list.get(2);
-        Object o4 = list.get(3);
-        Object o5 = list.get(4);
-        Object o6 = list.get(5);
-        Object[] rest = list.subList(6, list.size()).toArray();
-        return ImmutableSet.of(o1, o2, o3, o4, o5, o6, rest);
-      }
-    },
-    COPY_OF_ARRAY {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        return ImmutableSet.copyOf(list.toArray());
-      }
-    },
-    COPY_OF_LIST {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        return ImmutableSet.copyOf(list);
-      }
-    },
-    BUILDER_ADD_ONE_BY_ONE {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
-        for (Object o : list) {
-          builder.add(o);
-        }
-        return builder.build();
-      }
-    },
-    BUILDER_ADD_ARRAY {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
-        builder.add(list.toArray());
-        return builder.build();
-      }
-    },
-    BUILDER_ADD_LIST {
-      @Override
-      ImmutableSet<?> create(List<?> list) {
-        ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
-        builder.addAll(list);
-        return builder.build();
-      }
-    };
-
-    @CanIgnoreReturnValue
-    abstract ImmutableSet<?> create(List<?> list);
-  }
-
-  /**
-   * Returns a list of objects with the same hash code, of size 2^power, counting calls to equals,
-   * hashCode, and compareTo in counter.
-   */
-  static List<CountsHashCodeAndEquals> createAdversarialInput(int power, CallsCounter counter) {
-    String str1 = "Aa";
-    String str2 = "BB";
-    assertEquals(str1.hashCode(), str2.hashCode());
-    List<String> haveSameHashes2 = Arrays.asList(str1, str2);
-    List<CountsHashCodeAndEquals> result =
-        Lists.newArrayList(
-            Lists.transform(
-                Lists.cartesianProduct(Collections.nCopies(power, haveSameHashes2)),
-                strs ->
-                    new CountsHashCodeAndEquals(
-                        String.join("", strs),
-                        () -> counter.hashCode++,
-                        () -> counter.equals++,
-                        () -> counter.compareTo++)));
-    assertEquals(
-        result.get(0).delegateString.hashCode(),
-        result.get(result.size() - 1).delegateString.hashCode());
-    return result;
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingInConstruction() {
-    CallsCounter smallCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
-    int smallSize = haveSameHashesSmall.size();
-
-    CallsCounter largeCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
-    int largeSize = haveSameHashesLarge.size();
-
-    for (ConstructionPathway pathway : ConstructionPathway.values()) {
-      smallCounter.zero();
-      pathway.create(haveSameHashesSmall);
-
-      largeCounter.zero();
-      pathway.create(haveSameHashesLarge);
-
-      double ratio = (double) largeCounter.total() / smallCounter.total();
-
-      assertWithMessage(
-              "ratio of equals/hashCode/compareTo operations to build an ImmutableSet via pathway "
-                  + "%s of size %s versus size %s",
-              pathway, haveSameHashesLarge.size(), haveSameHashesSmall.size())
-          .that(ratio)
-          .isAtMost(2.0 * (largeSize * Math.log(largeSize)) / (smallSize * Math.log(smallSize)));
-      // We allow up to 2x wobble in the constant factors.
-    }
-  }
-
-  @GwtIncompatible
-  public void testResistsHashFloodingOnContains() {
-    CallsCounter smallCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesSmall = createAdversarialInput(10, smallCounter);
-    ImmutableSet<?> smallSet = ConstructionPathway.COPY_OF_LIST.create(haveSameHashesSmall);
-    long worstCaseOpsSmall = worstCaseQueryOperations(smallSet, smallCounter);
-
-    CallsCounter largeCounter = new CallsCounter();
-    List<CountsHashCodeAndEquals> haveSameHashesLarge = createAdversarialInput(15, largeCounter);
-    ImmutableSet<?> largeSet = ConstructionPathway.COPY_OF_LIST.create(haveSameHashesLarge);
-    long worstCaseOpsLarge = worstCaseQueryOperations(largeSet, largeCounter);
-
-    double ratio = (double) worstCaseOpsLarge / worstCaseOpsSmall;
-    int smallSize = haveSameHashesSmall.size();
-    int largeSize = haveSameHashesLarge.size();
-
-    assertWithMessage(
-            "ratio of equals/hashCode/compareTo operations to worst-case query an ImmutableSet "
-                + "of size %s versus size %s",
-            haveSameHashesLarge.size(), haveSameHashesSmall.size())
-        .that(ratio)
-        .isAtMost(2 * Math.log(largeSize) / Math.log(smallSize));
-    // We allow up to 2x wobble in the constant factors.
-  }
-
-  private static long worstCaseQueryOperations(Set<?> set, CallsCounter counter) {
-    long worstCalls = 0;
-    for (Object k : set) {
-      counter.zero();
-      if (set.contains(k)) {
-        worstCalls = Math.max(worstCalls, counter.total());
-      }
-    }
-    return worstCalls;
-  }
-
   public void testReuseBuilderReducingHashTableSizeWithPowerOfTwoTotalElements() {
     ImmutableSet.Builder<Object> builder = ImmutableSet.builderWithExpectedSize(6);
     builder.add(0);
     ImmutableSet<Object> unused = builder.build();
     ImmutableSet<Object> subject = builder.add(1).add(2).add(3).build();
     assertFalse(subject.contains(4));
+  }
+
+  public static class FloodingTest extends AbstractHashFloodingTest<Set<Object>> {
+    public FloodingTest() {
+      super(
+          Arrays.asList(ConstructionPathway.values()),
+          n -> n * Math.log(n),
+          ImmutableList.of(QueryOp.create("contains", Set::contains, Math::log)));
+    }
+    /** All the ways to construct an ImmutableSet. */
+    enum ConstructionPathway implements Construction<Set<Object>> {
+      OF {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          Object o1 = list.get(0);
+          Object o2 = list.get(1);
+          Object o3 = list.get(2);
+          Object o4 = list.get(3);
+          Object o5 = list.get(4);
+          Object o6 = list.get(5);
+          Object[] rest = list.subList(6, list.size()).toArray();
+          return ImmutableSet.of(o1, o2, o3, o4, o5, o6, rest);
+        }
+      },
+      COPY_OF_ARRAY {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          return ImmutableSet.copyOf(list.toArray());
+        }
+      },
+      COPY_OF_LIST {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          return ImmutableSet.copyOf(list);
+        }
+      },
+      BUILDER_ADD_ONE_BY_ONE {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
+          for (Object o : list) {
+            builder.add(o);
+          }
+          return builder.build();
+        }
+      },
+      BUILDER_ADD_ARRAY {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
+          builder.add(list.toArray());
+          return builder.build();
+        }
+      },
+      BUILDER_ADD_LIST {
+        @Override
+        public ImmutableSet<Object> create(List<?> list) {
+          ImmutableSet.Builder<Object> builder = ImmutableSet.builder();
+          builder.addAll(list);
+          return builder.build();
+        }
+      };
+    }
   }
 }

--- a/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
+++ b/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
@@ -604,6 +604,7 @@ public class MapMakerInternalMapTest extends TestCase {
     assertNull(segment.get(key, hash));
   }
 
+  @SuppressWarnings("GuardedBy")
   public void testExpand() {
     MapMakerInternalMap<Object, Object, ?, ?> map =
         makeMap(createMapMaker().concurrencyLevel(1).initialCapacity(1));
@@ -629,6 +630,8 @@ public class MapMakerInternalMapTest extends TestCase {
 
     for (int i = 1; i <= originalCount * 2; i *= 2) {
       if (i > 1) {
+        // TODO(b/145386688): This access should be guarded by 'segment', which is not currently
+        // held
         segment.expand();
       }
       assertEquals(i, segment.table.length());
@@ -687,6 +690,7 @@ public class MapMakerInternalMapTest extends TestCase {
     assertNull(newFirst.getNext());
   }
 
+  @SuppressWarnings("GuardedBy")
   public void testExpand_cleanup() {
     MapMakerInternalMap<Object, Object, ?, ?> map =
         makeMap(createMapMaker().concurrencyLevel(1).initialCapacity(1));
@@ -719,6 +723,8 @@ public class MapMakerInternalMapTest extends TestCase {
 
     for (int i = 1; i <= originalCount * 2; i *= 2) {
       if (i > 1) {
+        // TODO(b/145386688): This access should be guarded by 'segment', which is not currently
+        // held
         segment.expand();
       }
       assertEquals(i, segment.table.length());

--- a/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/guava/src/com/google/common/collect/CompactHashMap.java
@@ -115,7 +115,7 @@ class CompactHashMap<K, V> extends AbstractMap<K, V> implements Serializable {
   static final double HASH_FLOODING_FPP = 0.001;
 
   /**
-   * Maximum allowed length of a hash table bucket before falling back to a j.u.HashMap based
+   * Maximum allowed length of a hash table bucket before falling back to a j.u.LinkedHashMap-based
    * implementation. Experimentally determined.
    */
   private static final int MAX_HASH_BUCKET_LENGTH = 9;

--- a/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -18,9 +18,12 @@ package com.google.common.collect;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -115,6 +118,19 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     int expectedSize = super.allocArrays();
     this.links = new long[expectedSize];
     return expectedSize;
+  }
+
+  @Override
+  Map<K, V> createHashFloodingResistantDelegate(int tableSize) {
+    return new LinkedHashMap<K, V>(tableSize, 1.0f, accessOrder);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  Map<K, V> convertToHashFloodingResistantImplementation() {
+    Map<K, V> result = super.convertToHashFloodingResistantImplementation();
+    links = null;
+    return result;
   }
 
   private int getPredecessor(int entry) {
@@ -261,7 +277,9 @@ class CompactLinkedHashMap<K, V> extends CompactHashMap<K, V> {
     }
     this.firstEntry = ENDPOINT;
     this.lastEntry = ENDPOINT;
-    Arrays.fill(links, 0, size(), 0);
+    if (links != null) {
+      Arrays.fill(links, 0, size(), 0);
+    }
     super.clear();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make Compact(Linked)HashMap fall back to a java.util.LinkedHashMap if hash flooding is detected, just as the immutable collections do.

5dffec12c07ea23bcba653198036e55df27792f0

-------

<p> Fix Maven test failures from CL 286604248:
- Make "abstract" class abstract. (And make its constructor package-private while we're at it.)
- Add a dummy test method (similar to what FilteredCollectionsTest already has).

These should fix:
- warning(junit.framework.TestSuite$1): Class com.google.common.collect.AbstractHashFloodingTest has no public constructor TestCase(String name) or TestCase()
- warning(junit.framework.TestSuite$1): No tests found in com.google.common.collect.ImmutableBiMapTest

https://travis-ci.org/google/guava/jobs/628734577

(Also, address a review comment: https://github.com/google/guava/pull/3746/files/40d75c94d568935159ce838c61940430fce54249#r360917786)

8ccd51880e63c487af858c6de57a2d37eb2cf4ac

-------

<p> Add @SuppressWarnings for new violations of the GuardedBy checker.

98736425927413862c058d11f1aaeae53bbe0f91