### PR TITLE
Fixed NoSuchElementException when using Lists.partition and remove #3790

### DIFF
--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -664,9 +664,11 @@ public final class Lists {
   private static class Partition<T> extends AbstractList<List<T>> {
     final List<T> list;
     final int size;
+    final int listSize;
 
     Partition(List<T> list, int size) {
       this.list = list;
+      this.listSize = IntMath.divide(list.size(), size, RoundingMode.CEILING);
       this.size = size;
     }
 
@@ -680,7 +682,7 @@ public final class Lists {
 
     @Override
     public int size() {
-      return IntMath.divide(list.size(), size, RoundingMode.CEILING);
+      return this.listSize;
     }
 
     @Override


### PR DESCRIPTION
NoSuchElementException occurs because of Iterator in AbstractList call hasNext() as below
```
public boolean hasNext() {
            return cursor != size();
        }
```

But after execute remove operation on List, the result of calling size() will change. So I make size as a final int listSize.