### PR TITLE
Issue #2617 add lastIndexOf(byte[] array, byte[] target)

### DIFF
--- a/guava-tests/test/com/google/common/primitives/BytesTest.java
+++ b/guava-tests/test/com/google/common/primitives/BytesTest.java
@@ -110,6 +110,38 @@ public class BytesTest extends TestCase {
         3, Bytes.lastIndexOf(new byte[] {(byte) 2, (byte) 3, (byte) 2, (byte) 3}, (byte) 3));
   }
 
+  public void testLastIndexOf_arrayTarget() {
+    assertEquals(0, Bytes.lastIndexOf(EMPTY, EMPTY));
+    assertEquals(ARRAY234.length, Bytes.lastIndexOf(ARRAY234, EMPTY));
+    assertEquals(-1, Bytes.lastIndexOf(EMPTY, ARRAY234));
+    assertEquals(-1, Bytes.lastIndexOf(ARRAY234, ARRAY1));
+    assertEquals(-1, Bytes.lastIndexOf(ARRAY1, ARRAY234));
+    assertEquals(0, Bytes.lastIndexOf(ARRAY1, ARRAY1));
+    assertEquals(0, Bytes.lastIndexOf(ARRAY234, ARRAY234));
+    assertEquals(0, Bytes.lastIndexOf(ARRAY234, new byte[] {(byte) 2, (byte) 3}));
+    assertEquals(1, Bytes.lastIndexOf(ARRAY234, new byte[] {(byte) 3, (byte) 4}));
+    assertEquals(1, Bytes.lastIndexOf(ARRAY234, new byte[] {(byte) 3}));
+    assertEquals(2, Bytes.lastIndexOf(ARRAY234, new byte[] {(byte) 4}));
+    assertEquals(
+            4,
+            Bytes.lastIndexOf(
+                    new byte[] {(byte) 2, (byte) 3, (byte) 3, (byte) 3, (byte) 3}, new byte[] {(byte) 3}));
+    assertEquals(
+            2,
+            Bytes.lastIndexOf(
+                    new byte[] {(byte) 2, (byte) 3, (byte) 2, (byte) 3, (byte) 4, (byte) 2, (byte) 3},
+                    new byte[] {(byte) 2, (byte) 3, (byte) 4}));
+    assertEquals(
+            4,
+            Bytes.lastIndexOf(
+                    new byte[] {(byte) 2, (byte) 2, (byte) 3, (byte) 4, (byte) 2, (byte) 3, (byte) 4, 4},
+                    new byte[] {(byte) 2, (byte) 3, (byte) 4}));
+    assertEquals(
+            -1,
+            Bytes.lastIndexOf(
+                    new byte[] {(byte) 4, (byte) 3, (byte) 2}, new byte[] {(byte) 2, (byte) 3, (byte) 4}));
+  }
+
   public void testConcat() {
     assertTrue(Arrays.equals(EMPTY, Bytes.concat()));
     assertTrue(Arrays.equals(EMPTY, Bytes.concat(EMPTY)));

--- a/guava/src/com/google/common/primitives/Bytes.java
+++ b/guava/src/com/google/common/primitives/Bytes.java
@@ -140,6 +140,35 @@ public final class Bytes {
     return lastIndexOf(array, target, 0, array.length);
   }
 
+  /**
+   * Returns the start position of the last occurrence of the specified {@code target} within
+   * {@code array}, or {@code -1} if there is no such occurrence.
+   *
+   * <p>More formally, returns the greatest index {@code i} such that {@code Arrays.copyOfRange(array,
+   * i, i + target.length)} contains exactly the same elements as {@code target}.
+   *
+   * @param array the array to search for the sequence {@code target}
+   * @param target the array to search for as a sub-sequence of {@code array}
+   */
+  public static int lastIndexOf(byte[] array, byte[] target) {
+    checkNotNull(array, "array");
+    checkNotNull(target, "target");
+    if (target.length == 0) {
+      return array.length;
+    }
+
+    searchFromLastChar:
+    for (int i = array.length - target.length; i >= 0; i--) {
+      for (int j = 0; j < target.length; j++) {
+        if (array[i + j] != target[j]) {
+          continue searchFromLastChar;
+        }
+      }
+      return i;
+    }
+    return -1;
+  }
+
   // TODO(kevinb): consider making this public
   private static int lastIndexOf(byte[] array, byte target, int start, int end) {
     for (int i = end - 1; i >= start; i--) {


### PR DESCRIPTION
Hi, I hope this issue still makes sense. I wanted to attempt to add the `lastIndexOf` method to the Primitive's utility classes to fix #2617. 

To try it out I've started with simple implementation of `Bytes#lastIndexOf` to gather initial feedback. I want to implement `lastIndexOf` for other classes in the same manner. Do you think it is ok or I need to consider any other approach/put some annotations/etc. ?