### PR TITLE
MOE Sync 2020-02-17

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for a directed {@link ConfigurableMutableGraph}. */
+/** Tests for a directed {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardImmutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {

--- a/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+/** Tests for an undirected {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardImmutableUndirectedGraphTest

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for a directed {@link ConfigurableMutableGraph}. */
+/** Tests for a directed {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardMutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {

--- a/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+/** Tests for an undirected {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirectedGraphTest {

--- a/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/android/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ConfigurableMutableValueGraph} and related functionality. */
+/** Tests for {@link StandardMutableValueGraph} and related functionality. */
 // TODO(user): Expand coverage and move to proper test suite.
 @RunWith(JUnit4.class)
 public final class ValueGraphTest {

--- a/android/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/GraphBuilder.java
@@ -169,7 +169,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
 
   /** Returns an empty {@link MutableGraph} with the properties of this {@link GraphBuilder}. */
   public <N1 extends N> MutableGraph<N1> build() {
-    return new ConfigurableMutableGraph<N1>(this);
+    return new StandardMutableGraph<N1>(this);
   }
 
   GraphBuilder<N> copy() {

--- a/android/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -58,7 +58,7 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return (graph instanceof ImmutableGraph)
         ? (ImmutableGraph<N>) graph
         : new ImmutableGraph<N>(
-            new ConfigurableValueGraph<N, Presence>(
+            new StandardValueGraph<N, Presence>(
                 GraphBuilder.from(graph), getNodeConnections(graph), graph.edges().size()));
   }
 

--- a/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -43,7 +43,7 @@ import com.google.errorprone.annotations.Immutable;
 @Beta
 @Immutable(containerOf = {"N", "V"})
 @SuppressWarnings("Immutable") // Extends ConfigurableValueGraph but uses ImmutableMaps.
-public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V> {
+public final class ImmutableValueGraph<N, V> extends StandardValueGraph<N, V> {
 
   private ImmutableValueGraph(ValueGraph<N, V> graph) {
     super(ValueGraphBuilder.from(graph), getNodeConnections(graph), graph.edges().size());

--- a/android/guava/src/com/google/common/graph/StandardMutableGraph.java
+++ b/android/guava/src/com/google/common/graph/StandardMutableGraph.java
@@ -28,12 +28,12 @@ import com.google.common.graph.GraphConstants.Presence;
  * @author James Sexton
  * @param <N> Node parameter type
  */
-final class ConfigurableMutableGraph<N> extends ForwardingGraph<N> implements MutableGraph<N> {
+final class StandardMutableGraph<N> extends ForwardingGraph<N> implements MutableGraph<N> {
   private final MutableValueGraph<N, Presence> backingValueGraph;
 
   /** Constructs a {@link MutableGraph} with the properties specified in {@code builder}. */
-  ConfigurableMutableGraph(AbstractGraphBuilder<? super N> builder) {
-    this.backingValueGraph = new ConfigurableMutableValueGraph<>(builder);
+  StandardMutableGraph(AbstractGraphBuilder<? super N> builder) {
+    this.backingValueGraph = new StandardMutableValueGraph<>(builder);
   }
 
   @Override

--- a/android/guava/src/com/google/common/graph/StandardMutableValueGraph.java
+++ b/android/guava/src/com/google/common/graph/StandardMutableValueGraph.java
@@ -38,13 +38,13 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
-final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N, V>
+final class StandardMutableValueGraph<N, V> extends StandardValueGraph<N, V>
     implements MutableValueGraph<N, V> {
 
   private final ElementOrder<N> incidentEdgeOrder;
 
   /** Constructs a mutable graph with the properties specified in {@code builder}. */
-  ConfigurableMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
+  StandardMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
     super(builder);
     incidentEdgeOrder = builder.incidentEdgeOrder.cast();
   }

--- a/android/guava/src/com/google/common/graph/StandardValueGraph.java
+++ b/android/guava/src/com/google/common/graph/StandardValueGraph.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Configurable implementation of {@link ValueGraph} that supports the options supplied by {@link
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
-class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
+class StandardValueGraph<N, V> extends AbstractValueGraph<N, V> {
   private final boolean isDirected;
   private final boolean allowsSelfLoops;
   private final ElementOrder<N> nodeOrder;
@@ -53,7 +53,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
   protected long edgeCount; // must be updated when edges are added or removed
 
   /** Constructs a graph with the properties specified in {@code builder}. */
-  ConfigurableValueGraph(AbstractGraphBuilder<? super N> builder) {
+  StandardValueGraph(AbstractGraphBuilder<? super N> builder) {
     this(
         builder,
         builder.nodeOrder.<N, GraphConnections<N, V>>createMap(
@@ -65,7 +65,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
    * Constructs a graph with the properties specified in {@code builder}, initialized with the given
    * node map.
    */
-  ConfigurableValueGraph(
+  StandardValueGraph(
       AbstractGraphBuilder<? super N> builder,
       Map<N, GraphConnections<N, V>> nodeConnections,
       long edgeCount) {
@@ -140,12 +140,14 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
-  public @Nullable V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
+  @NullableDecl
+  public V edgeValueOrDefault(N nodeU, N nodeV, @NullableDecl V defaultValue) {
     return edgeValueOrDefault_internal(checkNotNull(nodeU), checkNotNull(nodeV), defaultValue);
   }
 
   @Override
-  public @Nullable V edgeValueOrDefault(EndpointPair<N> endpoints, @Nullable V defaultValue) {
+  @NullableDecl
+  public V edgeValueOrDefault(EndpointPair<N> endpoints, @NullableDecl V defaultValue) {
     validateEndpoints(endpoints);
     return edgeValueOrDefault_internal(endpoints.nodeU(), endpoints.nodeV(), defaultValue);
   }
@@ -164,7 +166,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
     return connections;
   }
 
-  protected final boolean containsNode(@Nullable N node) {
+  protected final boolean containsNode(@NullableDecl N node) {
     return nodeConnections.containsKey(node);
   }
 

--- a/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/android/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -176,7 +176,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * ValueGraphBuilder}.
    */
   public <N1 extends N, V1 extends V> MutableValueGraph<N1, V1> build() {
-    return new ConfigurableMutableValueGraph<>(this);
+    return new StandardMutableValueGraph<>(this);
   }
 
   ValueGraphBuilder<N, V> copy() {

--- a/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableDirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for a directed {@link ConfigurableMutableGraph}. */
+/** Tests for a directed {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardImmutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {

--- a/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardImmutableUndirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+/** Tests for an undirected {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardImmutableUndirectedGraphTest

--- a/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableDirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for a directed {@link ConfigurableMutableGraph}. */
+/** Tests for a directed {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public final class StandardMutableDirectedGraphTest extends AbstractStandardDirectedGraphTest {

--- a/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/StandardMutableUndirectedGraphTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Tests for an undirected {@link ConfigurableMutableGraph}. */
+/** Tests for an undirected {@link StandardMutableGraph}. */
 @AndroidIncompatible
 @RunWith(Parameterized.class)
 public class StandardMutableUndirectedGraphTest extends AbstractStandardUndirectedGraphTest {

--- a/guava-tests/test/com/google/common/graph/ValueGraphTest.java
+++ b/guava-tests/test/com/google/common/graph/ValueGraphTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ConfigurableMutableValueGraph} and related functionality. */
+/** Tests for {@link StandardMutableValueGraph} and related functionality. */
 // TODO(user): Expand coverage and move to proper test suite.
 @RunWith(JUnit4.class)
 public final class ValueGraphTest {

--- a/guava/src/com/google/common/graph/GraphBuilder.java
+++ b/guava/src/com/google/common/graph/GraphBuilder.java
@@ -169,7 +169,7 @@ public final class GraphBuilder<N> extends AbstractGraphBuilder<N> {
 
   /** Returns an empty {@link MutableGraph} with the properties of this {@link GraphBuilder}. */
   public <N1 extends N> MutableGraph<N1> build() {
-    return new ConfigurableMutableGraph<N1>(this);
+    return new StandardMutableGraph<N1>(this);
   }
 
   GraphBuilder<N> copy() {

--- a/guava/src/com/google/common/graph/ImmutableGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableGraph.java
@@ -58,7 +58,7 @@ public class ImmutableGraph<N> extends ForwardingGraph<N> {
     return (graph instanceof ImmutableGraph)
         ? (ImmutableGraph<N>) graph
         : new ImmutableGraph<N>(
-            new ConfigurableValueGraph<N, Presence>(
+            new StandardValueGraph<N, Presence>(
                 GraphBuilder.from(graph), getNodeConnections(graph), graph.edges().size()));
   }
 

--- a/guava/src/com/google/common/graph/ImmutableValueGraph.java
+++ b/guava/src/com/google/common/graph/ImmutableValueGraph.java
@@ -43,7 +43,7 @@ import com.google.errorprone.annotations.Immutable;
 @Beta
 @Immutable(containerOf = {"N", "V"})
 @SuppressWarnings("Immutable") // Extends ConfigurableValueGraph but uses ImmutableMaps.
-public final class ImmutableValueGraph<N, V> extends ConfigurableValueGraph<N, V> {
+public final class ImmutableValueGraph<N, V> extends StandardValueGraph<N, V> {
 
   private ImmutableValueGraph(ValueGraph<N, V> graph) {
     super(ValueGraphBuilder.from(graph), getNodeConnections(graph), graph.edges().size());

--- a/guava/src/com/google/common/graph/StandardMutableGraph.java
+++ b/guava/src/com/google/common/graph/StandardMutableGraph.java
@@ -28,12 +28,12 @@ import com.google.common.graph.GraphConstants.Presence;
  * @author James Sexton
  * @param <N> Node parameter type
  */
-final class ConfigurableMutableGraph<N> extends ForwardingGraph<N> implements MutableGraph<N> {
+final class StandardMutableGraph<N> extends ForwardingGraph<N> implements MutableGraph<N> {
   private final MutableValueGraph<N, Presence> backingValueGraph;
 
   /** Constructs a {@link MutableGraph} with the properties specified in {@code builder}. */
-  ConfigurableMutableGraph(AbstractGraphBuilder<? super N> builder) {
-    this.backingValueGraph = new ConfigurableMutableValueGraph<>(builder);
+  StandardMutableGraph(AbstractGraphBuilder<? super N> builder) {
+    this.backingValueGraph = new StandardMutableValueGraph<>(builder);
   }
 
   @Override

--- a/guava/src/com/google/common/graph/StandardMutableValueGraph.java
+++ b/guava/src/com/google/common/graph/StandardMutableValueGraph.java
@@ -38,13 +38,13 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
-final class ConfigurableMutableValueGraph<N, V> extends ConfigurableValueGraph<N, V>
+final class StandardMutableValueGraph<N, V> extends StandardValueGraph<N, V>
     implements MutableValueGraph<N, V> {
 
   private final ElementOrder<N> incidentEdgeOrder;
 
   /** Constructs a mutable graph with the properties specified in {@code builder}. */
-  ConfigurableMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
+  StandardMutableValueGraph(AbstractGraphBuilder<? super N> builder) {
     super(builder);
     incidentEdgeOrder = builder.incidentEdgeOrder.cast();
   }

--- a/guava/src/com/google/common/graph/StandardValueGraph.java
+++ b/guava/src/com/google/common/graph/StandardValueGraph.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Configurable implementation of {@link ValueGraph} that supports the options supplied by {@link
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @param <N> Node parameter type
  * @param <V> Value parameter type
  */
-class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
+class StandardValueGraph<N, V> extends AbstractValueGraph<N, V> {
   private final boolean isDirected;
   private final boolean allowsSelfLoops;
   private final ElementOrder<N> nodeOrder;
@@ -53,7 +53,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
   protected long edgeCount; // must be updated when edges are added or removed
 
   /** Constructs a graph with the properties specified in {@code builder}. */
-  ConfigurableValueGraph(AbstractGraphBuilder<? super N> builder) {
+  StandardValueGraph(AbstractGraphBuilder<? super N> builder) {
     this(
         builder,
         builder.nodeOrder.<N, GraphConnections<N, V>>createMap(
@@ -65,7 +65,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
    * Constructs a graph with the properties specified in {@code builder}, initialized with the given
    * node map.
    */
-  ConfigurableValueGraph(
+  StandardValueGraph(
       AbstractGraphBuilder<? super N> builder,
       Map<N, GraphConnections<N, V>> nodeConnections,
       long edgeCount) {
@@ -140,14 +140,12 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
   }
 
   @Override
-  @NullableDecl
-  public V edgeValueOrDefault(N nodeU, N nodeV, @NullableDecl V defaultValue) {
+  public @Nullable V edgeValueOrDefault(N nodeU, N nodeV, @Nullable V defaultValue) {
     return edgeValueOrDefault_internal(checkNotNull(nodeU), checkNotNull(nodeV), defaultValue);
   }
 
   @Override
-  @NullableDecl
-  public V edgeValueOrDefault(EndpointPair<N> endpoints, @NullableDecl V defaultValue) {
+  public @Nullable V edgeValueOrDefault(EndpointPair<N> endpoints, @Nullable V defaultValue) {
     validateEndpoints(endpoints);
     return edgeValueOrDefault_internal(endpoints.nodeU(), endpoints.nodeV(), defaultValue);
   }
@@ -166,7 +164,7 @@ class ConfigurableValueGraph<N, V> extends AbstractValueGraph<N, V> {
     return connections;
   }
 
-  protected final boolean containsNode(@NullableDecl N node) {
+  protected final boolean containsNode(@Nullable N node) {
     return nodeConnections.containsKey(node);
   }
 

--- a/guava/src/com/google/common/graph/ValueGraphBuilder.java
+++ b/guava/src/com/google/common/graph/ValueGraphBuilder.java
@@ -176,7 +176,7 @@ public final class ValueGraphBuilder<N, V> extends AbstractGraphBuilder<N> {
    * ValueGraphBuilder}.
    */
   public <N1 extends N, V1 extends V> MutableValueGraph<N1, V1> build() {
-    return new ConfigurableMutableValueGraph<>(this);
+    return new StandardMutableValueGraph<>(this);
   }
 
   ValueGraphBuilder<N, V> copy() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rename 'ConfigurableX' to 'StandardX' for [Value]Graph, which better captures what these implementations represent.

Note that this work was already started in the past with the abstract StandardGraph tests.

1be4110bac4c8540053fb4d096fdbb6d28d8a504