### PR TITLE
MOE Sync 2020-04-02

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/QueuesTest.java
+++ b/android/guava-tests/test/com/google/common/collect/QueuesTest.java
@@ -77,7 +77,7 @@ public class QueuesTest extends TestCase {
   @Override
   public void tearDown() throws InterruptedException {
     threadPool.shutdown();
-    assertTrue("Some worker didn't finish in time", threadPool.awaitTermination(1, SECONDS));
+    assertTrue("Some worker didn't finish in time", threadPool.awaitTermination(10, SECONDS));
   }
 
   private static <T> int drain(

--- a/guava-tests/test/com/google/common/collect/QueuesTest.java
+++ b/guava-tests/test/com/google/common/collect/QueuesTest.java
@@ -77,7 +77,7 @@ public class QueuesTest extends TestCase {
   @Override
   public void tearDown() throws InterruptedException {
     threadPool.shutdown();
-    assertTrue("Some worker didn't finish in time", threadPool.awaitTermination(1, SECONDS));
+    assertTrue("Some worker didn't finish in time", threadPool.awaitTermination(10, SECONDS));
   }
 
   private static <T> int drain(

--- a/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -211,6 +212,12 @@ public abstract class AbstractExecutionThreadService implements Service {
     delegate.awaitRunning();
   }
 
+  /** @since 28.0 */
+  @Override
+  public final void awaitRunning(Duration timeout) throws TimeoutException {
+    Service.super.awaitRunning(timeout);
+  }
+
   /** @since 15.0 */
   @Override
   public final void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
@@ -221,6 +228,12 @@ public abstract class AbstractExecutionThreadService implements Service {
   @Override
   public final void awaitTerminated() {
     delegate.awaitTerminated();
+  }
+
+  /** @since 28.0 */
+  @Override
+  public final void awaitTerminated(Duration timeout) throws TimeoutException {
+    Service.super.awaitTerminated(timeout);
   }
 
   /** @since 15.0 */

--- a/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.j2objc.annotations.WeakOuter;
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -165,6 +166,12 @@ public abstract class AbstractIdleService implements Service {
     delegate.awaitRunning();
   }
 
+  /** @since 28.0 */
+  @Override
+  public final void awaitRunning(Duration timeout) throws TimeoutException {
+    Service.super.awaitRunning(timeout);
+  }
+
   /** @since 15.0 */
   @Override
   public final void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
@@ -175,6 +182,12 @@ public abstract class AbstractIdleService implements Service {
   @Override
   public final void awaitTerminated() {
     delegate.awaitTerminated();
+  }
+
+  /** @since 28.0 */
+  @Override
+  public final void awaitTerminated(Duration timeout) throws TimeoutException {
+    Service.super.awaitTerminated(timeout);
   }
 
   /** @since 15.0 */

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -443,6 +443,12 @@ public abstract class AbstractScheduledService implements Service {
     delegate.awaitRunning();
   }
 
+  /** @since 28.0 */
+  @Override
+  public final void awaitRunning(Duration timeout) throws TimeoutException {
+    Service.super.awaitRunning(timeout);
+  }
+
   /** @since 15.0 */
   @Override
   public final void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
@@ -453,6 +459,12 @@ public abstract class AbstractScheduledService implements Service {
   @Override
   public final void awaitTerminated() {
     delegate.awaitTerminated();
+  }
+
+  /** @since 28.0 */
+  @Override
+  public final void awaitTerminated(Duration timeout) throws TimeoutException {
+    Service.super.awaitTerminated(timeout);
   }
 
   /** @since 15.0 */

--- a/guava/src/com/google/common/util/concurrent/AbstractService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractService.java
@@ -32,6 +32,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.j2objc.annotations.WeakOuter;
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -305,6 +306,12 @@ public abstract class AbstractService implements Service {
     }
   }
 
+  /** @since 28.0 */
+  @Override
+  public final void awaitRunning(Duration timeout) throws TimeoutException {
+    Service.super.awaitRunning(timeout);
+  }
+
   @Override
   public final void awaitRunning(long timeout, TimeUnit unit) throws TimeoutException {
     if (monitor.enterWhenUninterruptibly(hasReachedRunning, timeout, unit)) {
@@ -330,6 +337,12 @@ public abstract class AbstractService implements Service {
     } finally {
       monitor.leave();
     }
+  }
+
+  /** @since 28.0 */
+  @Override
+  public final void awaitTerminated(Duration timeout) throws TimeoutException {
+    Service.super.awaitTerminated(timeout);
   }
 
   @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make `Duration` overloads of `awaitRunning` and `awaitTerminated` `final` in all `Abstract*Service` classes.

The other overloads already are already `final`. These ones aren't only because we didn't think to do this when adding the new `default` methods.

929867a724fc2a9b4f881534dca8d1458c9ece9c

-------

<p> Extend deadline to fix flakiness.

It's possible that we don't really need to assert that the pool finishes shutting down at all. Maybe the other existing assertions are enough? But I haven't bothered to look into it.

1611de32e6a029ef713499b6e878c1af11f613ca