### PR TITLE
Fix unnecessary method access level escalation

### DIFF
--- a/android/guava/src/com/google/common/hash/Murmur3_128HashFunction.java
+++ b/android/guava/src/com/google/common/hash/Murmur3_128HashFunction.java
@@ -166,7 +166,7 @@ final class Murmur3_128HashFunction extends AbstractHashFunction implements Seri
     }
 
     @Override
-    public HashCode makeHash() {
+    protected HashCode makeHash() {
       h1 ^= length;
       h2 ^= length;
 

--- a/android/guava/src/com/google/common/hash/SipHashFunction.java
+++ b/android/guava/src/com/google/common/hash/SipHashFunction.java
@@ -143,7 +143,7 @@ final class SipHashFunction extends AbstractHashFunction implements Serializable
     }
 
     @Override
-    public HashCode makeHash() {
+    protected HashCode makeHash() {
       // End with a byte encoding the positive integer b mod 256.
       finalM ^= b << 56;
       processM(finalM);

--- a/guava/src/com/google/common/hash/Murmur3_128HashFunction.java
+++ b/guava/src/com/google/common/hash/Murmur3_128HashFunction.java
@@ -166,7 +166,7 @@ final class Murmur3_128HashFunction extends AbstractHashFunction implements Seri
     }
 
     @Override
-    public HashCode makeHash() {
+    protected HashCode makeHash() {
       h1 ^= length;
       h2 ^= length;
 

--- a/guava/src/com/google/common/hash/SipHashFunction.java
+++ b/guava/src/com/google/common/hash/SipHashFunction.java
@@ -143,7 +143,7 @@ final class SipHashFunction extends AbstractHashFunction implements Serializable
     }
 
     @Override
-    public HashCode makeHash() {
+    protected HashCode makeHash() {
       // End with a byte encoding the positive integer b mod 256.
       finalM ^= b << 56;
       processM(finalM);


### PR DESCRIPTION
The overridden methods are protected in superclasses, and there is no need do make them public in subclasses. Why this change doesn't break anything? Because the objects containing the changed methods are passed as HashFunction implementations, which hides the methods anyway.