### PR TITLE
MOE Sync 2020-04-20

### DIFF
--- a/refactorings/TraverserRewrite.java
+++ b/refactorings/TraverserRewrite.java
@@ -24,6 +24,7 @@ import com.google.errorprone.refaster.annotation.Placeholder;
  * Refaster rules to rewrite usages of {@code com.google.common.collect.TreeTraverser} in terms of
  * {@code com.google.common.graph.Traverser}.
  */
+@SuppressWarnings("DefaultPackage")
 public class TraverserRewrite {
   abstract class TreeTraverserPreOrder<N> {
     @Placeholder


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> This change suppresses DefaultPackage check for any java class which uses the default java package, in preparation for enabling a compiler error that will prevent new instances of the bug.

The Google Java Style Guide §8.2.1 requires Java files to have a (non-default) package declaration.  Missing package declarations can cause odd problems that are difficult to debug, such as a class not being included in a test suite or confusion around package-private visibility.

RELNOTES=suppresses warning for using default package

6eec9ca96b8880cf17b9190b1148e28b3e2ca2e4