### PR TITLE
MOE Sync 2020-03-16

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/CollectionFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/CollectionFuture.java
@@ -41,7 +41,7 @@ abstract class CollectionFuture<V, C> extends AggregateFuture<V, C> {
       boolean allMustSucceed) {
     super(futures, allMustSucceed, true);
 
-    this.values =
+    List<Present<V>> values =
         futures.isEmpty()
             ? ImmutableList.<Present<V>>of()
             : Lists.<Present<V>>newArrayListWithCapacity(futures.size());
@@ -50,6 +50,8 @@ abstract class CollectionFuture<V, C> extends AggregateFuture<V, C> {
     for (int i = 0; i < futures.size(); ++i) {
       values.add(null);
     }
+
+    this.values = values;
   }
 
   @Override

--- a/guava/src/com/google/common/util/concurrent/CollectionFuture.java
+++ b/guava/src/com/google/common/util/concurrent/CollectionFuture.java
@@ -41,7 +41,7 @@ abstract class CollectionFuture<V, C> extends AggregateFuture<V, C> {
       boolean allMustSucceed) {
     super(futures, allMustSucceed, true);
 
-    this.values =
+    List<Present<V>> values =
         futures.isEmpty()
             ? ImmutableList.<Present<V>>of()
             : Lists.<Present<V>>newArrayListWithCapacity(futures.size());
@@ -50,6 +50,8 @@ abstract class CollectionFuture<V, C> extends AggregateFuture<V, C> {
     for (int i = 0; i < futures.size(); ++i) {
       values.add(null);
     }
+
+    this.values = values;
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Store `values` in a local first instead of repeatedly reading it from a field.

At worst, this is a no-op. At best, it may perform better.

b6d4f65f1065dcf3fe75bbeb1b2df226280116c5