### PR TITLE
MOE Sync 2020-03-02

### DIFF
--- a/android/guava-tests/test/com/google/common/io/CharStreamsTest.java
+++ b/android/guava-tests/test/com/google/common/io/CharStreamsTest.java
@@ -267,6 +267,21 @@ public class CharStreamsTest extends IoTestCase {
     String test = "Test string for NullWriter";
     nullWriter.write(test);
     nullWriter.write(test, 2, 10);
+    nullWriter.append(null);
+    nullWriter.append(null, 0, 4);
+
+    try {
+      nullWriter.append(null, -1, 4);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+
+    try {
+      nullWriter.append(null, 0, 5);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+
     // nothing really to assert?
     assertSame(CharStreams.nullWriter(), CharStreams.nullWriter());
   }

--- a/android/guava/src/com/google/common/io/CharStreams.java
+++ b/android/guava/src/com/google/common/io/CharStreams.java
@@ -28,6 +28,7 @@ import java.io.Writer;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 /**
  * Provides utility methods for working with character streams.
@@ -306,14 +307,13 @@ public final class CharStreams {
     }
 
     @Override
-    public Writer append(CharSequence csq) {
-      checkNotNull(csq);
+    public Writer append(@NullableDecl CharSequence csq) {
       return this;
     }
 
     @Override
-    public Writer append(CharSequence csq, int start, int end) {
-      checkPositionIndexes(start, end, csq.length());
+    public Writer append(@NullableDecl CharSequence csq, int start, int end) {
+      checkPositionIndexes(start, end, csq == null ? "null".length() : csq.length());
       return this;
     }
 

--- a/guava-tests/test/com/google/common/io/CharStreamsTest.java
+++ b/guava-tests/test/com/google/common/io/CharStreamsTest.java
@@ -267,6 +267,21 @@ public class CharStreamsTest extends IoTestCase {
     String test = "Test string for NullWriter";
     nullWriter.write(test);
     nullWriter.write(test, 2, 10);
+    nullWriter.append(null);
+    nullWriter.append(null, 0, 4);
+
+    try {
+      nullWriter.append(null, -1, 4);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+
+    try {
+      nullWriter.append(null, 0, 5);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+    }
+
     // nothing really to assert?
     assertSame(CharStreams.nullWriter(), CharStreams.nullWriter());
   }

--- a/guava/src/com/google/common/io/CharStreams.java
+++ b/guava/src/com/google/common/io/CharStreams.java
@@ -28,6 +28,7 @@ import java.io.Writer;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Provides utility methods for working with character streams.
@@ -306,14 +307,13 @@ public final class CharStreams {
     }
 
     @Override
-    public Writer append(CharSequence csq) {
-      checkNotNull(csq);
+    public Writer append(@Nullable CharSequence csq) {
       return this;
     }
 
     @Override
-    public Writer append(CharSequence csq, int start, int end) {
-      checkPositionIndexes(start, end, csq.length());
+    public Writer append(@Nullable CharSequence csq, int start, int end) {
+      checkPositionIndexes(start, end, csq == null ? "null".length() : csq.length());
       return this;
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make nullWriter().append(...) (both overloads) accept a null CharSequence.

The docs of Writer are misleading:

"""
An invocation of this method of the form out.append(csq) behaves in exactly the same way as the invocation
     out.write(csq.toString())
"""
https://docs.oracle.com/javase/7/docs/api/java/io/Writer.html#append%28java.lang.CharSequence%29

But that's not true, as the docs go on to say:

"""
csq - The character sequence to append. If csq is null, then the four characters "null" are appended to this writer.
"""

Accepting null in the 2-arg method is arguably even weirder, but at least the docs call it out more prominently:
https://docs.oracle.com/javase/7/docs/api/java/io/Writer.html#append%28java.lang.CharSequence,%20int,%20int%29

Credit to the Checker Framework for identifying this bug.

a27746a876d9426a7252460ef288f4abf9c0d785