### PR TITLE
Issue #3742 Changing the axesSizeProduct entries to Integer.MAX_VALUE instead of throwing exception

### DIFF
--- a/guava/src/com/google/common/collect/CartesianList.java
+++ b/guava/src/com/google/common/collect/CartesianList.java
@@ -57,10 +57,10 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
         axesSizeProduct[i] = IntMath.checkedMultiply(axesSizeProduct[i + 1], axes.get(i).size());
       }
     } catch (ArithmeticException e) {
-        // size which returns axesSizeProduct[0] will now return Integer.MAX_VALUE
-        for (; i >= 0; i--) {
-          axesSizeProduct[i] = Integer.MAX_VALUE;
-        }
+      // size which returns axesSizeProduct[0] will now return Integer.MAX_VALUE
+      for (; i >= 0; i--) {
+        axesSizeProduct[i] = Integer.MAX_VALUE;
+      }
     }
     this.axesSizeProduct = axesSizeProduct;
   }

--- a/guava/src/com/google/common/collect/CartesianList.java
+++ b/guava/src/com/google/common/collect/CartesianList.java
@@ -51,13 +51,16 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
     this.axes = axes;
     int[] axesSizeProduct = new int[axes.size() + 1];
     axesSizeProduct[axes.size()] = 1;
+    int i = axes.size() - 1;
     try {
-      for (int i = axes.size() - 1; i >= 0; i--) {
+      for (; i >= 0; i--) {
         axesSizeProduct[i] = IntMath.checkedMultiply(axesSizeProduct[i + 1], axes.get(i).size());
       }
     } catch (ArithmeticException e) {
-      throw new IllegalArgumentException(
-          "Cartesian product too large; must have size at most Integer.MAX_VALUE");
+        // size which returns axesSizeProduct[0] will now return Integer.MAX_VALUE
+        for (; i >= 0; i--) {
+          axesSizeProduct[i] = Integer.MAX_VALUE;
+        }
     }
     this.axesSizeProduct = axesSizeProduct;
   }

--- a/guava/src/com/google/common/collect/CartesianList.java
+++ b/guava/src/com/google/common/collect/CartesianList.java
@@ -60,7 +60,7 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
       // size which returns axesSizeProduct[0] will now return Integer.MAX_VALUE
       for (; i >= 0; i--) {
         axesSizeProduct[i] = Integer.MAX_VALUE;
-      }
+      } // test
     }
     this.axesSizeProduct = axesSizeProduct;
   }


### PR DESCRIPTION
#3742 said that they would like to be able to create a `Sets::cartesianProduct` object that would have more than 2^31-1 elements in the resulting set. Currently, it throws an `IllegalArgumentException` when this happens. @Meijuh said that since "java.util.Set::size() specifies that if the size would be more than Integer.MAX_VALUE it would simply be Integer.MAX_VALUE" this should be fixed.
So the code change is that instead of throwing an exception, the remaining lower parts of the axesSizeProduct integer array are set to Integer.MAX_VALUE so the size function (which returns axesSizeProduct[0]) will now return Integer.MAX_VALUE.