### PR TITLE
MOE Sync 2020-05-14

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/AbstractBiMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/AbstractBiMapTest.java
@@ -28,6 +28,7 @@ public class AbstractBiMapTest extends TestCase {
 
   // The next two tests verify that map entries are not accessed after they're
   // removed, since IdentityHashMap throws an exception when that occurs.
+  @SuppressWarnings("IdentityHashMapBoxing") // explicitly testing IdentityHashMap
   public void testIdentityKeySetIteratorRemove() {
     BiMap<Integer, String> bimap =
         new AbstractBiMap<Integer, String>(
@@ -45,6 +46,7 @@ public class AbstractBiMapTest extends TestCase {
     assertEquals(1, bimap.inverse().size());
   }
 
+  @SuppressWarnings("IdentityHashMapBoxing") // explicitly testing IdentityHashMap
   public void testIdentityEntrySetIteratorRemove() {
     BiMap<Integer, String> bimap =
         new AbstractBiMap<Integer, String>(

--- a/android/guava-tests/test/com/google/common/net/HttpHeadersTest.java
+++ b/android/guava-tests/test/com/google/common/net/HttpHeadersTest.java
@@ -50,7 +50,8 @@ public class HttpHeadersTest extends TestCase {
             .build();
     ImmutableSet<String> uppercaseAcronyms =
         ImmutableSet.of(
-            "ID", "DNT", "DNS", "HTTP2", "IP", "MD5", "P3P", "TE", "UID", "URL", "WWW", "XSS");
+            "CH", "ID", "DNT", "DNS", "HTTP2", "IP", "MD5", "P3P", "TE", "UA", "UID", "URL", "WWW",
+            "XSS");
     assertConstantNameMatchesString(HttpHeaders.class, specialCases, uppercaseAcronyms);
   }
 

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -475,6 +475,14 @@ public final class HttpHeaders {
   public static final String X_MOZ = "X-Moz";
 
   /**
+   * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua">{@code Sec-CH-UA}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_CH_UA = "Sec-CH-UA";
+
+  /**
    * The HTTP <a href="https://w3c.github.io/webappsec-fetch-metadata/">{@code Sec-Fetch-Dest}</a>
    * header field name.
    *

--- a/guava-tests/test/com/google/common/collect/AbstractBiMapTest.java
+++ b/guava-tests/test/com/google/common/collect/AbstractBiMapTest.java
@@ -28,6 +28,7 @@ public class AbstractBiMapTest extends TestCase {
 
   // The next two tests verify that map entries are not accessed after they're
   // removed, since IdentityHashMap throws an exception when that occurs.
+  @SuppressWarnings("IdentityHashMapBoxing") // explicitly testing IdentityHashMap
   public void testIdentityKeySetIteratorRemove() {
     BiMap<Integer, String> bimap =
         new AbstractBiMap<Integer, String>(
@@ -45,6 +46,7 @@ public class AbstractBiMapTest extends TestCase {
     assertEquals(1, bimap.inverse().size());
   }
 
+  @SuppressWarnings("IdentityHashMapBoxing") // explicitly testing IdentityHashMap
   public void testIdentityEntrySetIteratorRemove() {
     BiMap<Integer, String> bimap =
         new AbstractBiMap<Integer, String>(

--- a/guava-tests/test/com/google/common/net/HttpHeadersTest.java
+++ b/guava-tests/test/com/google/common/net/HttpHeadersTest.java
@@ -50,7 +50,8 @@ public class HttpHeadersTest extends TestCase {
             .build();
     ImmutableSet<String> uppercaseAcronyms =
         ImmutableSet.of(
-            "ID", "DNT", "DNS", "HTTP2", "IP", "MD5", "P3P", "TE", "UID", "URL", "WWW", "XSS");
+            "CH", "ID", "DNT", "DNS", "HTTP2", "IP", "MD5", "P3P", "TE", "UA", "UID", "URL", "WWW",
+            "XSS");
     assertConstantNameMatchesString(HttpHeaders.class, specialCases, uppercaseAcronyms);
   }
 

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -475,6 +475,14 @@ public final class HttpHeaders {
   public static final String X_MOZ = "X-Moz";
 
   /**
+   * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua">{@code Sec-CH-UA}</a>
+   * header field name.
+   *
+   * @since NEXT
+   */
+  public static final String SEC_CH_UA = "Sec-CH-UA";
+
+  /**
    * The HTTP <a href="https://w3c.github.io/webappsec-fetch-metadata/">{@code Sec-Fetch-Dest}</a>
    * header field name.
    *


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Suppress IdentityHashMapBoxing check

This would soon become an ERROR in blaze.

0b46c0b65b9f98f3cc36aaf185a888d3e8e76f60

-------

<p> Adding the Sec-CH-UA header. Ignore ClangTidy. It has to do with the constant naming scheme for httputils.h.

Spec for header: https://wicg.github.io/ua-client-hints/

bd128b4f293ea94eaad3aa0ba29d71ee8ea25b3c