### PR TITLE
documenting IllegalArgumentException for too-large Cartesian Product in Sets.cartesianProduct

### DIFF
--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -1319,6 +1319,7 @@ public final class Sets {
    * @return the Cartesian product, as an immutable set containing immutable lists
    * @throws NullPointerException if {@code sets}, any one of the {@code sets}, or any element of a
    *     provided set is null
+   * @throws IllegalArgumentException if cartesian product too large, must have size at most Integer.MAX_VALUE
    * @since 2.0
    */
   public static <B> Set<List<B>> cartesianProduct(List<? extends Set<? extends B>> sets) {
@@ -1375,6 +1376,7 @@ public final class Sets {
    * @return the Cartesian product, as an immutable set containing immutable lists
    * @throws NullPointerException if {@code sets}, any one of the {@code sets}, or any element of a
    *     provided set is null
+   * @throws IllegalArgumentException if cartesian product too large, must have size at most Integer.MAX_VALUE
    * @since 2.0
    */
   @SafeVarargs


### PR DESCRIPTION
#3742 mentions that there's no documentation for an IllegalArgumentException being thrown.

It turns out there's a test case here that covers this case, but it's not mentioned in the JavaDoc: https://github.com/google/guava/blob/d9b73b20964b9d87457c56d1e422a67f45c2c257/guava-tests/test/com/google/common/collect/SetsTest.java#L774

The original exception is thrown here in the CartesianList constructor: https://github.com/google/guava/blob/d9b73b20964b9d87457c56d1e422a67f45c2c257/guava/src/com/google/common/collect/CartesianList.java#L59

I've just added a `throws` line in both of the JavaDocs for `Sets.cartesianProduct()`