### PR TITLE
Remove some settings that we don't appear to need.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,39 +4,19 @@ subtitle: Google core libraries for Java
 description: Google core libraries for Java
 baseurl: /
 url: https://guava.dev
-permalink: /news/:year/:month/:day/:title/
 
 themeColor: red
 
 exclude:
-- "Gemfile*"
-- "README.md"
-- "*.sh"
-
-# Set by default by GitHub pages (can't be changed)
-safe: true
-lsi: false
-markdown: kramdown
-kramdown:
-  input: GFM
-  hard_wrap: false
-highlighter: rouge
-gist:
-  noscript: false
-# source: <top level directory>
-
-# Set by default by GitHub pages (can be changed)
-# github: <repository metadata> (https://help.github.com/articles/repository-metadata-on-github-pages/)
-
-# Collections
-#collections:
-# releases collection disabled until there's non-Javadoc/JDiff content that needs to go there
-# Files under the releases/ directory (where the Javadoc/JDiff is kept) are included directly.
-# When there are .md files that need rendering, they should go under _releases and this collection
-# should be re-enabled.
-# releases:
-#   output: true
-#   permalink: /:collection/:path/
+  - CHANGELOG.md
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - README.md
+  - _site
+  - node_modules
+  - vendor
+  - "*.sh"
 
 # Release data
 # Do not change! updaterelease.sh automatically updates these fields


### PR DESCRIPTION
The one I really care about removing is `safe: true`.
It seems to have been required at one point but not anymore.
And `safe: true` appears to prevent plugins from working.
This is a problem when I try to use jekyll-redirect-from for b/144155774.

The rest are just to hopefully avoid future problems.
Or maybe cause them :)
But I'm encouraged that they're mostly absent from our other projects, like Truth.

Also, while here, update our exclude section to look more like what we've done for our other projects.
Compare to https://github.com/google/truth/commit/3f22311589f438e51ad2f74d3c67eb234da4ad7e