### PR TITLE
MOE Sync 2020-03-16

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
@@ -188,7 +188,7 @@ public class SequentialExecutorTest extends TestCase {
     // Check that this thread has been marked as interrupted again now that the thread has been
     // returned by SequentialExecutor. Clear the bit while checking so that the test doesn't hose
     // JUnit or some other test case.
-    assertThat(Thread.currentThread().interrupted()).isTrue();
+    assertThat(Thread.interrupted()).isTrue();
   }
 
   public void testInterrupt_doesNotInterruptSubsequentTask() throws Exception {
@@ -215,7 +215,7 @@ public class SequentialExecutorTest extends TestCase {
     // Check that the interruption of a SequentialExecutor's task is restored to the thread once
     // it is yielded. Clear the bit while checking so that the test doesn't hose JUnit or some other
     // test case.
-    assertThat(Thread.currentThread().interrupted()).isTrue();
+    assertThat(Thread.interrupted()).isTrue();
   }
 
   public void testInterrupt_doesNotStopExecution() {

--- a/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
@@ -188,7 +188,7 @@ public class SequentialExecutorTest extends TestCase {
     // Check that this thread has been marked as interrupted again now that the thread has been
     // returned by SequentialExecutor. Clear the bit while checking so that the test doesn't hose
     // JUnit or some other test case.
-    assertThat(Thread.currentThread().interrupted()).isTrue();
+    assertThat(Thread.interrupted()).isTrue();
   }
 
   public void testInterrupt_doesNotInterruptSubsequentTask() throws Exception {
@@ -215,7 +215,7 @@ public class SequentialExecutorTest extends TestCase {
     // Check that the interruption of a SequentialExecutor's task is restored to the thread once
     // it is yielded. Clear the bit while checking so that the test doesn't hose JUnit or some other
     // test case.
-    assertThat(Thread.currentThread().interrupted()).isTrue();
+    assertThat(Thread.interrupted()).isTrue();
   }
 
   public void testInterrupt_doesNotStopExecution() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace Thread.currentThread().interrupted() with Thread.interrupted() or Thread.currentThread().interrupt(), whichever seems appropriate.

Thread.interrupted: static method on Thread which returns whether the thread has been interrupted (and resets the interrupt bit)

Thread.currentThread().interrupt(): interrupts the current thread

744b356fa6769d4ae6924d649ac20da6c7e748ac