### PR TITLE
MOE Sync 2020-05-13

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -629,6 +629,16 @@ public class ListsTest extends TestCase {
     assertEquals(actual.indexOf(list(1, 1, 1)), -1);
   }
 
+  public void testCartesianProduct_lastIndexOf() {
+    List<List<Integer>> actual = Lists.cartesianProduct(list(1, 1), list(2, 3));
+    assertThat(actual.lastIndexOf(list(1, 2))).isEqualTo(2);
+    assertThat(actual.lastIndexOf(list(1, 3))).isEqualTo(3);
+    assertThat(actual.lastIndexOf(list(1, 1))).isEqualTo(-1);
+
+    assertThat(actual.lastIndexOf(list(1))).isEqualTo(-1);
+    assertThat(actual.lastIndexOf(list(1, 1, 1))).isEqualTo(-1);
+  }
+
   @SuppressWarnings("unchecked") // varargs!
   public void testCartesianProduct_unrelatedTypes() {
     List<Integer> x = list(1, 2);

--- a/android/guava/src/com/google/common/collect/CartesianList.java
+++ b/android/guava/src/com/google/common/collect/CartesianList.java
@@ -89,6 +89,28 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
   }
 
   @Override
+  public int lastIndexOf(Object o) {
+    if (!(o instanceof List)) {
+      return -1;
+    }
+    List<?> list = (List<?>) o;
+    if (list.size() != axes.size()) {
+      return -1;
+    }
+    ListIterator<?> itr = list.listIterator();
+    int computedIndex = 0;
+    while (itr.hasNext()) {
+      int axisIndex = itr.nextIndex();
+      int elemIndex = axes.get(axisIndex).lastIndexOf(itr.next());
+      if (elemIndex == -1) {
+        return -1;
+      }
+      computedIndex += elemIndex * axesSizeProduct[axisIndex + 1];
+    }
+    return computedIndex;
+  }
+
+  @Override
   public ImmutableList<E> get(final int index) {
     checkElementIndex(index, size());
     return new ImmutableList<E>() {

--- a/android/guava/src/com/google/common/primitives/ImmutableIntArray.java
+++ b/android/guava/src/com/google/common/primitives/ImmutableIntArray.java
@@ -262,9 +262,7 @@ public final class ImmutableIntArray implements Serializable {
     private void ensureRoomFor(int numberToAdd) {
       int newCount = count + numberToAdd; // TODO(kevinb): check overflow now?
       if (newCount > array.length) {
-        int[] newArray = new int[expandedCapacity(array.length, newCount)];
-        System.arraycopy(array, 0, newArray, 0, count);
-        this.array = newArray;
+        this.array = Arrays.copyOf(array, expandedCapacity(array.length, newCount));
       }
     }
 

--- a/guava-gwt/test/com/google/common/collect/ListsTest_gwt.java
+++ b/guava-gwt/test/com/google/common/collect/ListsTest_gwt.java
@@ -68,6 +68,11 @@ public void testCartesianProduct_indexOf() throws Exception {
   testCase.testCartesianProduct_indexOf();
 }
 
+public void testCartesianProduct_lastIndexOf() throws Exception {
+  com.google.common.collect.ListsTest testCase = new com.google.common.collect.ListsTest();
+  testCase.testCartesianProduct_lastIndexOf();
+}
+
 public void testCartesianProduct_unrelatedTypes() throws Exception {
   com.google.common.collect.ListsTest testCase = new com.google.common.collect.ListsTest();
   testCase.testCartesianProduct_unrelatedTypes();

--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -629,6 +629,16 @@ public class ListsTest extends TestCase {
     assertEquals(actual.indexOf(list(1, 1, 1)), -1);
   }
 
+  public void testCartesianProduct_lastIndexOf() {
+    List<List<Integer>> actual = Lists.cartesianProduct(list(1, 1), list(2, 3));
+    assertThat(actual.lastIndexOf(list(1, 2))).isEqualTo(2);
+    assertThat(actual.lastIndexOf(list(1, 3))).isEqualTo(3);
+    assertThat(actual.lastIndexOf(list(1, 1))).isEqualTo(-1);
+
+    assertThat(actual.lastIndexOf(list(1))).isEqualTo(-1);
+    assertThat(actual.lastIndexOf(list(1, 1, 1))).isEqualTo(-1);
+  }
+
   @SuppressWarnings("unchecked") // varargs!
   public void testCartesianProduct_unrelatedTypes() {
     List<Integer> x = list(1, 2);

--- a/guava/src/com/google/common/collect/CartesianList.java
+++ b/guava/src/com/google/common/collect/CartesianList.java
@@ -89,6 +89,28 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
   }
 
   @Override
+  public int lastIndexOf(Object o) {
+    if (!(o instanceof List)) {
+      return -1;
+    }
+    List<?> list = (List<?>) o;
+    if (list.size() != axes.size()) {
+      return -1;
+    }
+    ListIterator<?> itr = list.listIterator();
+    int computedIndex = 0;
+    while (itr.hasNext()) {
+      int axisIndex = itr.nextIndex();
+      int elemIndex = axes.get(axisIndex).lastIndexOf(itr.next());
+      if (elemIndex == -1) {
+        return -1;
+      }
+      computedIndex += elemIndex * axesSizeProduct[axisIndex + 1];
+    }
+    return computedIndex;
+  }
+
+  @Override
   public ImmutableList<E> get(final int index) {
     checkElementIndex(index, size());
     return new ImmutableList<E>() {

--- a/guava/src/com/google/common/primitives/ImmutableIntArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableIntArray.java
@@ -291,9 +291,7 @@ public final class ImmutableIntArray implements Serializable {
     private void ensureRoomFor(int numberToAdd) {
       int newCount = count + numberToAdd; // TODO(kevinb): check overflow now?
       if (newCount > array.length) {
-        int[] newArray = new int[expandedCapacity(array.length, newCount)];
-        System.arraycopy(array, 0, newArray, 0, count);
-        this.array = newArray;
+        this.array = Arrays.copyOf(array, expandedCapacity(array.length, newCount));
       }
     }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> In ImmutableIntArray, use Arrays.copyOf when expanding the internal array.

909bdb290675c41238a194ad32e6686cda58f6dc

-------

<p> Implemented lastIndexOf in CartesianList

Fixes #3878

13da6dd1e8446bc2e5e6a5ac6e87e82ce0b7743f