### PR TITLE
MOE Sync 2020-02-19

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/FluentIterableTest.java
+++ b/android/guava-tests/test/com/google/common/collect/FluentIterableTest.java
@@ -76,7 +76,7 @@ public class FluentIterableTest extends TestCase {
         Lists.newArrayList(FluentIterable.from(ImmutableList.of(1, 2, 3, 4))));
   }
 
-  @SuppressWarnings("deprecation") // test of deprecated method
+  @SuppressWarnings({"deprecation", "DoNotCall"}) // test of deprecated method
   public void testFrom_alreadyFluentIterable() {
     FluentIterable<Integer> iterable = FluentIterable.from(asList(1));
     assertSame(iterable, FluentIterable.from(iterable));

--- a/android/guava/src/com/google/common/collect/FluentIterable.java
+++ b/android/guava/src/com/google/common/collect/FluentIterable.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotCall;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -173,6 +174,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
    *     FluentIterable}
    */
   @Deprecated
+  @DoNotCall("instances of FluentIterable don't need to be converetd to a FluentIterable")
   public static <E> FluentIterable<E> from(FluentIterable<E> iterable) {
     return checkNotNull(iterable);
   }

--- a/android/guava/src/com/google/common/collect/SortedMultiset.java
+++ b/android/guava/src/com/google/common/collect/SortedMultiset.java
@@ -32,7 +32,7 @@ import java.util.Set;
  *
  * <p><b>Warning:</b> The comparison must be <i>consistent with equals</i> as explained by the
  * {@link Comparable} class specification. Otherwise, the resulting multiset will violate the {@link
- * Collection} contract, which it is specified in terms of {@link Object#equals}.
+ * Collection} contract, which is specified in terms of {@link Object#equals}.
  *
  * <p>See the Guava User Guide article on <a href=
  * "https://github.com/google/guava/wiki/NewCollectionTypesExplained#multiset"> {@code

--- a/android/guava/src/com/google/common/collect/TopKSelector.java
+++ b/android/guava/src/com/google/common/collect/TopKSelector.java
@@ -57,7 +57,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
    * relative to the natural ordering of the elements, and returns them via {@link #topK} in
    * ascending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T extends Comparable<? super T>> TopKSelector<T> least(int k) {
     return least(k, Ordering.natural());
@@ -67,7 +67,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
    * Returns a {@code TopKSelector} that collects the lowest {@code k} elements added to it,
    * relative to the specified comparator, and returns them via {@link #topK} in ascending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T> TopKSelector<T> least(int k, Comparator<? super T> comparator) {
     return new TopKSelector<T>(comparator, k);
@@ -78,7 +78,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
    * relative to the natural ordering of the elements, and returns them via {@link #topK} in
    * descending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T extends Comparable<? super T>> TopKSelector<T> greatest(int k) {
     return greatest(k, Ordering.natural());
@@ -88,7 +88,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
    * Returns a {@code TopKSelector} that collects the greatest {@code k} elements added to it,
    * relative to the specified comparator, and returns them via {@link #topK} in descending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T> TopKSelector<T> greatest(int k, Comparator<? super T> comparator) {
     return new TopKSelector<T>(Ordering.from(comparator).reverse(), k);
@@ -114,8 +114,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
   private TopKSelector(Comparator<? super T> comparator, int k) {
     this.comparator = checkNotNull(comparator, "comparator");
     this.k = k;
-    checkArgument(k >= 0, "k must be nonnegative, was %s", k);
-    this.buffer = (T[]) new Object[k * 2];
+    checkArgument(k >= 0, "k (%s) must be >= 0", k);
+    checkArgument(k <= Integer.MAX_VALUE / 2, "k (%s) must be <= Integer.MAX_VALUE / 2", k);
+    this.buffer = (T[]) new Object[IntMath.checkedMultiply(k, 2)];
     this.bufferSize = 0;
     this.threshold = null;
   }

--- a/android/guava/src/com/google/common/collect/TreeMultimap.java
+++ b/android/guava/src/com/google/common/collect/TreeMultimap.java
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *
  * <p><b>Warning:</b> The comparators or comparables used must be <i>consistent with equals</i> as
  * explained by the {@link Comparable} class specification. Otherwise, the resulting multiset will
- * violate the general contract of {@link SetMultimap}, which it is specified in terms of {@link
+ * violate the general contract of {@link SetMultimap}, which is specified in terms of {@link
  * Object#equals}.
  *
  * <p>The collections returned by {@code keySet} and {@code asMap} iterate through the keys

--- a/guava-tests/test/com/google/common/collect/FluentIterableTest.java
+++ b/guava-tests/test/com/google/common/collect/FluentIterableTest.java
@@ -80,7 +80,7 @@ public class FluentIterableTest extends TestCase {
         Lists.newArrayList(FluentIterable.from(ImmutableList.of(1, 2, 3, 4))));
   }
 
-  @SuppressWarnings("deprecation") // test of deprecated method
+  @SuppressWarnings({"deprecation", "DoNotCall"}) // test of deprecated method
   public void testFrom_alreadyFluentIterable() {
     FluentIterable<Integer> iterable = FluentIterable.from(asList(1));
     assertSame(iterable, FluentIterable.from(iterable));

--- a/guava/src/com/google/common/collect/FluentIterable.java
+++ b/guava/src/com/google/common/collect/FluentIterable.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.DoNotCall;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -170,6 +171,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
    *     FluentIterable}
    */
   @Deprecated
+  @DoNotCall("instances of FluentIterable don't need to be converetd to a FluentIterable")
   public static <E> FluentIterable<E> from(FluentIterable<E> iterable) {
     return checkNotNull(iterable);
   }

--- a/guava/src/com/google/common/collect/SortedMultiset.java
+++ b/guava/src/com/google/common/collect/SortedMultiset.java
@@ -32,7 +32,7 @@ import java.util.Set;
  *
  * <p><b>Warning:</b> The comparison must be <i>consistent with equals</i> as explained by the
  * {@link Comparable} class specification. Otherwise, the resulting multiset will violate the {@link
- * Collection} contract, which it is specified in terms of {@link Object#equals}.
+ * Collection} contract, which is specified in terms of {@link Object#equals}.
  *
  * <p>See the Guava User Guide article on <a href=
  * "https://github.com/google/guava/wiki/NewCollectionTypesExplained#multiset"> {@code

--- a/guava/src/com/google/common/collect/TopKSelector.java
+++ b/guava/src/com/google/common/collect/TopKSelector.java
@@ -58,7 +58,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * relative to the natural ordering of the elements, and returns them via {@link #topK} in
    * ascending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T extends Comparable<? super T>> TopKSelector<T> least(int k) {
     return least(k, Ordering.natural());
@@ -68,7 +68,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * Returns a {@code TopKSelector} that collects the lowest {@code k} elements added to it,
    * relative to the specified comparator, and returns them via {@link #topK} in ascending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T> TopKSelector<T> least(int k, Comparator<? super T> comparator) {
     return new TopKSelector<T>(comparator, k);
@@ -79,7 +79,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * relative to the natural ordering of the elements, and returns them via {@link #topK} in
    * descending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T extends Comparable<? super T>> TopKSelector<T> greatest(int k) {
     return greatest(k, Ordering.natural());
@@ -89,7 +89,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
    * Returns a {@code TopKSelector} that collects the greatest {@code k} elements added to it,
    * relative to the specified comparator, and returns them via {@link #topK} in descending order.
    *
-   * @throws IllegalArgumentException if {@code k < 0}
+   * @throws IllegalArgumentException if {@code k < 0} or {@code k > Integer.MAX_VALUE / 2}
    */
   public static <T> TopKSelector<T> greatest(int k, Comparator<? super T> comparator) {
     return new TopKSelector<T>(Ordering.from(comparator).reverse(), k);
@@ -115,8 +115,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   private TopKSelector(Comparator<? super T> comparator, int k) {
     this.comparator = checkNotNull(comparator, "comparator");
     this.k = k;
-    checkArgument(k >= 0, "k must be nonnegative, was %s", k);
-    this.buffer = (T[]) new Object[k * 2];
+    checkArgument(k >= 0, "k (%s) must be >= 0", k);
+    checkArgument(k <= Integer.MAX_VALUE / 2, "k (%s) must be <= Integer.MAX_VALUE / 2", k);
+    this.buffer = (T[]) new Object[IntMath.checkedMultiply(k, 2)];
     this.bufferSize = 0;
     this.threshold = null;
   }

--- a/guava/src/com/google/common/collect/TreeMultimap.java
+++ b/guava/src/com/google/common/collect/TreeMultimap.java
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <p><b>Warning:</b> The comparators or comparables used must be <i>consistent with equals</i> as
  * explained by the {@link Comparable} class specification. Otherwise, the resulting multiset will
- * violate the general contract of {@link SetMultimap}, which it is specified in terms of {@link
+ * violate the general contract of {@link SetMultimap}, which is specified in terms of {@link
  * Object#equals}.
  *
  * <p>The collections returned by {@code keySet} and {@code asMap} iterate through the keys


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make TopKSelector ctor throw IllegalArgumentException when buffer size is too big to be held in memory.

Previously this would lead to java.lang.NegativeArraySizeException.

e0418c067aea976e3e59e23e035d15177112597a

-------

<p> Annotate FluentIterable.from(FluentIterable) with @DoNotCall

RELNOTES=Annotate FluentIterable.from(FluentIterable) with @DoNotCall

e3264687f823752dea2d724d2734b4a18e5c92a3

-------

<p> Fixing a typo in some Guava javadocs.

RELNOTES=Fixing a typo in javadoc.

5efab94ad9b77695012878c6b7c5a8815c7d2d36