### PR TITLE
Change maximum capacity for Maps as per JDK 8

### DIFF
--- a/guava-tests/test/com/google/common/collect/MapsTest.java
+++ b/guava-tests/test/com/google/common/collect/MapsTest.java
@@ -35,6 +35,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.common.collect.Maps.ValueDifferenceImpl;
 import com.google.common.collect.SetsTest.Derived;
+import com.google.common.primitives.Ints;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.SerializableTester;
@@ -188,11 +189,17 @@ public class MapsTest extends TestCase {
           Integer.MAX_VALUE - 1,
           Integer.MAX_VALUE
         };
-    for (int expectedSize : largeExpectedSizes) {
-      int capacity = Maps.capacity(expectedSize);
-      assertTrue(
-          "capacity (" + capacity + ") must be >= expectedSize (" + expectedSize + ")",
-          capacity >= expectedSize);
+    for (int expectedSize: largeExpectedSizes) {
+        int capacity = Maps.capacity(expectedSize);
+        if (expectedSize < Ints.MAX_POWER_OF_TWO) {
+            assertTrue(
+                "capacity (" + capacity + ") must be >= expectedSize (" + expectedSize + ")",
+                capacity >= expectedSize);
+        } else {
+            assertTrue(
+                "capacity (" + capacity + ") must be <= Ints.MAX_POWER_OF_TWO (" + expectedSize + ")",
+                capacity <= Ints.MAX_POWER_OF_TWO);
+        }
     }
   }
 

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -332,7 +332,7 @@ public final class Maps {
       // can make.  0.75 is the default load factor.
       return (int) ((float) expectedSize / 0.75F + 1.0F);
     }
-    return Integer.MAX_VALUE; // any large value
+    return Ints.MAX_POWER_OF_TWO; // Maximum Capacity Used By JDK 8
   }
 
   /**


### PR DESCRIPTION
If initialCapacity is greater than Ints.MAX_POWER_OF_TWO then JDK 8 uses Ints.MAX_POWER_OF_TWO as MAXIMUM_CAPACITY.
So, Even if we return Integer.MAX_VALUE as MAXIMUM_CAPACITY, JDK gonna use Ints.MAX_POWER_OF_TWO as MAXIMUM_CAPACITY

Snippet from JDK 8 Source:
public HashMap(int initialCapacity, float loadFactor) {
if (initialCapacity < 0)
throw new IllegalArgumentException("Illegal initial capacity: " +
initialCapacity);
if (initialCapacity > MAXIMUM_CAPACITY)
initialCapacity = MAXIMUM_CAPACITY; // which is Ints.MAX_POWER_OF_TWO