### PR TITLE
Issue #3874: Improve cartesianProduct.lastIndexOf 

### DIFF
--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -629,6 +629,15 @@ public class ListsTest extends TestCase {
     assertEquals(actual.indexOf(list(1, 1, 1)), -1);
   }
 
+  public void testCartesianProduct_lastIndexOf() {
+    List<List<Integer>> actual = Lists.cartesianProduct(list(1, 1), list(2, 3));
+    assertEquals(actual.lastIndexOf(list(1, 2)), 2);
+    assertEquals(actual.lastIndexOf(list(1, 3)), 3);
+
+    assertEquals(actual.lastIndexOf(list(1)), -1);
+    assertEquals(actual.lastIndexOf(list(1, 1, 1)), -1);
+  }
+
   @SuppressWarnings("unchecked") // varargs!
   public void testCartesianProduct_unrelatedTypes() {
     List<Integer> x = list(1, 2);

--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -631,11 +631,12 @@ public class ListsTest extends TestCase {
 
   public void testCartesianProduct_lastIndexOf() {
     List<List<Integer>> actual = Lists.cartesianProduct(list(1, 1), list(2, 3));
-    assertEquals(actual.lastIndexOf(list(1, 2)), 2);
-    assertEquals(actual.lastIndexOf(list(1, 3)), 3);
+    assertThat(actual.lastIndexOf(list(1, 2))).isEqualTo(2);
+    assertThat(actual.lastIndexOf(list(1, 3))).isEqualTo(3);
+    assertThat(actual.lastIndexOf(list(1, 1))).isEqualTo(-1);
 
-    assertEquals(actual.lastIndexOf(list(1)), -1);
-    assertEquals(actual.lastIndexOf(list(1, 1, 1)), -1);
+    assertThat(actual.lastIndexOf(list(1))).isEqualTo(-1);
+    assertThat(actual.lastIndexOf(list(1, 1, 1))).isEqualTo(-1);
   }
 
   @SuppressWarnings("unchecked") // varargs!

--- a/guava/src/com/google/common/collect/CartesianList.java
+++ b/guava/src/com/google/common/collect/CartesianList.java
@@ -89,6 +89,28 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
   }
 
   @Override
+  public int lastIndexOf(Object o) {
+    if (!(o instanceof List)) {
+      return -1;
+    }
+    List<?> list = (List<?>) o;
+    if (list.size() != axes.size()) {
+      return -1;
+    }
+    ListIterator<?> itr = list.listIterator();
+    int computedIndex = 0;
+    while (itr.hasNext()) {
+      int axisIndex = itr.nextIndex();
+      int elemIndex = axes.get(axisIndex).lastIndexOf(itr.next());
+      if (elemIndex == -1) {
+        return -1;
+      }
+      computedIndex += elemIndex * axesSizeProduct[axisIndex + 1];
+    }
+    return computedIndex;
+  }
+
+  @Override
   public ImmutableList<E> get(final int index) {
     checkElementIndex(index, size());
     return new ImmutableList<E>() {


### PR DESCRIPTION
Implemented `lastIndexOf()` in `CertesianList` and added appropriate tests.