### PR TITLE
MOE Sync 2020-01-07

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -33,6 +33,8 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
 
   abstract boolean allowsSelfLoops();
 
+  abstract ElementOrder<Integer> incidentEdgeOrder();
+
   @After
   public void validateUndirectedEdges() {
     for (Integer node : graph.nodes()) {
@@ -240,6 +242,82 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.outDegree(N1)).isEqualTo(2);
     putEdge(N2, N1);
     assertThat(graph.outDegree(N1)).isEqualTo(3);
+  }
+
+  // Stable order tests
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void stableIncidentEdgeOrder_edges_returnsInStableOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.edges())
+        .containsExactly(
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3),
+            EndpointPair.unordered(4, 5))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_adjacentNodes_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_predecessors_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_successors_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  /**
+   * Populates the graph with nodes and edges in a star shape with node `1` in the middle.
+   *
+   * <p>Note that the edges are added in a shuffled order to properly test the effect of the
+   * insertion order.
+   */
+  private void populateTShapedGraph() {
+    putEdge(2, 1);
+    putEdge(1, 4);
+    putEdge(1, 3);
+    putEdge(1, 2); // Duplicate
+    putEdge(4, 5);
   }
 
   // Element Mutation

--- a/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -122,4 +122,20 @@ public class ImmutableValueGraphTest {
     assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
     assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
   }
+
+  @Test
+  public void immutableValueGraphBuilder_incidentEdges_preservesIncidentEdgesOrder() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed()
+            .<Integer, String>immutable()
+            .putEdgeValue(2, 1, "2-1")
+            .putEdgeValue(2, 3, "2-3")
+            .putEdgeValue(1, 2, "1-2")
+            .build();
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
 }

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+@AndroidIncompatible
+@RunWith(Parameterized.class)
+public final class StandardImmutableUndirectedGraphTest
+    extends AbstractStandardUndirectedGraphTest {
+
+  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[][] {
+          {false, ElementOrder.unordered()},
+          {true, ElementOrder.unordered()},
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()}
+        });
+  }
+
+  private final boolean allowsSelfLoops;
+  private final ElementOrder<Integer> incidentEdgeOrder;
+  private ImmutableGraph.Builder<Integer> graphBuilder;
+
+  public StandardImmutableUndirectedGraphTest(
+      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+    this.allowsSelfLoops = allowsSelfLoops;
+    this.incidentEdgeOrder = incidentEdgeOrder;
+  }
+
+  @Override
+  boolean allowsSelfLoops() {
+    return allowsSelfLoops;
+  }
+
+  @Override
+  ElementOrder<Integer> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
+  public Graph<Integer> createGraph() {
+    graphBuilder =
+        GraphBuilder.undirected()
+            .allowsSelfLoops(allowsSelfLoops())
+            .incidentEdgeOrder(incidentEdgeOrder)
+            .immutable();
+    return graphBuilder.build();
+  }
+
+  @Override
+  final void addNode(Integer n) {
+    graphBuilder.addNode(n);
+    graph = graphBuilder.build();
+  }
+
+  @Override
+  final void putEdge(Integer n1, Integer n2) {
+    graphBuilder.putEdge(n1, n2);
+    graph = graphBuilder.build();
+  }
+}

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -60,7 +60,7 @@ public final class StandardMutableDirectedGraphTest extends AbstractStandardDire
   @Override
   public MutableGraph<Integer> createGraph() {
     return GraphBuilder.directed()
-        .allowsSelfLoops(allowsSelfLoops())
+        .allowsSelfLoops(allowsSelfLoops)
         .incidentEdgeOrder(incidentEdgeOrder)
         .build();
   }

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -27,18 +27,24 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}")
+  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(
         new Object[][] {
-          {false}, {true},
+          {false, ElementOrder.unordered()},
+          {true, ElementOrder.unordered()},
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()},
         });
   }
 
   private final boolean allowsSelfLoops;
+  private final ElementOrder<Integer> incidentEdgeOrder;
 
-  public StandardMutableUndirectedGraphTest(boolean allowsSelfLoops) {
+  public StandardMutableUndirectedGraphTest(
+      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
     this.allowsSelfLoops = allowsSelfLoops;
+    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -47,8 +53,16 @@ public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirect
   }
 
   @Override
+  ElementOrder<Integer> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
   public MutableGraph<Integer> createGraph() {
-    return GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).build();
+    return GraphBuilder.undirected()
+        .allowsSelfLoops(allowsSelfLoops)
+        .incidentEdgeOrder(incidentEdgeOrder)
+        .build();
   }
 
   @Override

--- a/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -339,6 +339,19 @@ public final class ValueGraphTest {
   }
 
   @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(1, 2, "1-2");
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
   public void concurrentIteration() throws Exception {
     graph = ValueGraphBuilder.directed().build();
     graph.putEdgeValue(1, 2, "A");

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -1675,6 +1675,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
    * This method is a convenience for testing. Code should call {@link Segment#copyEntry} directly.
    */
   // Guarded By Segment.this
+  @SuppressWarnings("GuardedBy")
   @VisibleForTesting
   ReferenceEntry<K, V> copyEntry(ReferenceEntry<K, V> original, ReferenceEntry<K, V> newNext) {
     int hash = original.getHash();

--- a/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -171,6 +171,6 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
   private GraphConnections<N, V> newConnections() {
     return isDirected()
         ? DirectedGraphConnections.<N, V>of(incidentEdgeOrder)
-        : UndirectedGraphConnections.<N, V>of();
+        : UndirectedGraphConnections.<N, V>of(incidentEdgeOrder);
   }
 }

--- a/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -125,7 +125,10 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
     private final MutableValueGraph<N, V> mutableValueGraph;
 
     Builder(ValueGraphBuilder<N, V> graphBuilder) {
-      this.mutableValueGraph = graphBuilder.build();
+      // The incidentEdgeOrder for immutable graphs is always stable. However, we don't want to
+      // modify this builder, so we make a copy instead.
+      this.mutableValueGraph =
+          graphBuilder.copy().incidentEdgeOrder(ElementOrder.<N>stable()).build();
     }
 
     /**

--- a/android/guava/src/com/google/common/graph/UndirectedGraphConnections.java
+++ b/android/guava/src/com/google/common/graph/UndirectedGraphConnections.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterators;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,8 +44,17 @@ final class UndirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     this.adjacentNodeValues = checkNotNull(adjacentNodeValues);
   }
 
-  static <N, V> UndirectedGraphConnections<N, V> of() {
-    return new UndirectedGraphConnections<>(new HashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+  static <N, V> UndirectedGraphConnections<N, V> of(ElementOrder<N> incidentEdgeOrder) {
+    switch (incidentEdgeOrder.type()) {
+      case UNORDERED:
+        return new UndirectedGraphConnections<>(
+            new HashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+      case STABLE:
+        return new UndirectedGraphConnections<>(
+            new LinkedHashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+      default:
+        throw new AssertionError(incidentEdgeOrder.type());
+    }
   }
 
   static <N, V> UndirectedGraphConnections<N, V> ofImmutable(Map<N, V> adjacentNodeValues) {

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -16,6 +16,7 @@
 
 package com.google.common.graph;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.graph.Graphs.checkNonNegative;
 
@@ -94,6 +95,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return new ValueGraphBuilder<N, V>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
         .nodeOrder(graph.nodeOrder());
+    // TODO(b/142723300): Add incidentEdgeOrder
   }
 
   /**
@@ -101,6 +103,9 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * ValueGraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.
+   *
+   * <p>Note that the returned builder will always have {@link #incidentEdgeOrder} set to {@link
+   * ElementOrder#stable()}, regardless of the value that was set in this builder.
    *
    * @since 28.0
    */
@@ -142,6 +147,30 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return newBuilder;
   }
 
+  /**
+   * Specifies the order of iteration for the elements of {@link ValueGraph#edges()}, {@link
+   * ValueGraph#adjacentNodes(Object)}, {@link ValueGraph#predecessors(Object)}, {@link
+   * ValueGraph#successors(Object)} and {@link ValueGraph#incidentEdges(Object)}.
+   *
+   * <p>The default value is {@link ElementOrder#unordered() unordered} for mutable graphs. For
+   * immutable graphs, this value is ignored; they always have a {@link ElementOrder#stable()
+   * stable} order.
+   *
+   * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
+   *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
+   */
+  // TODO(b/142723300): Make this method public
+  <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+    checkArgument(
+        incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
+            || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,
+        "The given elementOrder (%s) is unsupported. incidentEdgeOrder() only supports"
+            + " ElementOrder.unordered() and ElementOrder.stable().",
+        incidentEdgeOrder);
+    ValueGraphBuilder<N1, V> newBuilder = cast();
+    newBuilder.incidentEdgeOrder = checkNotNull(incidentEdgeOrder);
+    return newBuilder;
+  }
   /**
    * Returns an empty {@link MutableValueGraph} with the properties of this {@link
    * ValueGraphBuilder}.

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -179,6 +179,15 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return new ConfigurableMutableValueGraph<>(this);
   }
 
+  ValueGraphBuilder<N, V> copy() {
+    ValueGraphBuilder<N, V> newBuilder = new ValueGraphBuilder<>(directed);
+    newBuilder.allowsSelfLoops = allowsSelfLoops;
+    newBuilder.nodeOrder = nodeOrder;
+    newBuilder.expectedNodeCount = expectedNodeCount;
+    newBuilder.incidentEdgeOrder = incidentEdgeOrder;
+    return newBuilder;
+  }
+
   @SuppressWarnings("unchecked")
   private <N1 extends N, V1 extends V> ValueGraphBuilder<N1, V1> cast() {
     return (ValueGraphBuilder<N1, V1>) this;

--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -116,9 +116,11 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <excludes>
-            <!-- Yes, we want to exclude this 3 times: -->
+            <!-- Yes, we want to exclude ForceGuavaCompilation 4 times: -->
+            <!-- (And we might as well exclude DummyJavadocClass 3 times (though it would be harmless to include).) -->
             <!-- 1. Don't compile it (since that requires a *non-test* dep on gwt-user. -->
             <exclude>**/ForceGuavaCompilation*</exclude>
+            <exclude>**/DummyJavadocClass*</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -128,6 +130,7 @@
           <excludes>
             <!-- 2. Don't include the source in the jar (since that would let users depend on it from GWT client code, which is compiled from source). -->
             <exclude>**/ForceGuavaCompilation*</exclude>
+            <exclude>**/DummyJavadocClass*</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -137,15 +140,19 @@
           <excludes>
             <!-- 3. Don't include it in the source jar (since it's really more of a "test" than it is production code). -->
             <exclude>**/ForceGuavaCompilation*</exclude>
+            <exclude>**/DummyJavadocClass*</exclude>
           </excludes>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <!-- No meaningful public classes, just sources for the GWT compiler, some internal serialization classes, and dummy entry-point class to force compilation. -->
-          <!-- And soon, the serialization classes will be going away, and the entry point won't compile after we move gwt-user to test scope. -->
-          <skip>true</skip>
+          <sourceFileExcludes>
+            <!-- 4. Don't build Javadoc for it (since that, too, would require a *non-test* dep on gwt-user. -->
+            <sourceFileExclude>**/ForceGuavaCompilation*</sourceFileExclude>
+          </sourceFileExcludes>
+          <!-- After removing GWT-RPC support, we will have no real classes to build Javadoc for. This would result in an empty Javadoc jar, which the Sonatype repository manager would reject. To avoid that, we've introduced a dummy class. But we made it package-private so that no one can depend on it. That in turn forced us to configure Javadoc to show package-private APIs. -->
+          <show>package</show>
         </configuration>
       </plugin>
       <!-- Disable "normal" testing, which doesn't work for GWT tests. -->

--- a/guava-gwt/src/com/google/common/DummyJavadocClass.java
+++ b/guava-gwt/src/com/google/common/DummyJavadocClass.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common;
+
+/**
+ * A dummy class so that the Maven Javadoc plugin will produce a jar. If it doesn't produce a jar,
+ * then the Sonatype repository manager issues an error.
+ *
+ * @author Chris Povirk
+ */
+class DummyJavadocClass {}

--- a/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -33,6 +33,8 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
 
   abstract boolean allowsSelfLoops();
 
+  abstract ElementOrder<Integer> incidentEdgeOrder();
+
   @After
   public void validateUndirectedEdges() {
     for (Integer node : graph.nodes()) {
@@ -240,6 +242,82 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.outDegree(N1)).isEqualTo(2);
     putEdge(N2, N1);
     assertThat(graph.outDegree(N1)).isEqualTo(3);
+  }
+
+  // Stable order tests
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void stableIncidentEdgeOrder_edges_returnsInStableOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.edges())
+        .containsExactly(
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3),
+            EndpointPair.unordered(4, 5))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_adjacentNodes_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_predecessors_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_successors_returnsInConnectingEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
+  }
+
+  // Note: Stable order means that the ordering doesn't change between iterations and versions.
+  // Ideally, the ordering in test should never be updated.
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+
+    populateTShapedGraph();
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  /**
+   * Populates the graph with nodes and edges in a star shape with node `1` in the middle.
+   *
+   * <p>Note that the edges are added in a shuffled order to properly test the effect of the
+   * insertion order.
+   */
+  private void populateTShapedGraph() {
+    putEdge(2, 1);
+    putEdge(1, 4);
+    putEdge(1, 3);
+    putEdge(1, 2); // Duplicate
+    putEdge(4, 5);
   }
 
   // Element Mutation

--- a/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -122,4 +122,20 @@ public class ImmutableValueGraphTest {
     assertThat(graph.edges()).containsExactly(EndpointPair.ordered("A", "B"));
     assertThat(graph.edgeValueOrDefault("A", "B", null)).isEqualTo(10);
   }
+
+  @Test
+  public void immutableValueGraphBuilder_incidentEdges_preservesIncidentEdgesOrder() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed()
+            .<Integer, String>immutable()
+            .putEdgeValue(2, 1, "2-1")
+            .putEdgeValue(2, 3, "2-3")
+            .putEdgeValue(1, 2, "1-2")
+            .build();
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
 }

--- a/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.graph;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+@AndroidIncompatible
+@RunWith(Parameterized.class)
+public final class StandardImmutableUndirectedGraphTest
+    extends AbstractStandardUndirectedGraphTest {
+
+  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[][] {
+          {false, ElementOrder.unordered()},
+          {true, ElementOrder.unordered()},
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()}
+        });
+  }
+
+  private final boolean allowsSelfLoops;
+  private final ElementOrder<Integer> incidentEdgeOrder;
+  private ImmutableGraph.Builder<Integer> graphBuilder;
+
+  public StandardImmutableUndirectedGraphTest(
+      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+    this.allowsSelfLoops = allowsSelfLoops;
+    this.incidentEdgeOrder = incidentEdgeOrder;
+  }
+
+  @Override
+  boolean allowsSelfLoops() {
+    return allowsSelfLoops;
+  }
+
+  @Override
+  ElementOrder<Integer> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
+  public Graph<Integer> createGraph() {
+    graphBuilder =
+        GraphBuilder.undirected()
+            .allowsSelfLoops(allowsSelfLoops())
+            .incidentEdgeOrder(incidentEdgeOrder)
+            .immutable();
+    return graphBuilder.build();
+  }
+
+  @Override
+  final void addNode(Integer n) {
+    graphBuilder.addNode(n);
+    graph = graphBuilder.build();
+  }
+
+  @Override
+  final void putEdge(Integer n1, Integer n2) {
+    graphBuilder.putEdge(n1, n2);
+    graph = graphBuilder.build();
+  }
+}

--- a/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -60,7 +60,7 @@ public final class StandardMutableDirectedGraphTest extends AbstractStandardDire
   @Override
   public MutableGraph<Integer> createGraph() {
     return GraphBuilder.directed()
-        .allowsSelfLoops(allowsSelfLoops())
+        .allowsSelfLoops(allowsSelfLoops)
         .incidentEdgeOrder(incidentEdgeOrder)
         .build();
   }

--- a/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -27,18 +27,24 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}")
+  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(
         new Object[][] {
-          {false}, {true},
+          {false, ElementOrder.unordered()},
+          {true, ElementOrder.unordered()},
+          {false, ElementOrder.stable()},
+          {true, ElementOrder.stable()},
         });
   }
 
   private final boolean allowsSelfLoops;
+  private final ElementOrder<Integer> incidentEdgeOrder;
 
-  public StandardMutableUndirectedGraphTest(boolean allowsSelfLoops) {
+  public StandardMutableUndirectedGraphTest(
+      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
     this.allowsSelfLoops = allowsSelfLoops;
+    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -47,8 +53,16 @@ public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirect
   }
 
   @Override
+  ElementOrder<Integer> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
   public MutableGraph<Integer> createGraph() {
-    return GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).build();
+    return GraphBuilder.undirected()
+        .allowsSelfLoops(allowsSelfLoops)
+        .incidentEdgeOrder(incidentEdgeOrder)
+        .build();
   }
 
   @Override

--- a/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -399,6 +399,19 @@ public final class ValueGraphTest {
   }
 
   @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(1, 2, "1-2");
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
   public void concurrentIteration() throws Exception {
     graph = ValueGraphBuilder.directed().build();
     graph.putEdgeValue(1, 2, "A");

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -1677,6 +1677,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
    * This method is a convenience for testing. Code should call {@link Segment#copyEntry} directly.
    */
   // Guarded By Segment.this
+  @SuppressWarnings("GuardedBy")
   @VisibleForTesting
   ReferenceEntry<K, V> copyEntry(ReferenceEntry<K, V> original, ReferenceEntry<K, V> newNext) {
     int hash = original.getHash();

--- a/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -171,6 +171,6 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
   private GraphConnections<N, V> newConnections() {
     return isDirected()
         ? DirectedGraphConnections.<N, V>of(incidentEdgeOrder)
-        : UndirectedGraphConnections.<N, V>of();
+        : UndirectedGraphConnections.<N, V>of(incidentEdgeOrder);
   }
 }

--- a/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -125,7 +125,10 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
     private final MutableValueGraph<N, V> mutableValueGraph;
 
     Builder(ValueGraphBuilder<N, V> graphBuilder) {
-      this.mutableValueGraph = graphBuilder.build();
+      // The incidentEdgeOrder for immutable graphs is always stable. However, we don't want to
+      // modify this builder, so we make a copy instead.
+      this.mutableValueGraph =
+          graphBuilder.copy().incidentEdgeOrder(ElementOrder.<N>stable()).build();
     }
 
     /**

--- a/guava/src/com/google/common/graph/UndirectedGraphConnections.java
+++ b/guava/src/com/google/common/graph/UndirectedGraphConnections.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Iterators;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,8 +44,17 @@ final class UndirectedGraphConnections<N, V> implements GraphConnections<N, V> {
     this.adjacentNodeValues = checkNotNull(adjacentNodeValues);
   }
 
-  static <N, V> UndirectedGraphConnections<N, V> of() {
-    return new UndirectedGraphConnections<>(new HashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+  static <N, V> UndirectedGraphConnections<N, V> of(ElementOrder<N> incidentEdgeOrder) {
+    switch (incidentEdgeOrder.type()) {
+      case UNORDERED:
+        return new UndirectedGraphConnections<>(
+            new HashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+      case STABLE:
+        return new UndirectedGraphConnections<>(
+            new LinkedHashMap<N, V>(INNER_CAPACITY, INNER_LOAD_FACTOR));
+      default:
+        throw new AssertionError(incidentEdgeOrder.type());
+    }
   }
 
   static <N, V> UndirectedGraphConnections<N, V> ofImmutable(Map<N, V> adjacentNodeValues) {

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -16,6 +16,7 @@
 
 package com.google.common.graph;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.graph.Graphs.checkNonNegative;
 
@@ -94,6 +95,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return new ValueGraphBuilder<N, V>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
         .nodeOrder(graph.nodeOrder());
+    // TODO(b/142723300): Add incidentEdgeOrder
   }
 
   /**
@@ -101,6 +103,9 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * ValueGraphBuilder}.
    *
    * <p>The returned builder can be used for populating an {@link ImmutableValueGraph}.
+   *
+   * <p>Note that the returned builder will always have {@link #incidentEdgeOrder} set to {@link
+   * ElementOrder#stable()}, regardless of the value that was set in this builder.
    *
    * @since 28.0
    */
@@ -142,6 +147,30 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return newBuilder;
   }
 
+  /**
+   * Specifies the order of iteration for the elements of {@link ValueGraph#edges()}, {@link
+   * ValueGraph#adjacentNodes(Object)}, {@link ValueGraph#predecessors(Object)}, {@link
+   * ValueGraph#successors(Object)} and {@link ValueGraph#incidentEdges(Object)}.
+   *
+   * <p>The default value is {@link ElementOrder#unordered() unordered} for mutable graphs. For
+   * immutable graphs, this value is ignored; they always have a {@link ElementOrder#stable()
+   * stable} order.
+   *
+   * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
+   *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
+   */
+  // TODO(b/142723300): Make this method public
+  <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+    checkArgument(
+        incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
+            || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,
+        "The given elementOrder (%s) is unsupported. incidentEdgeOrder() only supports"
+            + " ElementOrder.unordered() and ElementOrder.stable().",
+        incidentEdgeOrder);
+    ValueGraphBuilder<N1, V> newBuilder = cast();
+    newBuilder.incidentEdgeOrder = checkNotNull(incidentEdgeOrder);
+    return newBuilder;
+  }
   /**
    * Returns an empty {@link MutableValueGraph} with the properties of this {@link
    * ValueGraphBuilder}.

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -179,6 +179,15 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
     return new ConfigurableMutableValueGraph<>(this);
   }
 
+  ValueGraphBuilder<N, V> copy() {
+    ValueGraphBuilder<N, V> newBuilder = new ValueGraphBuilder<>(directed);
+    newBuilder.allowsSelfLoops = allowsSelfLoops;
+    newBuilder.nodeOrder = nodeOrder;
+    newBuilder.expectedNodeCount = expectedNodeCount;
+    newBuilder.incidentEdgeOrder = incidentEdgeOrder;
+    return newBuilder;
+  }
+
   @SuppressWarnings("unchecked")
   private <N1 extends N, V1 extends V> ValueGraphBuilder<N1, V1> cast() {
     return (ValueGraphBuilder<N1, V1>) this;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ensure that we generate a non-empty Javadoc jar for guava-gwt.

Without it, we get an error during Sonatype deployment:
  Missing: no javadoc jar found in folder '/com/google/guava/guava-gwt/28.2-jre'

I hacked around this on the GitHub release branch for 28.2 by reenabling Javadoc:
https://github.com/google/guava/commit/a1b3c06876803a0b0e5d2f16708e1328da1bac09

But as you may recall from CL 276327335, we're soon going to have no classes to generate Javadoc for (after we remove GWT-RPC support). So even with Javadoc generation enabled, we'd end up with no jar.

To ensure that we get a jar, I've introduced a package-private dummy class (and then excluded it from the other steps in which source files are used).

80210f266950156ccd1eb56d18af7552f41dd274

-------

<p> ValueGraph: Support incidentEdgeOrder=stable

f05442beb167e9e7953022983f3885cb219d9968

-------

<p> ImmutableValueGraph: Support incidentEdgeOrder=stable

RELNOTES=N/A

12b0521095bde73b06c13ccd9558be10cd648d4f

-------

<p> Graph: Support stable incidentEdgeOrder for undirected graphs

e541ab5ee31f86733a0bfa0caa11f872292f51cd

-------

<p> Add StandardImmutableUndirectedGraphTest

5fddc483ad638b46badddcc44ca0501b9a185c5c

-------

<p> Suppress GuardedBy violation in LocalCache.

This looks like it's just for testing, which I think makes it /probably OK/, but feel free to suggest otherwise.

db04af06932fe7ff009a7903e44471e945ea057d