### PR TITLE
Simplify redundant `Collection.addALl()` call

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/CollectionTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/CollectionTestSuiteBuilder.java
@@ -91,8 +91,7 @@ public class CollectionTestSuiteBuilder<E>
   }
 
   private static Set<Feature<?>> computeReserializedCollectionFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(SERIALIZABLE);
     derivedFeatures.remove(SERIALIZABLE_INCLUDING_VIEWS);
     return derivedFeatures;

--- a/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
+++ b/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
@@ -488,8 +488,7 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<Entry<?, ?>> allEntries = new ArrayList<>();
-      allEntries.addAll(extremeValues);
+      List<Entry<?, ?>> allEntries = new ArrayList<>(extremeValues);
       for (Object entry : entries) {
         allEntries.add((Entry<?, ?>) entry);
       }

--- a/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
+++ b/guava-testlib/src/com/google/common/collect/testing/DerivedCollectionGenerators.java
@@ -488,7 +488,8 @@ public final class DerivedCollectionGenerators {
       }
 
       // the regular values should be visible after filtering
-      List<Entry<?, ?>> allEntries = new ArrayList<>(extremeValues);
+      List<Entry<?, ?>> allEntries = new ArrayList<>();
+      allEntries.addAll(extremeValues);
       for (Object entry : entries) {
         allEntries.add((Entry<?, ?>) entry);
       }

--- a/guava-testlib/src/com/google/common/collect/testing/Helpers.java
+++ b/guava-testlib/src/com/google/common/collect/testing/Helpers.java
@@ -169,8 +169,7 @@ public class Helpers {
   }
 
   public static void assertContainsAllOf(Iterable<?> actual, Object... expected) {
-    List<Object> expectedList = new ArrayList<>();
-    expectedList.addAll(Arrays.asList(expected));
+    List<Object> expectedList = new ArrayList<>(Arrays.asList(expected));
 
     for (Object o : actual) {
       expectedList.remove(o);

--- a/guava-testlib/src/com/google/common/collect/testing/ListTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/ListTestSuiteBuilder.java
@@ -148,8 +148,7 @@ public final class ListTestSuiteBuilder<E>
   }
 
   private static Set<Feature<?>> computeReserializedCollectionFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(SERIALIZABLE);
     derivedFeatures.remove(SERIALIZABLE_INCLUDING_VIEWS);
     return derivedFeatures;

--- a/guava-testlib/src/com/google/common/collect/testing/SetTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/SetTestSuiteBuilder.java
@@ -112,8 +112,7 @@ public class SetTestSuiteBuilder<E>
   }
 
   private static Set<Feature<?>> computeReserializedCollectionFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(SERIALIZABLE);
     derivedFeatures.remove(SERIALIZABLE_INCLUDING_VIEWS);
     return derivedFeatures;

--- a/guava-testlib/src/com/google/common/collect/testing/SortedSetTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/SortedSetTestSuiteBuilder.java
@@ -86,8 +86,7 @@ public class SortedSetTestSuiteBuilder<E> extends SetTestSuiteBuilder<E> {
     final TestSortedSetGenerator<E> delegate =
         (TestSortedSetGenerator<E>) parentBuilder.getSubjectGenerator().getInnerGenerator();
 
-    List<Feature<?>> features = new ArrayList<>();
-    features.addAll(parentBuilder.getFeatures());
+    List<Feature<?>> features = new ArrayList<>(parentBuilder.getFeatures());
     features.remove(CollectionFeature.ALLOWS_NULL_VALUES);
     features.add(CollectionFeature.SUBSET_VIEW);
 

--- a/guava-testlib/src/com/google/common/collect/testing/google/MultisetTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/MultisetTestSuiteBuilder.java
@@ -89,8 +89,7 @@ public class MultisetTestSuiteBuilder<E>
   }
 
   private static Set<Feature<?>> computeEntrySetFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(CollectionFeature.GENERAL_PURPOSE);
     derivedFeatures.remove(CollectionFeature.SUPPORTS_ADD);
     derivedFeatures.remove(CollectionFeature.ALLOWS_NULL_VALUES);
@@ -102,8 +101,7 @@ public class MultisetTestSuiteBuilder<E>
   }
 
   static Set<Feature<?>> computeElementSetFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(CollectionFeature.GENERAL_PURPOSE);
     derivedFeatures.remove(CollectionFeature.SUPPORTS_ADD);
     if (!derivedFeatures.remove(CollectionFeature.SERIALIZABLE_INCLUDING_VIEWS)) {
@@ -113,8 +111,7 @@ public class MultisetTestSuiteBuilder<E>
   }
 
   private static Set<Feature<?>> computeReserializedMultisetFeatures(Set<Feature<?>> features) {
-    Set<Feature<?>> derivedFeatures = new HashSet<>();
-    derivedFeatures.addAll(features);
+    Set<Feature<?>> derivedFeatures = new HashSet<>(features);
     derivedFeatures.remove(CollectionFeature.SERIALIZABLE);
     derivedFeatures.remove(CollectionFeature.SERIALIZABLE_INCLUDING_VIEWS);
     return derivedFeatures;

--- a/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/SortedMultisetTestSuiteBuilder.java
@@ -266,8 +266,7 @@ public class SortedMultisetTestSuiteBuilder<E> extends MultisetTestSuiteBuilder<
     final TestMultisetGenerator<E> delegate =
         (TestMultisetGenerator<E>) parentBuilder.getSubjectGenerator();
 
-    Set<Feature<?>> features = new HashSet<>();
-    features.addAll(parentBuilder.getFeatures());
+    Set<Feature<?>> features = new HashSet<>(parentBuilder.getFeatures());
     features.remove(SERIALIZABLE);
     features.remove(SERIALIZABLE_INCLUDING_VIEWS);
 

--- a/guava-testlib/src/com/google/common/testing/ClusterException.java
+++ b/guava-testlib/src/com/google/common/testing/ClusterException.java
@@ -67,8 +67,7 @@ final class ClusterException extends RuntimeException {
     super(
         exceptions.size() + " exceptions were thrown. The first exception is listed as a cause.",
         exceptions.iterator().next());
-    ArrayList<Throwable> temp = new ArrayList<>();
-    temp.addAll(exceptions);
+    ArrayList<Throwable> temp = new ArrayList<>(exceptions);
     this.exceptions = Collections.unmodifiableCollection(temp);
   }
 

--- a/guava-tests/test/com/google/common/collect/IteratorsTest.java
+++ b/guava-tests/test/com/google/common/collect/IteratorsTest.java
@@ -1279,8 +1279,7 @@ public class IteratorsTest extends TestCase {
   }
 
   private static Enumeration<Integer> enumerate(Integer... ints) {
-    Vector<Integer> vector = new Vector<>();
-    vector.addAll(asList(ints));
+    Vector<Integer> vector = new Vector<>(asList(ints));
     return vector.elements();
   }
 


### PR DESCRIPTION
Simplify redundant `Collection.addALl()` call and Optimize performance.