### PR TITLE
 JDK 8  uses MAXIMUM_CAPACITY = Ints.MAX_POWER_OF_TWO

### DIFF
--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -332,7 +332,7 @@ public final class Maps {
       // can make.  0.75 is the default load factor.
       return (int) ((float) expectedSize / 0.75F + 1.0F);
     }
-    return Integer.MAX_VALUE; // any large value
+    return Ints.MAX_POWER_OF_TWO; // Maximum capacity used by JDK 8
   }
 
   /**


### PR DESCRIPTION
If initialCapacity is greater than Ints.MAX_POWER_OF_TWO  then JDK 8 uses  Ints.MAX_POWER_OF_TWO as MAXIMUM_CAPACITY.
So, Even if return Integer.MAX_VALUE as MAXIMUM_CAPACITY, JDK  gonna use  Ints.MAX_POWER_OF_TWO as MAXIMUM_CAPACITY

**Snippet from JDK 8 Source:**
   public HashMap(int initialCapacity, float loadFactor) {
        if (initialCapacity < 0)
            throw new IllegalArgumentException("Illegal initial capacity: " +
                                               initialCapacity);
        if (initialCapacity > MAXIMUM_CAPACITY)
            initialCapacity = MAXIMUM_CAPACITY;