### PR TITLE
MOE Sync 2020-03-30

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/android/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -243,8 +243,9 @@ public final class ServiceManager {
    * during {@code Executor.execute} (e.g., a {@code RejectedExecutionException}) will be caught and
    * logged.
    *
-   * <p>For fast, lightweight listeners that would be safe to execute in any thread, consider
-   * calling {@link #addListener(Listener)}.
+   * <p>When selecting an executor, note that {@code directExecutor} is dangerous in some cases. See
+   * the discussion in the {@link ListenableFuture#addListener ListenableFuture.addListener}
+   * documentation.
    *
    * @param listener the listener to run when the manager changes state
    * @param executor the executor in which the listeners callback methods will be run.
@@ -269,7 +270,14 @@ public final class ServiceManager {
    *
    * @param listener the listener to run when the manager changes state
    * @since 15.0
+   * @deprecated Use {@linkplain #addListener(Listener, Executor) the overload that accepts an
+   *     executor}. For equivalent behavior, pass {@link MoreExecutors#directExecutor}. However,
+   *     consider whether another executor would be more appropriate, as discussed in the docs for
+   *     {@link ListenableFuture#addListener ListenableFuture.addListener}. This method is scheduled
+   *     for deletion in October 2020.
    */
+  @Beta // currently redundant, but ensures we keep this @Beta when we gradate the class!
+  @Deprecated
   public void addListener(Listener listener) {
     state.addListener(listener, directExecutor());
   }

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -245,8 +245,9 @@ public final class ServiceManager {
    * during {@code Executor.execute} (e.g., a {@code RejectedExecutionException}) will be caught and
    * logged.
    *
-   * <p>For fast, lightweight listeners that would be safe to execute in any thread, consider
-   * calling {@link #addListener(Listener)}.
+   * <p>When selecting an executor, note that {@code directExecutor} is dangerous in some cases. See
+   * the discussion in the {@link ListenableFuture#addListener ListenableFuture.addListener}
+   * documentation.
    *
    * @param listener the listener to run when the manager changes state
    * @param executor the executor in which the listeners callback methods will be run.
@@ -271,7 +272,14 @@ public final class ServiceManager {
    *
    * @param listener the listener to run when the manager changes state
    * @since 15.0
+   * @deprecated Use {@linkplain #addListener(Listener, Executor) the overload that accepts an
+   *     executor}. For equivalent behavior, pass {@link MoreExecutors#directExecutor}. However,
+   *     consider whether another executor would be more appropriate, as discussed in the docs for
+   *     {@link ListenableFuture#addListener ListenableFuture.addListener}. This method is scheduled
+   *     for deletion in October 2020.
    */
+  @Beta // currently redundant, but ensures we keep this @Beta when we gradate the class!
+  @Deprecated
   public void addListener(Listener listener) {
     state.addListener(listener, directExecutor());
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate 1-arg overload of ServiceManager.addListener.

It default to directExecutor(). directExecutor() is often useful, but it should be an explicit choice, as some usages are dangerous:
https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/util/concurrent/ListenableFuture.html#addListener-java.lang.Runnable-java.util.concurrent.Executor-

https://github.com/google/guava/issues/3418

RELNOTES=`util.concurrent`: Deprecated the 1-arg overload of `ServiceManager.addListener`.

200056a4525bf28f1d252505f1564fdf26322ccb