### PR TITLE
MOE Sync 2020-05-12

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/SequentialExecutor.java
+++ b/android/guava/src/com/google/common/util/concurrent/SequentialExecutor.java
@@ -24,7 +24,7 @@ import static java.lang.System.identityHashCode;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import com.google.j2objc.annotations.WeakOuter;
+import com.google.j2objc.annotations.RetainedWith;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Executor;
@@ -80,7 +80,7 @@ final class SequentialExecutor implements Executor {
   @GuardedBy("queue")
   private long workerRunCount = 0;
 
-  private final QueueWorker worker = new QueueWorker();
+  @RetainedWith private final QueueWorker worker = new QueueWorker();
 
   /** Use {@link MoreExecutors#newSequentialExecutor} */
   SequentialExecutor(Executor executor) {
@@ -164,7 +164,6 @@ final class SequentialExecutor implements Executor {
   }
 
   /** Worker that runs tasks from {@link #queue} until it is empty. */
-  @WeakOuter
   private final class QueueWorker implements Runnable {
     @Override
     public void run() {

--- a/guava/src/com/google/common/util/concurrent/SequentialExecutor.java
+++ b/guava/src/com/google/common/util/concurrent/SequentialExecutor.java
@@ -24,7 +24,7 @@ import static java.lang.System.identityHashCode;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import com.google.j2objc.annotations.WeakOuter;
+import com.google.j2objc.annotations.RetainedWith;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Executor;
@@ -80,7 +80,7 @@ final class SequentialExecutor implements Executor {
   @GuardedBy("queue")
   private long workerRunCount = 0;
 
-  private final QueueWorker worker = new QueueWorker();
+  @RetainedWith private final QueueWorker worker = new QueueWorker();
 
   /** Use {@link MoreExecutors#newSequentialExecutor} */
   SequentialExecutor(Executor executor) {
@@ -164,7 +164,6 @@ final class SequentialExecutor implements Executor {
   }
 
   /** Worker that runs tasks from {@link #queue} until it is empty. */
-  @WeakOuter
   private final class QueueWorker implements Runnable {
     @Override
     public void run() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ensure QueueWorker does not outlive SequentialExecutor on iOS.

When `SequentialExecutor` is used on iOS as J2ObjC-transpiled code, we need to
make sure that `SequentialExecutor.QueueWorker` does not outlive its outer
class. Previously, because the inner class was annotated with `@WeakOuter`, it
could happen, and, when this happened, the inner class would then invoke
methods on a dangling pointer and crash the process in turn. The issue is now
fixed by annotating the worker field in the outer class with `@RetainedWith`.

Although `@RetainedWith` was initially designed for bimaps, the annotation
addresses exactly the lifecycle problem here.

180157a2ab9d4574d69eeed3d654ceaff7f5b59d