### PR TITLE
Fixed double slicing ByteSource #3501

### DIFF
--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -664,11 +664,14 @@ public final class Lists {
   private static class Partition<T> extends AbstractList<List<T>> {
     final List<T> list;
     final int size;
+    final int listSize;
 
     Partition(List<T> list, int size) {
       this.list = list;
+      this.listSize = IntMath.divide(list.size(), size, RoundingMode.CEILING);
       this.size = size;
     }
+
 
     @Override
     public List<T> get(int index) {
@@ -680,7 +683,7 @@ public final class Lists {
 
     @Override
     public int size() {
-      return IntMath.divide(list.size(), size, RoundingMode.CEILING);
+      return this.listSize;
     }
 
     @Override

--- a/guava/src/com/google/common/io/ByteSource.java
+++ b/guava/src/com/google/common/io/ByteSource.java
@@ -530,7 +530,7 @@ public abstract class ByteSource {
       checkArgument(offset >= 0, "offset (%s) may not be negative", offset);
       checkArgument(length >= 0, "length (%s) may not be negative", length);
       long maxLength = this.length - offset;
-      return ByteSource.this.slice(this.offset + offset, Math.min(length, maxLength));
+      return maxLength < 0 ? ByteSource.empty() : ByteSource.this.slice(this.offset + offset, Math.min(length, maxLength));
     }
 
     @Override


### PR DESCRIPTION
Fixes #3501

add maxLength < 0 to check whether the offset is greater than the source size. If so, return an empty source according to the API description.