### PR TITLE
MOE Sync 2020-05-04

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/SetsTest.java
+++ b/android/guava-tests/test/com/google/common/collect/SetsTest.java
@@ -949,6 +949,13 @@ public class SetsTest extends TestCase {
     }
   }
 
+  public void testPowerSetEquals_independentOfOrder() {
+    ImmutableSet<Integer> elements = ImmutableSet.of(1, 2, 3, 4);
+    Set<Set<Integer>> forward = powerSet(elements);
+    Set<Set<Integer>> reverse = powerSet(ImmutableSet.copyOf(elements.asList().reverse()));
+    new EqualsTester().addEqualityGroup(forward, reverse).testEquals();
+  }
+
   /**
    * Test that a hash code miscomputed by "input.hashCode() * tooFarValue / 2" is correct under our
    * {@code hashCode} implementation.

--- a/android/guava/src/com/google/common/collect/Sets.java
+++ b/android/guava/src/com/google/common/collect/Sets.java
@@ -1505,7 +1505,7 @@ public final class Sets {
     public boolean equals(@NullableDecl Object obj) {
       if (obj instanceof PowerSet) {
         PowerSet<?> that = (PowerSet<?>) obj;
-        return inputSet.equals(that.inputSet);
+        return inputSet.keySet().equals(that.inputSet.keySet());
       }
       return super.equals(obj);
     }

--- a/guava-gwt/test/com/google/common/collect/SetsTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/SetsTest_gwt.java
@@ -303,6 +303,11 @@ public void testPowerSetEqualsAndHashCode_verifyAgainstHashSet() throws Exceptio
   testCase.testPowerSetEqualsAndHashCode_verifyAgainstHashSet();
 }
 
+public void testPowerSetEquals_independentOfOrder() throws Exception {
+  com.google.common.collect.SetsTest testCase = new com.google.common.collect.SetsTest();
+  testCase.testPowerSetEquals_independentOfOrder();
+}
+
 public void testPowerSetHashCode_inputHashCodeTimesTooFarValueIsZero() throws Exception {
   com.google.common.collect.SetsTest testCase = new com.google.common.collect.SetsTest();
   testCase.testPowerSetHashCode_inputHashCodeTimesTooFarValueIsZero();

--- a/guava-tests/test/com/google/common/collect/SetsTest.java
+++ b/guava-tests/test/com/google/common/collect/SetsTest.java
@@ -961,6 +961,13 @@ public class SetsTest extends TestCase {
     }
   }
 
+  public void testPowerSetEquals_independentOfOrder() {
+    ImmutableSet<Integer> elements = ImmutableSet.of(1, 2, 3, 4);
+    Set<Set<Integer>> forward = powerSet(elements);
+    Set<Set<Integer>> reverse = powerSet(ImmutableSet.copyOf(elements.asList().reverse()));
+    new EqualsTester().addEqualityGroup(forward, reverse).testEquals();
+  }
+
   /**
    * Test that a hash code miscomputed by "input.hashCode() * tooFarValue / 2" is correct under our
    * {@code hashCode} implementation.

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -1596,7 +1596,7 @@ public final class Sets {
     public boolean equals(@Nullable Object obj) {
       if (obj instanceof PowerSet) {
         PowerSet<?> that = (PowerSet<?>) obj;
-        return inputSet.equals(that.inputSet);
+        return inputSet.keySet().equals(that.inputSet.keySet());
       }
       return super.equals(obj);
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix PowerSet.equals() when comparing to another PowerSet whose items are the same, but in a different iteration order.

RELNOTES:
  Fix issue where PowerSet.equals(PowerSet) would erroneously return
  false if the PowerSet's underlying Sets were equal, but in a different
  iteration order.

Fixes #3891, #3890

befd5ced9edc93a65c75201eb0698a571398005f