### PR TITLE
MOE Sync 2020-04-09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ jdk:
   - openjdk8
   - openjdk11
 
+addons:
+  apt:
+    packages:
+      - openjdk-8-source
+      - openjdk-11-source
+
 install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
 
 # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
       - openjdk-8-source
-      - openjdk-11-source
 
 install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
 

--- a/android/guava/src/com/google/common/base/Stopwatch.java
+++ b/android/guava/src/com/google/common/base/Stopwatch.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * <p>In contrast, <i>wall time</i> is a reading of "now" as given by a method like
  * {@link System#currentTimeMillis()}, best represented as an {@link Instant}. Such values
  *
- * <p><i>can</i> be subtracted to obtain a {@link Duration} (such as by {@link Duration#between}),
+ * <p><i>can</i> be subtracted to obtain a {@code Duration} (such as by {@code Duration.between}),
  * but doing so does <i>not</i> give a reliable measurement of elapsed time, because wall time
  * readings are inherently approximate, routinely affected by periodic clock corrections. Because
  * this class (by default) uses {@link System#nanoTime}, it is unaffected by these changes.

--- a/android/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/android/guava/src/com/google/common/cache/CacheBuilder.java
@@ -49,9 +49,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  *   <li>automatic loading of entries into the cache
  *   <li>least-recently-used eviction when a maximum size is exceeded
  *   <li>time-based expiration of entries, measured since last access or last write
- *   <li>keys automatically wrapped in {@linkplain WeakReference weak} references
- *   <li>values automatically wrapped in {@linkplain WeakReference weak} or {@linkplain
- *       SoftReference soft} references
+ *   <li>keys automatically wrapped in {@code WeakReference}
+ *   <li>values automatically wrapped in {@code WeakReference} or {@code SoftReference}
  *   <li>notification of evicted (or otherwise removed) entries
  *   <li>accumulation of cache access statistics
  * </ul>

--- a/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -47,13 +47,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
  * Factory and utility methods for {@link java.util.concurrent.Executor}, {@link ExecutorService},
- * and {@link ThreadFactory}.
+ * and {@link java.util.concurrent.ThreadFactory}.
  *
  * @author Eric Fellheimer
  * @author Kyle Littlefield
@@ -340,10 +339,11 @@ public final class MoreExecutors {
 
   /**
    * Creates an executor service that runs each task in the thread that invokes {@code
-   * execute/submit}, as in {@link CallerRunsPolicy} This applies both to individually submitted
-   * tasks and to collections of tasks submitted via {@code invokeAll} or {@code invokeAny}. In the
-   * latter case, tasks will run serially on the calling thread. Tasks are run to completion before
-   * a {@code Future} is returned to the caller (unless the executor has been shutdown).
+   * execute/submit}, as in {@code ThreadPoolExecutor.CallerRunsPolicy}. This applies both to
+   * individually submitted tasks and to collections of tasks submitted via {@code invokeAll} or
+   * {@code invokeAny}. In the latter case, tasks will run serially on the calling thread. Tasks are
+   * run to completion before a {@code Future} is returned to the caller (unless the executor has
+   * been shutdown).
    *
    * <p>Although all tasks are immediately executed in the thread that submitted the task, this
    * {@code ExecutorService} imposes a small locking overhead on each task submission in order to
@@ -370,7 +370,7 @@ public final class MoreExecutors {
 
   /**
    * Returns an {@link Executor} that runs each task in the thread that invokes {@link
-   * Executor#execute execute}, as in {@link CallerRunsPolicy}.
+   * Executor#execute execute}, as in {@code ThreadPoolExecutor.CallerRunsPolicy}.
    *
    * <p>This instance is equivalent to:
    *

--- a/guava/src/com/google/common/base/Stopwatch.java
+++ b/guava/src/com/google/common/base/Stopwatch.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>In contrast, <i>wall time</i> is a reading of "now" as given by a method like
  * {@link System#currentTimeMillis()}, best represented as an {@link Instant}. Such values
- * <i>can</i> be subtracted to obtain a {@link Duration} (such as by {@link Duration#between}), but
+ * <i>can</i> be subtracted to obtain a {@code Duration} (such as by {@code Duration.between}), but
  * doing so does <i>not</i> give a reliable measurement of elapsed time, because wall time readings
  * are inherently approximate, routinely affected by periodic clock corrections. Because this class
  * (by default) uses {@link System#nanoTime}, it is unaffected by these changes.
@@ -202,7 +202,7 @@ public final class Stopwatch {
    *
    * <p>It is generally not a good idea to use an ambiguous, unitless {@code long} to represent
    * elapsed time. Therefore, we recommend using {@link #elapsed()} instead, which returns a
-   * strongly-typed {@link Duration} instance.
+   * strongly-typed {@code Duration} instance.
    *
    * @since 14.0 (since 10.0 as {@code elapsedTime()})
    */

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -31,8 +31,6 @@ import com.google.common.cache.AbstractCache.StatsCounter;
 import com.google.common.cache.LocalCache.Strength;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
-import java.lang.ref.SoftReference;
-import java.lang.ref.WeakReference;
 import java.util.ConcurrentModificationException;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -50,9 +48,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *   <li>automatic loading of entries into the cache
  *   <li>least-recently-used eviction when a maximum size is exceeded
  *   <li>time-based expiration of entries, measured since last access or last write
- *   <li>keys automatically wrapped in {@linkplain WeakReference weak} references
- *   <li>values automatically wrapped in {@linkplain WeakReference weak} or {@linkplain
- *       SoftReference soft} references
+ *   <li>keys automatically wrapped in {@code WeakReference}
+ *   <li>values automatically wrapped in {@code WeakReference} or {@code SoftReference}
  *   <li>notification of evicted (or otherwise removed) entries
  *   <li>accumulation of cache access statistics
  * </ul>

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -49,13 +49,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
  * Factory and utility methods for {@link java.util.concurrent.Executor}, {@link ExecutorService},
- * and {@link ThreadFactory}.
+ * and {@link java.util.concurrent.ThreadFactory}.
  *
  * @author Eric Fellheimer
  * @author Kyle Littlefield
@@ -401,10 +400,11 @@ public final class MoreExecutors {
 
   /**
    * Creates an executor service that runs each task in the thread that invokes {@code
-   * execute/submit}, as in {@link CallerRunsPolicy} This applies both to individually submitted
-   * tasks and to collections of tasks submitted via {@code invokeAll} or {@code invokeAny}. In the
-   * latter case, tasks will run serially on the calling thread. Tasks are run to completion before
-   * a {@code Future} is returned to the caller (unless the executor has been shutdown).
+   * execute/submit}, as in {@code ThreadPoolExecutor.CallerRunsPolicy}. This applies both to
+   * individually submitted tasks and to collections of tasks submitted via {@code invokeAll} or
+   * {@code invokeAny}. In the latter case, tasks will run serially on the calling thread. Tasks are
+   * run to completion before a {@code Future} is returned to the caller (unless the executor has
+   * been shutdown).
    *
    * <p>Although all tasks are immediately executed in the thread that submitted the task, this
    * {@code ExecutorService} imposes a small locking overhead on each task submission in order to
@@ -431,7 +431,7 @@ public final class MoreExecutors {
 
   /**
    * Returns an {@link Executor} that runs each task in the thread that invokes {@link
-   * Executor#execute execute}, as in {@link CallerRunsPolicy}.
+   * Executor#execute execute}, as in {@code ThreadPoolExecutor.CallerRunsPolicy}.
    *
    * <p>This instance is equivalent to:
    *


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Try yet again to inherit docs from the JDK when building Javadoc for snapshots.

I am optimistic: See https://github.com/google/guava/issues/3669#issuecomment-611658339

c76c0af95f7c115ec9d87c7961d0292d2ff9d736

-------

<p> Use @code instead of @link to allow imports to be stripped

fd4ed9d63a985f16ee5eae9e3e64dae000f4d793

-------

<p> Don't request openjdk-11-source.

We don't need it yet, since we build Javadoc snapshots with OpenJDK 8.
Maybe we'll need it someday, but currently it doesn't exist :)

https://travis-ci.org/github/google/guava/jobs/673105448
E: Unable to locate package openjdk-11-source

Followup to CL 305716744.

6e89adb89e313f5dba7b2c2c88056fdaf0e5c434