### PR TITLE
MOE Sync 2020-01-09

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -76,6 +76,10 @@ public abstract class AbstractGraphTest {
   /** Creates and returns an instance of the graph to be tested. */
   abstract Graph<Integer> createGraph();
 
+  abstract boolean allowsSelfLoops();
+
+  abstract ElementOrder<Integer> incidentEdgeOrder();
+
   /**
    * A proxy method that adds the node {@code n} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
@@ -222,6 +226,11 @@ public abstract class AbstractGraphTest {
   @Test
   public void nodes_noNodes() {
     assertThat(graph.nodes()).isEmpty();
+  }
+
+  @Test
+  public void incidentEdgeOrder_matchesTheValueAtConstruction() {
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(incidentEdgeOrder());
   }
 
   @Test

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -306,6 +304,25 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
             EndpointPair.ordered(5, 1),
             EndpointPair.ordered(1, 2),
             EndpointPair.ordered(3, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+    putEdge(1, 2);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 1),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
         .inOrder();
   }
 

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -30,10 +30,6 @@ import org.junit.Test;
  */
 public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTest {
 
-  abstract boolean allowsSelfLoops();
-
-  abstract ElementOrder<Integer> incidentEdgeOrder();
-
   @Override
   @Test
   public void nodes_checkReturnedSetMutability() {

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -302,6 +300,23 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
         .containsExactly(
             EndpointPair.unordered(1, 2),
             EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(2, 1),
+            EndpointPair.unordered(1, 1),
             EndpointPair.unordered(1, 3))
         .inOrder();
   }

--- a/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -31,10 +31,6 @@ import org.junit.Test;
  */
 public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphTest {
 
-  abstract boolean allowsSelfLoops();
-
-  abstract ElementOrder<Integer> incidentEdgeOrder();
-
   @After
   public void validateUndirectedEdges() {
     for (Integer node : graph.nodes()) {

--- a/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -51,6 +51,25 @@ public class ImmutableValueGraphTest {
   }
 
   @Test
+  public void incidentEdgeOrder_stable() {
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
+
+    assertThat(immutableValueGraph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void incidentEdgeOrder_fromUnorderedGraph_stable() {
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(
+            ValueGraphBuilder.directed()
+                .incidentEdgeOrder(ElementOrder.unordered())
+                .<String, Integer>build());
+
+    assertThat(immutableValueGraph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
   public void immutableValueGraphBuilder_appliesGraphBuilderConfig() {
     ImmutableValueGraph<String, Integer> emptyGraph =
         ValueGraphBuilder.directed()
@@ -137,5 +156,24 @@ public class ImmutableValueGraphTest {
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
         .inOrder();
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_incidentEdgeOrder_stable() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed().<Integer, String>immutable().build();
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_fromUnorderedBuilder_incidentEdgeOrder_stable() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed()
+            .incidentEdgeOrder(ElementOrder.unordered())
+            .<Integer, String>immutable()
+            .build();
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
   }
 }

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -27,25 +27,16 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public final class StandardImmutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  @Parameters(name = "allowsSelfLoops={0}")
   public static Collection<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[][] {
-          {false, ElementOrder.unordered()},
-          {true, ElementOrder.unordered()},
-          {false, ElementOrder.stable()},
-          {true, ElementOrder.stable()}
-        });
+    return Arrays.asList(new Object[][] {{false}, {true}});
   }
 
   private final boolean allowsSelfLoops;
-  private final ElementOrder<Integer> incidentEdgeOrder;
   private ImmutableGraph.Builder<Integer> graphBuilder;
 
-  public StandardImmutableDirectedGraphTest(
-      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+  public StandardImmutableDirectedGraphTest(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
-    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -55,16 +46,12 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
 
   @Override
   ElementOrder<Integer> incidentEdgeOrder() {
-    return incidentEdgeOrder;
+    return ElementOrder.stable();
   }
 
   @Override
   public Graph<Integer> createGraph() {
-    graphBuilder =
-        GraphBuilder.directed()
-            .allowsSelfLoops(allowsSelfLoops())
-            .incidentEdgeOrder(incidentEdgeOrder)
-            .immutable();
+    graphBuilder = GraphBuilder.directed().allowsSelfLoops(allowsSelfLoops()).immutable();
     return graphBuilder.build();
   }
 

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableGraphAdditionalTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableGraphAdditionalTest.java
@@ -87,6 +87,22 @@ public class StandardImmutableGraphAdditionalTest {
   }
 
   @Test
+  public void copyOf_incidentEdgeOrder() {
+    ImmutableGraph<Object> graph = ImmutableGraph.copyOf(GraphBuilder.undirected().build());
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void copyOf_fromUnorderedGraph_incidentEdgeOrder() {
+    ImmutableGraph<Object> graph =
+        ImmutableGraph.copyOf(
+            GraphBuilder.undirected().incidentEdgeOrder(ElementOrder.unordered()).build());
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
   public void immutableGraphBuilder_addNode() {
     ImmutableGraph<String> graph = GraphBuilder.directed().<String>immutable().addNode("A").build();
 

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -28,25 +28,16 @@ import org.junit.runners.Parameterized.Parameters;
 public final class StandardImmutableUndirectedGraphTest
     extends AbstractStandardUndirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  @Parameters(name = "allowsSelfLoops={0}")
   public static Collection<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[][] {
-          {false, ElementOrder.unordered()},
-          {true, ElementOrder.unordered()},
-          {false, ElementOrder.stable()},
-          {true, ElementOrder.stable()}
-        });
+    return Arrays.asList(new Object[][] {{false}, {true}});
   }
 
   private final boolean allowsSelfLoops;
-  private final ElementOrder<Integer> incidentEdgeOrder;
   private ImmutableGraph.Builder<Integer> graphBuilder;
 
-  public StandardImmutableUndirectedGraphTest(
-      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+  public StandardImmutableUndirectedGraphTest(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
-    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -56,16 +47,12 @@ public final class StandardImmutableUndirectedGraphTest
 
   @Override
   ElementOrder<Integer> incidentEdgeOrder() {
-    return incidentEdgeOrder;
+    return ElementOrder.stable();
   }
 
   @Override
   public Graph<Integer> createGraph() {
-    graphBuilder =
-        GraphBuilder.undirected()
-            .allowsSelfLoops(allowsSelfLoops())
-            .incidentEdgeOrder(incidentEdgeOrder)
-            .immutable();
+    graphBuilder = GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).immutable();
     return graphBuilder.build();
   }
 

--- a/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -339,7 +339,7 @@ public final class ValueGraphTest {
   }
 
   @Test
-  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_directed() {
     graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
     graph.putEdgeValue(2, 1, "2-1");
     graph.putEdgeValue(2, 3, "2-3");
@@ -348,6 +348,22 @@ public final class ValueGraphTest {
     assertThat(graph.incidentEdges(2))
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_undirected() {
+    graph = ValueGraphBuilder.undirected().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 4, "2-4");
+    graph.putEdgeValue(1, 2, "1-2"); // Duplicate nodes, different value
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.unordered(2, 3),
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(2, 4))
         .inOrder();
   }
 

--- a/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -51,6 +51,7 @@ public final class ValueGraphTest {
     assertThat(graph.nodes()).isEqualTo(asGraph.nodes());
     assertThat(graph.edges()).isEqualTo(asGraph.edges());
     assertThat(graph.nodeOrder()).isEqualTo(asGraph.nodeOrder());
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(asGraph.incidentEdgeOrder());
     assertThat(graph.isDirected()).isEqualTo(asGraph.isDirected());
     assertThat(graph.allowsSelfLoops()).isEqualTo(asGraph.allowsSelfLoops());
 
@@ -118,6 +119,18 @@ public final class ValueGraphTest {
     assertThat(toString).contains("valueB");
     assertThat(toString).contains("valueC");
     assertThat(toString).contains("valueD");
+  }
+
+  @Test
+  public void incidentEdgeOrder_unordered() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.unordered()).build();
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.unordered());
+  }
+
+  @Test
+  public void incidentEdgeOrder_stable() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
   }
 
   @Test

--- a/android/guava/src/com/google/common/base/Platform.java
+++ b/android/guava/src/com/google/common/base/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.base;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -103,18 +100,5 @@ final class Platform {
     }
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 }

--- a/android/guava/src/com/google/common/collect/Platform.java
+++ b/android/guava/src/com/google/common/collect/Platform.java
@@ -16,9 +16,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -112,20 +109,7 @@ final class Platform {
     return exponent;
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 
   private Platform() {}
 }

--- a/android/guava/src/com/google/common/graph/AbstractBaseGraph.java
+++ b/android/guava/src/com/google/common/graph/AbstractBaseGraph.java
@@ -98,6 +98,11 @@ abstract class AbstractBaseGraph<N> implements BaseGraph<N> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.unordered();
+  }
+
+  @Override
   public Set<EndpointPair<N>> incidentEdges(N node) {
     checkNotNull(node);
     checkArgument(nodes().contains(node), "Node %s is not an element of this graph.", node);

--- a/android/guava/src/com/google/common/graph/AbstractNetwork.java
+++ b/android/guava/src/com/google/common/graph/AbstractNetwork.java
@@ -107,6 +107,13 @@ public abstract class AbstractNetwork<N, E> implements Network<N, E> {
       }
 
       @Override
+      public ElementOrder<N> incidentEdgeOrder() {
+        // TODO(b/142723300): Return AbstractNetwork.this.incidentEdgeOrder() once Network has that
+        //   method.
+        return ElementOrder.unordered();
+      }
+
+      @Override
       public boolean isDirected() {
         return AbstractNetwork.this.isDirected();
       }

--- a/android/guava/src/com/google/common/graph/AbstractValueGraph.java
+++ b/android/guava/src/com/google/common/graph/AbstractValueGraph.java
@@ -68,6 +68,11 @@ public abstract class AbstractValueGraph<N, V> extends AbstractBaseGraph<N>
       }
 
       @Override
+      public ElementOrder<N> incidentEdgeOrder() {
+        return AbstractValueGraph.this.incidentEdgeOrder();
+      }
+
+      @Override
       public Set<N> adjacentNodes(N node) {
         return AbstractValueGraph.this.adjacentNodes(node);
       }

--- a/android/guava/src/com/google/common/graph/BaseGraph.java
+++ b/android/guava/src/com/google/common/graph/BaseGraph.java
@@ -56,6 +56,13 @@ interface BaseGraph<N> extends SuccessorsFunction<N>, PredecessorsFunction<N> {
   /** Returns the order of iteration for the elements of {@link #nodes()}. */
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -50,6 +50,11 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
   @CanIgnoreReturnValue
   public boolean addNode(N node) {
     checkNotNull(node, "node");

--- a/android/guava/src/com/google/common/graph/ElementOrder.java
+++ b/android/guava/src/com/google/common/graph/ElementOrder.java
@@ -116,8 +116,7 @@ public final class ElementOrder<T> {
    *       </ul>
    * </ul>
    */
-  // TODO(b/142723300): Make this method public
-  static <S> ElementOrder<S> stable() {
+  public static <S> ElementOrder<S> stable() {
     return new ElementOrder<S>(Type.STABLE, null);
   }
 

--- a/android/guava/src/com/google/common/graph/ForwardingGraph.java
+++ b/android/guava/src/com/google/common/graph/ForwardingGraph.java
@@ -58,6 +58,11 @@ abstract class ForwardingGraph<N> extends AbstractGraph<N> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return delegate().incidentEdgeOrder();
+  }
+
+  @Override
   public Set<N> adjacentNodes(N node) {
     return delegate().adjacentNodes(node);
   }

--- a/android/guava/src/com/google/common/graph/ForwardingValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ForwardingValueGraph.java
@@ -60,6 +60,11 @@ abstract class ForwardingValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return delegate().incidentEdgeOrder();
+  }
+
+  @Override
   public Set<N> adjacentNodes(N node) {
     return delegate().adjacentNodes(node);
   }

--- a/android/guava/src/com/google/common/graph/Graph.java
+++ b/android/guava/src/com/google/common/graph/Graph.java
@@ -140,6 +140,14 @@ public interface Graph<N> extends BaseGraph<N> {
   @Override
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  @Override
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -155,8 +155,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
    *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
    */
-  // TODO(b/142723300): Make this method public
-  <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+  public <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
     checkArgument(
         incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
             || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -91,8 +91,8 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   public static <N> GraphBuilder<N> from(Graph<N> graph) {
     return new GraphBuilder<N>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
-        .nodeOrder(graph.nodeOrder());
-    // TODO(b/142723300): Add incidentEdgeOrder
+        .nodeOrder(graph.nodeOrder())
+        .incidentEdgeOrder(graph.incidentEdgeOrder());
   }
 
   /**

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -72,6 +72,11 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return checkNotNull(graph);
   }
 
+  @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.stable();
+  }
+
   private static <N> ImmutableMap<N, GraphConnections<N, Presence>> getNodeConnections(
       Graph<N> graph) {
     // ImmutableMap.Builder maintains the order of the elements as inserted, so the map will have

--- a/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -67,6 +67,11 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.stable();
+  }
+
+  @Override
   public ImmutableGraph<N> asGraph() {
     return new ImmutableGraph<N>(this); // safe because the view is effectively immutable
   }

--- a/android/guava/src/com/google/common/graph/ValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ValueGraph.java
@@ -150,6 +150,14 @@ public interface ValueGraph<N, V> extends BaseGraph<N> {
   @Override
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  @Override
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -159,8 +159,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
    *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
    */
-  // TODO(b/142723300): Make this method public
-  <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+  public <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(
+      ElementOrder<N1> incidentEdgeOrder) {
     checkArgument(
         incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
             || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -94,8 +94,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   public static <N, V> ValueGraphBuilder<N, V> from(ValueGraph<N, V> graph) {
     return new ValueGraphBuilder<N, V>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
-        .nodeOrder(graph.nodeOrder());
-    // TODO(b/142723300): Add incidentEdgeOrder
+        .nodeOrder(graph.nodeOrder())
+        .incidentEdgeOrder(graph.incidentEdgeOrder());
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Longs.java
+++ b/android/guava/src/com/google/common/primitives/Longs.java
@@ -328,10 +328,10 @@ public final class Longs {
     static {
       byte[] result = new byte[128];
       Arrays.fill(result, (byte) -1);
-      for (int i = 0; i <= 9; i++) {
+      for (int i = 0; i < 10; i++) {
         result['0' + i] = (byte) i;
       }
-      for (int i = 0; i <= 26; i++) {
+      for (int i = 0; i < 26; i++) {
         result['A' + i] = (byte) (10 + i);
         result['a' + i] = (byte) (10 + i);
       }

--- a/android/guava/src/com/google/common/primitives/Platform.java
+++ b/android/guava/src/com/google/common/primitives/Platform.java
@@ -14,28 +14,12 @@
 
 package com.google.common.primitives;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 
 /** Methods factored out so that they can be emulated differently in GWT. */
 @GwtCompatible(emulated = true)
 final class Platform {
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
-  static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
-      throw new UnsupportedOperationException(
-          lenientFormat(
-              "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
-                  + " support by setting the system property %s to true. For more about system"
-                  + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
-              "https://stackoverflow.com/q/5189914/28465",
-              "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
-    }
-  }
+  static void checkGwtRpcEnabled() {}
 
   private Platform() {}
 }

--- a/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractGraphTest.java
@@ -76,6 +76,10 @@ public abstract class AbstractGraphTest {
   /** Creates and returns an instance of the graph to be tested. */
   abstract Graph<Integer> createGraph();
 
+  abstract boolean allowsSelfLoops();
+
+  abstract ElementOrder<Integer> incidentEdgeOrder();
+
   /**
    * A proxy method that adds the node {@code n} to the graph being tested. In case of Immutable
    * graph implementations, this method should replace {@link #graph} with a new graph that includes
@@ -222,6 +226,11 @@ public abstract class AbstractGraphTest {
   @Test
   public void nodes_noNodes() {
     assertThat(graph.nodes()).isEmpty();
+  }
+
+  @Test
+  public void incidentEdgeOrder_matchesTheValueAtConstruction() {
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(incidentEdgeOrder());
   }
 
   @Test

--- a/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
     assertThat(graph.successors(1)).containsExactly(4, 3, 2).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -306,6 +304,25 @@ public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTes
             EndpointPair.ordered(5, 1),
             EndpointPair.ordered(1, 2),
             EndpointPair.ordered(3, 1))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+    putEdge(1, 2);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.ordered(2, 1),
+            EndpointPair.ordered(1, 1),
+            EndpointPair.ordered(1, 3),
+            EndpointPair.ordered(1, 2))
         .inOrder();
   }
 

--- a/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardDirectedGraphTest.java
@@ -30,10 +30,6 @@ import org.junit.Test;
  */
 public abstract class AbstractStandardDirectedGraphTest extends AbstractGraphTest {
 
-  abstract boolean allowsSelfLoops();
-
-  abstract ElementOrder<Integer> incidentEdgeOrder();
-
   @Override
   @Test
   public void nodes_checkReturnedSetMutability() {

--- a/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -290,8 +290,6 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
     assertThat(graph.adjacentNodes(1)).containsExactly(2, 4, 3).inOrder();
   }
 
-  // Note: Stable order means that the ordering doesn't change between iterations and versions.
-  // Ideally, the ordering in test should never be updated.
   @Test
   public void stableIncidentEdgeOrder_incidentEdges_returnsInEdgeInsertionOrder() {
     assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
@@ -302,6 +300,23 @@ public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphT
         .containsExactly(
             EndpointPair.unordered(1, 2),
             EndpointPair.unordered(1, 4),
+            EndpointPair.unordered(1, 3))
+        .inOrder();
+  }
+
+  @Test
+  public void stableIncidentEdgeOrder_incidentEdges_withSelfLoop_returnsInEdgeInsertionOrder() {
+    assume().that(incidentEdgeOrder().type()).isEqualTo(ElementOrder.Type.STABLE);
+    assume().that(allowsSelfLoops()).isTrue();
+
+    putEdge(2, 1);
+    putEdge(1, 1);
+    putEdge(1, 3);
+
+    assertThat(graph.incidentEdges(1))
+        .containsExactly(
+            EndpointPair.unordered(2, 1),
+            EndpointPair.unordered(1, 1),
             EndpointPair.unordered(1, 3))
         .inOrder();
   }

--- a/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/AbstractStandardUndirectedGraphTest.java
@@ -31,10 +31,6 @@ import org.junit.Test;
  */
 public abstract class AbstractStandardUndirectedGraphTest extends AbstractGraphTest {
 
-  abstract boolean allowsSelfLoops();
-
-  abstract ElementOrder<Integer> incidentEdgeOrder();
-
   @After
   public void validateUndirectedEdges() {
     for (Integer node : graph.nodes()) {

--- a/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ImmutableValueGraphTest.java
@@ -51,6 +51,25 @@ public class ImmutableValueGraphTest {
   }
 
   @Test
+  public void incidentEdgeOrder_stable() {
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(ValueGraphBuilder.directed().<String, Integer>build());
+
+    assertThat(immutableValueGraph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void incidentEdgeOrder_fromUnorderedGraph_stable() {
+    ImmutableValueGraph<String, Integer> immutableValueGraph =
+        ImmutableValueGraph.copyOf(
+            ValueGraphBuilder.directed()
+                .incidentEdgeOrder(ElementOrder.unordered())
+                .<String, Integer>build());
+
+    assertThat(immutableValueGraph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
   public void immutableValueGraphBuilder_appliesGraphBuilderConfig() {
     ImmutableValueGraph<String, Integer> emptyGraph =
         ValueGraphBuilder.directed()
@@ -137,5 +156,24 @@ public class ImmutableValueGraphTest {
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
         .inOrder();
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_incidentEdgeOrder_stable() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed().<Integer, String>immutable().build();
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void immutableValueGraphBuilder_fromUnorderedBuilder_incidentEdgeOrder_stable() {
+    ImmutableValueGraph<Integer, String> graph =
+        ValueGraphBuilder.directed()
+            .incidentEdgeOrder(ElementOrder.unordered())
+            .<Integer, String>immutable()
+            .build();
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
   }
 }

--- a/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -27,25 +27,16 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public final class StandardImmutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  @Parameters(name = "allowsSelfLoops={0}")
   public static Collection<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[][] {
-          {false, ElementOrder.unordered()},
-          {true, ElementOrder.unordered()},
-          {false, ElementOrder.stable()},
-          {true, ElementOrder.stable()}
-        });
+    return Arrays.asList(new Object[][] {{false}, {true}});
   }
 
   private final boolean allowsSelfLoops;
-  private final ElementOrder<Integer> incidentEdgeOrder;
   private ImmutableGraph.Builder<Integer> graphBuilder;
 
-  public StandardImmutableDirectedGraphTest(
-      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+  public StandardImmutableDirectedGraphTest(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
-    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -55,16 +46,12 @@ public final class StandardImmutableDirectedGraphTest extends AbstractStandardDi
 
   @Override
   ElementOrder<Integer> incidentEdgeOrder() {
-    return incidentEdgeOrder;
+    return ElementOrder.stable();
   }
 
   @Override
   public Graph<Integer> createGraph() {
-    graphBuilder =
-        GraphBuilder.directed()
-            .allowsSelfLoops(allowsSelfLoops())
-            .incidentEdgeOrder(incidentEdgeOrder)
-            .immutable();
+    graphBuilder = GraphBuilder.directed().allowsSelfLoops(allowsSelfLoops()).immutable();
     return graphBuilder.build();
   }
 

--- a/guava-tests/test/com/google/common/graph/StandardImmutableGraphAdditionalTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableGraphAdditionalTest.java
@@ -87,6 +87,22 @@ public class StandardImmutableGraphAdditionalTest {
   }
 
   @Test
+  public void copyOf_incidentEdgeOrder() {
+    ImmutableGraph<Object> graph = ImmutableGraph.copyOf(GraphBuilder.undirected().build());
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
+  public void copyOf_fromUnorderedGraph_incidentEdgeOrder() {
+    ImmutableGraph<Object> graph =
+        ImmutableGraph.copyOf(
+            GraphBuilder.undirected().incidentEdgeOrder(ElementOrder.unordered()).build());
+
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
+  }
+
+  @Test
   public void immutableGraphBuilder_addNode() {
     ImmutableGraph<String> graph = GraphBuilder.directed().<String>immutable().addNode("A").build();
 

--- a/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -28,25 +28,16 @@ import org.junit.runners.Parameterized.Parameters;
 public final class StandardImmutableUndirectedGraphTest
     extends AbstractStandardUndirectedGraphTest {
 
-  @Parameters(name = "allowsSelfLoops={0}, incidentEdgeOrder={1}")
+  @Parameters(name = "allowsSelfLoops={0}")
   public static Collection<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[][] {
-          {false, ElementOrder.unordered()},
-          {true, ElementOrder.unordered()},
-          {false, ElementOrder.stable()},
-          {true, ElementOrder.stable()}
-        });
+    return Arrays.asList(new Object[][] {{false}, {true}});
   }
 
   private final boolean allowsSelfLoops;
-  private final ElementOrder<Integer> incidentEdgeOrder;
   private ImmutableGraph.Builder<Integer> graphBuilder;
 
-  public StandardImmutableUndirectedGraphTest(
-      boolean allowsSelfLoops, ElementOrder<Integer> incidentEdgeOrder) {
+  public StandardImmutableUndirectedGraphTest(boolean allowsSelfLoops) {
     this.allowsSelfLoops = allowsSelfLoops;
-    this.incidentEdgeOrder = incidentEdgeOrder;
   }
 
   @Override
@@ -56,16 +47,12 @@ public final class StandardImmutableUndirectedGraphTest
 
   @Override
   ElementOrder<Integer> incidentEdgeOrder() {
-    return incidentEdgeOrder;
+    return ElementOrder.stable();
   }
 
   @Override
   public Graph<Integer> createGraph() {
-    graphBuilder =
-        GraphBuilder.undirected()
-            .allowsSelfLoops(allowsSelfLoops())
-            .incidentEdgeOrder(incidentEdgeOrder)
-            .immutable();
+    graphBuilder = GraphBuilder.undirected().allowsSelfLoops(allowsSelfLoops()).immutable();
     return graphBuilder.build();
   }
 

--- a/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -399,7 +399,7 @@ public final class ValueGraphTest {
   }
 
   @Test
-  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder() {
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_directed() {
     graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
     graph.putEdgeValue(2, 1, "2-1");
     graph.putEdgeValue(2, 3, "2-3");
@@ -408,6 +408,22 @@ public final class ValueGraphTest {
     assertThat(graph.incidentEdges(2))
         .containsExactly(
             EndpointPair.ordered(2, 1), EndpointPair.ordered(2, 3), EndpointPair.ordered(1, 2))
+        .inOrder();
+  }
+
+  @Test
+  public void incidentEdges_stableIncidentEdgeOrder_preservesIncidentEdgesOrder_undirected() {
+    graph = ValueGraphBuilder.undirected().incidentEdgeOrder(ElementOrder.stable()).build();
+    graph.putEdgeValue(2, 3, "2-3");
+    graph.putEdgeValue(2, 1, "2-1");
+    graph.putEdgeValue(2, 4, "2-4");
+    graph.putEdgeValue(1, 2, "1-2"); // Duplicate nodes, different value
+
+    assertThat(graph.incidentEdges(2))
+        .containsExactly(
+            EndpointPair.unordered(2, 3),
+            EndpointPair.unordered(1, 2),
+            EndpointPair.unordered(2, 4))
         .inOrder();
   }
 

--- a/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -53,6 +53,7 @@ public final class ValueGraphTest {
     assertThat(graph.nodes()).isEqualTo(asGraph.nodes());
     assertThat(graph.edges()).isEqualTo(asGraph.edges());
     assertThat(graph.nodeOrder()).isEqualTo(asGraph.nodeOrder());
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(asGraph.incidentEdgeOrder());
     assertThat(graph.isDirected()).isEqualTo(asGraph.isDirected());
     assertThat(graph.allowsSelfLoops()).isEqualTo(asGraph.allowsSelfLoops());
 
@@ -120,6 +121,18 @@ public final class ValueGraphTest {
     assertThat(toString).contains("valueB");
     assertThat(toString).contains("valueC");
     assertThat(toString).contains("valueD");
+  }
+
+  @Test
+  public void incidentEdgeOrder_unordered() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.unordered()).build();
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.unordered());
+  }
+
+  @Test
+  public void incidentEdgeOrder_stable() {
+    graph = ValueGraphBuilder.directed().incidentEdgeOrder(ElementOrder.stable()).build();
+    assertThat(graph.incidentEdgeOrder()).isEqualTo(ElementOrder.stable());
   }
 
   @Test

--- a/guava/src/com/google/common/base/Platform.java
+++ b/guava/src/com/google/common/base/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.base;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -98,22 +95,22 @@ final class Platform {
     }
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());

--- a/guava/src/com/google/common/collect/Platform.java
+++ b/guava/src/com/google/common/collect/Platform.java
@@ -16,9 +16,6 @@
 
 package com.google.common.collect;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -115,22 +112,22 @@ final class Platform {
     return exponent;
   }
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          com.google.common.base.Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());

--- a/guava/src/com/google/common/graph/AbstractBaseGraph.java
+++ b/guava/src/com/google/common/graph/AbstractBaseGraph.java
@@ -98,6 +98,11 @@ abstract class AbstractBaseGraph<N> implements BaseGraph<N> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.unordered();
+  }
+
+  @Override
   public Set<EndpointPair<N>> incidentEdges(N node) {
     checkNotNull(node);
     checkArgument(nodes().contains(node), "Node %s is not an element of this graph.", node);

--- a/guava/src/com/google/common/graph/AbstractNetwork.java
+++ b/guava/src/com/google/common/graph/AbstractNetwork.java
@@ -108,6 +108,13 @@ public abstract class AbstractNetwork<N, E> implements Network<N, E> {
       }
 
       @Override
+      public ElementOrder<N> incidentEdgeOrder() {
+        // TODO(b/142723300): Return AbstractNetwork.this.incidentEdgeOrder() once Network has that
+        //   method.
+        return ElementOrder.unordered();
+      }
+
+      @Override
       public boolean isDirected() {
         return AbstractNetwork.this.isDirected();
       }

--- a/guava/src/com/google/common/graph/AbstractValueGraph.java
+++ b/guava/src/com/google/common/graph/AbstractValueGraph.java
@@ -69,6 +69,11 @@ public abstract class AbstractValueGraph<N, V> extends AbstractBaseGraph<N>
       }
 
       @Override
+      public ElementOrder<N> incidentEdgeOrder() {
+        return AbstractValueGraph.this.incidentEdgeOrder();
+      }
+
+      @Override
       public Set<N> adjacentNodes(N node) {
         return AbstractValueGraph.this.adjacentNodes(node);
       }

--- a/guava/src/com/google/common/graph/BaseGraph.java
+++ b/guava/src/com/google/common/graph/BaseGraph.java
@@ -56,6 +56,13 @@ interface BaseGraph<N> extends SuccessorsFunction<N>, PredecessorsFunction<N> {
   /** Returns the order of iteration for the elements of {@link #nodes()}. */
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ConfigurableMutableValueGraph.java
@@ -50,6 +50,11 @@ final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return incidentEdgeOrder;
+  }
+
+  @Override
   @CanIgnoreReturnValue
   public boolean addNode(N node) {
     checkNotNull(node, "node");

--- a/guava/src/com/google/common/graph/ElementOrder.java
+++ b/guava/src/com/google/common/graph/ElementOrder.java
@@ -115,8 +115,7 @@ public final class ElementOrder<T> {
    *       </ul>
    * </ul>
    */
-  // TODO(b/142723300): Make this method public
-  static <S> ElementOrder<S> stable() {
+  public static <S> ElementOrder<S> stable() {
     return new ElementOrder<S>(Type.STABLE, null);
   }
 

--- a/guava/src/com/google/common/graph/ForwardingGraph.java
+++ b/guava/src/com/google/common/graph/ForwardingGraph.java
@@ -58,6 +58,11 @@ abstract class ForwardingGraph<N> extends AbstractGraph<N> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return delegate().incidentEdgeOrder();
+  }
+
+  @Override
   public Set<N> adjacentNodes(N node) {
     return delegate().adjacentNodes(node);
   }

--- a/guava/src/com/google/common/graph/ForwardingValueGraph.java
+++ b/guava/src/com/google/common/graph/ForwardingValueGraph.java
@@ -61,6 +61,11 @@ abstract class ForwardingValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return delegate().incidentEdgeOrder();
+  }
+
+  @Override
   public Set<N> adjacentNodes(N node) {
     return delegate().adjacentNodes(node);
   }

--- a/guava/src/com/google/common/graph/Graph.java
+++ b/guava/src/com/google/common/graph/Graph.java
@@ -140,6 +140,14 @@ public interface Graph<N> extends BaseGraph<N> {
   @Override
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  @Override
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -155,8 +155,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
    * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
    *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
    */
-  // TODO(b/142723300): Make this method public
-  <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+  public <N1 extends N> GraphBuilder<N1> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
     checkArgument(
         incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
             || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -91,8 +91,8 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
   public static <N> GraphBuilder<N> from(Graph<N> graph) {
     return new GraphBuilder<N>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
-        .nodeOrder(graph.nodeOrder());
-    // TODO(b/142723300): Add incidentEdgeOrder
+        .nodeOrder(graph.nodeOrder())
+        .incidentEdgeOrder(graph.incidentEdgeOrder());
   }
 
   /**

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -72,6 +72,11 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return checkNotNull(graph);
   }
 
+  @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.stable();
+  }
+
   private static <N> ImmutableMap<N, GraphConnections<N, Presence>> getNodeConnections(
       Graph<N> graph) {
     // ImmutableMap.Builder maintains the order of the elements as inserted, so the map will have

--- a/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -67,6 +67,11 @@ public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V
   }
 
   @Override
+  public ElementOrder<N> incidentEdgeOrder() {
+    return ElementOrder.stable();
+  }
+
+  @Override
   public ImmutableGraph<N> asGraph() {
     return new ImmutableGraph<N>(this); // safe because the view is effectively immutable
   }

--- a/guava/src/com/google/common/graph/ValueGraph.java
+++ b/guava/src/com/google/common/graph/ValueGraph.java
@@ -151,6 +151,14 @@ public interface ValueGraph<N, V> extends BaseGraph<N> {
   @Override
   ElementOrder<N> nodeOrder();
 
+  /**
+   * Returns an {@link ElementOrder} that specifies the order of iteration for the elements of
+   * {@link #edges()}, {@link #adjacentNodes(Object)}, {@link #predecessors(Object)}, {@link
+   * #successors(Object)} and {@link #incidentEdges(Object)}.
+   */
+  @Override
+  ElementOrder<N> incidentEdgeOrder();
+
   //
   // Element-level accessors
   //

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -159,8 +159,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * @throws IllegalArgumentException if {@code incidentEdgeOrder} is not either {@code
    *     ElementOrder.unordered()} or {@code ElementOrder.stable()}.
    */
-  // TODO(b/142723300): Make this method public
-  <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(ElementOrder<N1> incidentEdgeOrder) {
+  public <N1 extends N> ValueGraphBuilder<N1, V> incidentEdgeOrder(
+      ElementOrder<N1> incidentEdgeOrder) {
     checkArgument(
         incidentEdgeOrder.type() == ElementOrder.Type.UNORDERED
             || incidentEdgeOrder.type() == ElementOrder.Type.STABLE,

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -94,8 +94,8 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
   public static <N, V> ValueGraphBuilder<N, V> from(ValueGraph<N, V> graph) {
     return new ValueGraphBuilder<N, V>(graph.isDirected())
         .allowsSelfLoops(graph.allowsSelfLoops())
-        .nodeOrder(graph.nodeOrder());
-    // TODO(b/142723300): Add incidentEdgeOrder
+        .nodeOrder(graph.nodeOrder())
+        .incidentEdgeOrder(graph.incidentEdgeOrder());
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -330,10 +330,10 @@ public final class Longs {
     static {
       byte[] result = new byte[128];
       Arrays.fill(result, (byte) -1);
-      for (int i = 0; i <= 9; i++) {
+      for (int i = 0; i < 10; i++) {
         result['0' + i] = (byte) i;
       }
-      for (int i = 0; i <= 26; i++) {
+      for (int i = 0; i < 26; i++) {
         result['A' + i] = (byte) (10 + i);
         result['a' + i] = (byte) (10 + i);
       }

--- a/guava/src/com/google/common/primitives/Platform.java
+++ b/guava/src/com/google/common/primitives/Platform.java
@@ -14,9 +14,6 @@
 
 package com.google.common.primitives;
 
-import static com.google.common.base.Strings.lenientFormat;
-import static java.lang.Boolean.parseBoolean;
-
 import com.google.common.annotations.GwtCompatible;
 
 /** Methods factored out so that they can be emulated differently in GWT. */
@@ -25,22 +22,22 @@ final class Platform {
   private static final java.util.logging.Logger logger =
       java.util.logging.Logger.getLogger(Platform.class.getName());
 
-  private static final String GWT_RPC_PROPERTY_NAME = "guava.gwt.emergency_reenable_rpc";
-
   static void checkGwtRpcEnabled() {
-    if (!parseBoolean(System.getProperty(GWT_RPC_PROPERTY_NAME, "true"))) {
+    String propertyName = "guava.gwt.emergency_reenable_rpc";
+
+    if (!Boolean.parseBoolean(System.getProperty(propertyName, "false"))) {
       throw new UnsupportedOperationException(
-          lenientFormat(
+          com.google.common.base.Strings.lenientFormat(
               "We are removing GWT-RPC support for Guava types. You can temporarily reenable"
                   + " support by setting the system property %s to true. For more about system"
                   + " properties, see %s. For more about Guava's GWT-RPC support, see %s.",
-              GWT_RPC_PROPERTY_NAME,
+              propertyName,
               "https://stackoverflow.com/q/5189914/28465",
               "https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ"));
     }
     logger.log(
         java.util.logging.Level.WARNING,
-        "In January 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
+        "Later in 2020, we will remove GWT-RPC support for Guava types. You are seeing this"
             + " warning because you are sending a Guava type over GWT-RPC, which will break. You"
             + " can identify which type by looking at the class name in the attached stack trace.",
         new Throwable());


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add test case stable incidentEdgeOrder with a self loop to AbstractStandard[Un]directedGraphTest.

845bc959a299f70f380c66fa9bf5da9459b1bdf7

-------

<p> Add test for stable incidentEdgeOrder support for mutable undirected valuegraphs in ValueGraphTest

5cc9a391837b0ac5b8e745c2bc8bdf85ff0543a8

-------

<p> Fix off-by-one error in AsciiDigits.asciiDigits initialization.

Fixes #3761.

7704a939a9910ca7f1339cbc0d65e431b8eb6bfe

-------

<p> Disable GWT-RPC by default in the open-source release.

RELNOTES=[Guava types can no longer be sent over GWT-RPC.](https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ) To _temporarily_ reenable support, set the `guava.gwt.emergency_reenable_rpc` system property to `true`.

50622528d589c17e9bd9f20841f7c35066263410

-------

<p> Add incidentEdgeOrder() to the [Value]Graph interface

RELNOTES=`graph`: Add `incidentEdgeOrder()` to the `[Value]Graph` interfaces

3446a348d5750f999cd429af57ca909b37a72655

-------

<p> Make incidentEdgeOrder() public for [Value]Graph

RELNOTES=`graph`: Allow setting a stable incident edge order by calling the newly added method `[Value]Graph.Builder.incidentEdgeOrder(ElementOrder.stable())`.

fab6309ae6cd256bd6ae826cd3eb61eb76a198f7