### PR TITLE
Add more context to the guava.dev landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,9 +3,11 @@ layout: default
 title: Guava
 ---
 
-Guava is a set of core libraries from Google that includes new collection types
+Guava is a set of core Java libraries from Google that includes new collection types
 (such as multimap and multiset), immutable collections, a graph library, and
-utilities for concurrency, I/O, hashing, primitives, strings, and more!
+utilities for concurrency, I/O, hashing, caching, primitives, strings, and more! It
+is widely used on most Java projects within Google, and widely used by many
+other companies as well.
 
 Guava comes in two flavors.
 
@@ -46,7 +48,7 @@ dependencies {
 }
 ```
 
-## Snapshots
+## Snapshots and Documentation
 
 Snapshots of Guava built from the `master` branch are available through Maven
 using version `HEAD-jre-SNAPSHOT`, or `HEAD-android-SNAPSHOT` for the Android


### PR DESCRIPTION
This change makes it clear how widely used Guava actually is; it's not just another throw-away library, it's essential to Java development with Google and many other companies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/guava/3778)
<!-- Reviewable:end -->
