### PR TITLE
MOE Sync 2020-03-17

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/ListeningScheduledExecutorServiceTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ListeningScheduledExecutorServiceTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.util.concurrent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import junit.framework.TestCase;
+
+/** Tests for default methods of the interface. */
+public class ListeningScheduledExecutorServiceTest extends TestCase {
+
+  private Runnable recordedCommand;
+  private long recordedDelay;
+  private long recordedInterval;
+  private TimeUnit recordedTimeUnit;
+
+  private final ListeningScheduledExecutorService executorService = new FakeExecutorService();
+
+  public void testScheduleRunnable() throws Exception {
+    Runnable command = () -> {};
+
+    ListenableScheduledFuture<?> future = executorService.schedule(command, Duration.ofSeconds(12));
+
+    assertThat(future.get()).isEqualTo("schedule");
+    assertThat(recordedCommand).isSameInstanceAs(command);
+    assertThat(recordedTimeUnit).isEqualTo(TimeUnit.NANOSECONDS);
+    assertThat(Duration.ofNanos(recordedDelay)).isEqualTo(Duration.ofSeconds(12));
+  }
+
+  public void testScheduleCallable() throws Exception {
+    Callable<String> callable = () -> "hello";
+
+    ListenableScheduledFuture<String> future =
+        executorService.schedule(callable, Duration.ofMinutes(12));
+
+    assertThat(future.get()).isEqualTo("hello");
+    assertThat(recordedTimeUnit).isEqualTo(TimeUnit.NANOSECONDS);
+    assertThat(Duration.ofNanos(recordedDelay)).isEqualTo(Duration.ofMinutes(12));
+  }
+
+  public void testScheduleAtFixedRate() throws Exception {
+    Runnable command = () -> {};
+
+    ListenableScheduledFuture<?> future =
+        executorService.scheduleAtFixedRate(command, Duration.ofDays(2), Duration.ofHours(4));
+
+    assertThat(future.get()).isEqualTo("scheduleAtFixedRate");
+    assertThat(recordedCommand).isSameInstanceAs(command);
+    assertThat(recordedTimeUnit).isEqualTo(TimeUnit.NANOSECONDS);
+    assertThat(Duration.ofNanos(recordedDelay)).isEqualTo(Duration.ofDays(2));
+    assertThat(Duration.ofNanos(recordedInterval)).isEqualTo(Duration.ofHours(4));
+  }
+
+  public void testScheduleWithFixedDelay() throws Exception {
+    Runnable command = () -> {};
+
+    ListenableScheduledFuture<?> future =
+        executorService.scheduleWithFixedDelay(command, Duration.ofDays(8), Duration.ofHours(16));
+
+    assertThat(future.get()).isEqualTo("scheduleWithFixedDelay");
+    assertThat(recordedCommand).isSameInstanceAs(command);
+    assertThat(recordedTimeUnit).isEqualTo(TimeUnit.NANOSECONDS);
+    assertThat(Duration.ofNanos(recordedDelay)).isEqualTo(Duration.ofDays(8));
+    assertThat(Duration.ofNanos(recordedInterval)).isEqualTo(Duration.ofHours(16));
+  }
+
+  private class FakeExecutorService extends AbstractListeningExecutorService
+      implements ListeningScheduledExecutorService {
+    @Override
+    public ListenableScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+      recordedCommand = command;
+      recordedDelay = delay;
+      recordedTimeUnit = unit;
+      return ImmediateScheduledFuture.of("schedule");
+    }
+
+    @Override
+    public <V> ListenableScheduledFuture<V> schedule(
+        Callable<V> callable, long delay, TimeUnit unit) {
+      recordedDelay = delay;
+      recordedTimeUnit = unit;
+      try {
+        return ImmediateScheduledFuture.of(callable.call());
+      } catch (Exception e) {
+        return ImmediateScheduledFuture.failed(e);
+      }
+    }
+
+    @Override
+    public ListenableScheduledFuture<?> scheduleAtFixedRate(
+        Runnable command, long initialDelay, long period, TimeUnit unit) {
+      recordedCommand = command;
+      recordedDelay = initialDelay;
+      recordedInterval = period;
+      recordedTimeUnit = unit;
+      return ImmediateScheduledFuture.of("scheduleAtFixedRate");
+    }
+
+    @Override
+    public ListenableScheduledFuture<?> scheduleWithFixedDelay(
+        Runnable command, long initialDelay, long delay, TimeUnit unit) {
+      recordedCommand = command;
+      recordedDelay = initialDelay;
+      recordedInterval = delay;
+      recordedTimeUnit = unit;
+      return ImmediateScheduledFuture.of("scheduleWithFixedDelay");
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shutdown() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class ImmediateScheduledFuture<V> extends SimpleForwardingListenableFuture<V>
+      implements ListenableScheduledFuture<V> {
+    static <V> ListenableScheduledFuture<V> of(V value) {
+      return new ImmediateScheduledFuture<>(Futures.immediateFuture(value));
+    }
+
+    static <V> ListenableScheduledFuture<V> failed(Throwable t) {
+      return new ImmediateScheduledFuture<>(Futures.immediateFailedFuture(t));
+    }
+
+    ImmediateScheduledFuture(ListenableFuture<V> delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+      return 0;
+    }
+
+    @Override
+    public int compareTo(Delayed other) {
+      return 0;
+    }
+  }
+}

--- a/guava/src/com/google/common/util/concurrent/ListeningScheduledExecutorService.java
+++ b/guava/src/com/google/common/util/concurrent/ListeningScheduledExecutorService.java
@@ -14,7 +14,10 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.util.concurrent.Internal.toNanosSaturated;
+
 import com.google.common.annotations.GwtIncompatible;
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,17 +39,57 @@ public interface ListeningScheduledExecutorService
   @Override
   ListenableScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
 
+  /**
+   * Duration-based overload of {@link #schedule(Runnable, long, TimeUnit)}.
+   *
+   * @since NEXT
+   */
+  default ListenableScheduledFuture<?> schedule(Runnable command, Duration delay) {
+    return schedule(command, toNanosSaturated(delay), TimeUnit.NANOSECONDS);
+  }
+
   /** @since 15.0 (previously returned ScheduledFuture) */
   @Override
   <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
+
+  /**
+   * Duration-based overload of {@link #schedule(Callable, long, TimeUnit)}.
+   *
+   * @since NEXT
+   */
+  default <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, Duration delay) {
+    return schedule(callable, toNanosSaturated(delay), TimeUnit.NANOSECONDS);
+  }
 
   /** @since 15.0 (previously returned ScheduledFuture) */
   @Override
   ListenableScheduledFuture<?> scheduleAtFixedRate(
       Runnable command, long initialDelay, long period, TimeUnit unit);
 
+  /**
+   * Duration-based overload of {@link #scheduleAtFixedRate(Runnable, long, long, TimeUnit)}.
+   *
+   * @since NEXT
+   */
+  default ListenableScheduledFuture<?> scheduleAtFixedRate(
+      Runnable command, Duration initialDelay, Duration period) {
+    return scheduleAtFixedRate(
+        command, toNanosSaturated(initialDelay), toNanosSaturated(period), TimeUnit.NANOSECONDS);
+  }
+
   /** @since 15.0 (previously returned ScheduledFuture) */
   @Override
   ListenableScheduledFuture<?> scheduleWithFixedDelay(
       Runnable command, long initialDelay, long delay, TimeUnit unit);
+
+  /**
+   * Duration-based overload of {@link #scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}.
+   *
+   * @since NEXT
+   */
+  default ListenableScheduledFuture<?> scheduleWithFixedDelay(
+      Runnable command, Duration initialDelay, Duration delay) {
+    return scheduleWithFixedDelay(
+        command, toNanosSaturated(initialDelay), toNanosSaturated(delay), TimeUnit.NANOSECONDS);
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add `Duration`-based default methods to `ListeningScheduledExecutorService`

They just delegate to the existing methods from the interface, using the existing saturated conversion to nanoseconds. This matches existing `Duration`-based overloads of `(long, TimeUnit)` methods in the same package.

RELNOTES=Added `Duration`-based `default` methods to `ListeningScheduledExecutorService`.

c7984e7e5c40868ca47faede472ad77c10965114