### PR TITLE
MOE Sync 2020-01-08

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -306,6 +304,25 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
             EndpointPair.ordered(5, 1),
             EndpointPair.ordered(1, 2),
             EndpointPair.ordered(3, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+    putEdge(1, 2);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 1),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
         .inOrder();
   }
 

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -302,6 +300,23 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
         .containsExactly(
             EndpointPair.unordered(1, 2),
             EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(2, 1),
+            EndpointPair.unordered(1, 1),
             EndpointPair.unordered(1, 3))
         .inOrder();
   }

--- a/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -339,7 +339,7 @@ public final class ValueGraphTest {
   }
 
   @Test
-  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_directed() {
     graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
     graph.putEdgeValue(2, 1, "2-1");
     graph.putEdgeValue(2, 3, "2-3");
@@ -348,6 +348,22 @@ public final class ValueGraphTest {
     assertThat(graph.incidentEdges(2))
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_undirected() {
+    graph = ValueGraphBuilder.undirected().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 4, "2-4");
+    graph.putEdgeValue(1, 2, "1-2"); // Duplicate nodes, different value
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.unordered(2, 3),
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(2, 4))
         .inOrder();
   }
 

--- a/android/guava/src/com/google/common/base/Platform.java
+++ b/android/guava/src/com/google/common/base/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.base;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -103,18 +100,5 @@ final class Platform {
     }
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 }

--- a/android/guava/src/com/google/common/collect/Platform.java
+++ b/android/guava/src/com/google/common/collect/Platform.java
@@ -16,9 +16,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -112,20 +109,7 @@ final class Platform {
     return exponent;
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 
   private Platform() {}
 }

--- a/android/guava/src/com/google/common/primitives/Longs.java
+++ b/android/guava/src/com/google/common/primitives/Longs.java
@@ -328,10 +328,10 @@ public final class Longs {
     static {
       byte[] result = new byte[128];
       Arrays.fill(result, (byte) -1);
-      for (int i = 0; i <= 9; i++) {
+      for (int i = 0; i < 10; i++) {
         result['0' + i] = (byte) i;
       }
-      for (int i = 0; i <= 26; i++) {
+      for (int i = 0; i < 26; i++) {
         result['A' + i] = (byte) (10 + i);
         result['a' + i] = (byte) (10 + i);
       }

--- a/android/guava/src/com/google/common/primitives/Platform.java
+++ b/android/guava/src/com/google/common/primitives/Platform.java
@@ -14,28 +14,12 @@
 
 package com.google.common.primitives;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 
 /** Methods factored out so that they can be emulated differently in GWT. */
 @GwtCompatible(emulated = true)
 final class Platform {
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 
   private Platform() {}
 }

--- a/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -306,6 +304,25 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
             EndpointPair.ordered(5, 1),
             EndpointPair.ordered(1, 2),
             EndpointPair.ordered(3, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+    putEdge(1, 2);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 1),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
         .inOrder();
   }
 

--- a/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -302,6 +300,23 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
         .containsExactly(
             EndpointPair.unordered(1, 2),
             EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(2, 1),
+            EndpointPair.unordered(1, 1),
             EndpointPair.unordered(1, 3))
         .inOrder();
   }

--- a/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -399,7 +399,7 @@ public final class ValueGraphTest {
   }
 
   @Test
-  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_directed() {
     graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
     graph.putEdgeValue(2, 1, "2-1");
     graph.putEdgeValue(2, 3, "2-3");
@@ -408,6 +408,22 @@ public final class ValueGraphTest {
     assertThat(graph.incidentEdges(2))
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_undirected() {
+    graph = ValueGraphBuilder.undirected().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 4, "2-4");
+    graph.putEdgeValue(1, 2, "1-2"); // Duplicate nodes, different value
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.unordered(2, 3),
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(2, 4))
         .inOrder();
   }
 

--- a/guava/src/com/google/common/base/Platform.java
+++ b/guava/src/com/google/common/base/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.base;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -98,22 +95,22 @@ final class Platform {
     }
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());

--- a/guava/src/com/google/common/collect/Platform.java
+++ b/guava/src/com/google/common/collect/Platform.java
@@ -16,9 +16,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -115,22 +112,22 @@ final class Platform {
     return exponent;
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          com.google.common.base.Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -330,10 +330,10 @@ public final class Longs {
     static {
       byte[] result = new byte[128];
       Arrays.fill(result, (byte) -1);
-      for (int i = 0; i <= 9; i++) {
+      for (int i = 0; i < 10; i++) {
         result['0' + i] = (byte) i;
       }
-      for (int i = 0; i <= 26; i++) {
+      for (int i = 0; i < 26; i++) {
         result['A' + i] = (byte) (10 + i);
         result['a' + i] = (byte) (10 + i);
       }

--- a/guava/src/com/google/common/primitives/Platform.java
+++ b/guava/src/com/google/common/primitives/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.primitives;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 
 /** Methods factored out so that they can be emulated differently in GWT. */
@@ -25,22 +22,22 @@ final class Platform {
   private static final java.util.logging.Logger logger =
       java.util.logging.Logger.getLogger(Platform.class.getName());
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          com.google.common.base.Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add test case stable incidentEdgeOrder with a self loop to AbstractStandard[Un]directedGraphTest.

aee54682770a3166c231bbfecced91f31c55d32a

-------

<p> Add test for stable incidentEdgeOrder support for mutable undirected valuegraphs in ValueGraphTest

0aba85dd247e254e10fcd84e7b2940fa0383e14e

-------

<p> Fix off-by-one error in AsciiDigits.asciiDigits initialization.

Fixes #3761.

2b27d9f906e18ae1105766d41e0940122ce686a0

-------

<p> Disable GWT-RPC by default in the open-source release.

RELNOTES=[Guava types can no longer be sent over GWT-RPC.](https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ) To _temporarily_ reenable support, set the `guava.gwt.emergency_reenable_rpc` system property to `true`.

ff0cd947f82d24611e39fb3d86e3d19da4af801f