### PR TITLE
MOE Sync 2020-06-02

### DIFF
--- a/android/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/android/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -192,6 +192,12 @@ public class MediaTypeTest extends TestCase {
     assertEquals("yams", newType.subtype());
   }
 
+  public void testCreateFontType() {
+    MediaType newType = MediaType.createFontType("yams");
+    assertEquals("font", newType.type());
+    assertEquals("yams", newType.subtype());
+  }
+
   public void testCreateImageType() {
     MediaType newType = MediaType.createImageType("yams");
     assertEquals("image", newType.type());

--- a/android/guava/src/com/google/common/annotations/VisibleForTesting.java
+++ b/android/guava/src/com/google/common/annotations/VisibleForTesting.java
@@ -18,6 +18,13 @@ package com.google.common.annotations;
  * Annotates a program element that exists, or is more widely visible than otherwise necessary, only
  * for use in test code.
  *
+ * <p><b>Do not use this interface</b> for public or protected declarations: it is a fig leaf for
+ * bad design, and it does not prevent anyone from using the declaration---and experience has shown
+ * that they will. If the method breaks the encapsulation of its class, then its internal
+ * representation will be hard to change. Instead, use <a
+ * href="http://errorprone.info/bugpattern/RestrictedApiChecker">RestrictedApiChecker</a>, which
+ * enforces fine-grained visibility policies.
+ *
  * @author Johannes Henkel
  */
 @GwtCompatible

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -101,6 +101,7 @@ public final class MediaType {
   private static final String IMAGE_TYPE = "image";
   private static final String TEXT_TYPE = "text";
   private static final String VIDEO_TYPE = "video";
+  private static final String FONT_TYPE = "font";
 
   private static final String WILDCARD = "*";
 
@@ -140,6 +141,13 @@ public final class MediaType {
   public static final MediaType ANY_AUDIO_TYPE = createConstant(AUDIO_TYPE, WILDCARD);
   public static final MediaType ANY_VIDEO_TYPE = createConstant(VIDEO_TYPE, WILDCARD);
   public static final MediaType ANY_APPLICATION_TYPE = createConstant(APPLICATION_TYPE, WILDCARD);
+
+  /**
+   * Wildcard matching any "font" top-level media type.
+   *
+   * @since NEXT
+   */
+  public static final MediaType ANY_FONT_TYPE = createConstant(FONT_TYPE, WILDCARD);
 
   /* text types */
   public static final MediaType CACHE_MANIFEST_UTF_8 =
@@ -189,6 +197,7 @@ public final class MediaType {
    */
   public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
+  /* image types */
   /**
    * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
    * files).
@@ -628,10 +637,9 @@ public final class MediaType {
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
-   * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
-   * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
-   * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
-   * the IANA.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_SFNT
+   * font/sfnt} to be the correct media type for SFNT, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 17.0
    */
@@ -664,18 +672,18 @@ public final class MediaType {
   public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
 
   /**
-   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
-   * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
-   * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
-   * the IANA.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_WOFF
+   * font/woff} to be the correct media type for WOFF, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 17.0
    */
   public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
 
   /**
-   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
-   * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_WOFF2
+   * font/woff2} to be the correct media type for WOFF2, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 20.0
    */
@@ -694,6 +702,62 @@ public final class MediaType {
   public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
 
   public static final MediaType ZIP = createConstant(APPLICATION_TYPE, "zip");
+
+  /* font types */
+
+  /**
+   * A collection of font outlines as defined by <a href="https://tools.ietf.org/html/rfc8081">RFC
+   * 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_COLLECTION = createConstant(FONT_TYPE, "collection");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_OTF = createConstant(FONT_TYPE, "otf");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/SFNT">Spline or Scalable Font Format</a> (SFNT). <a
+   * href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct media
+   * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
+   * for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_SFNT = createConstant(FONT_TYPE, "sfnt");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_TTF = createConstant(FONT_TYPE, "ttf");
+
+  /**
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF). <a
+   * href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct media
+   * type for SFNT, but {@link #WOFF application/font-woff} may be necessary in certain situations
+   * for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_WOFF = createConstant(FONT_TYPE, "woff");
+
+  /**
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF2).
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct
+   * media type for SFNT, but {@link #WOFF2 application/font-woff2} may be necessary in certain
+   * situations for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_WOFF2 = createConstant(FONT_TYPE, "woff2");
 
   private final String type;
   private final String subtype;
@@ -929,6 +993,15 @@ public final class MediaType {
    */
   static MediaType createAudioType(String subtype) {
     return create(AUDIO_TYPE, subtype);
+  }
+
+  /**
+   * Creates a media type with the "font" type and the given subtype.
+   *
+   * @throws IllegalArgumentException if subtype is invalid
+   */
+  static MediaType createFontType(String subtype) {
+    return create(FONT_TYPE, subtype);
   }
 
   /**

--- a/guava-gwt/test/com/google/common/net/MediaTypeTest_gwt.java
+++ b/guava-gwt/test/com/google/common/net/MediaTypeTest_gwt.java
@@ -28,6 +28,11 @@ public void testCreateAudioType() throws Exception {
   testCase.testCreateAudioType();
 }
 
+public void testCreateFontType() throws Exception {
+  com.google.common.net.MediaTypeTest testCase = new com.google.common.net.MediaTypeTest();
+  testCase.testCreateFontType();
+}
+
 public void testCreateImageType() throws Exception {
   com.google.common.net.MediaTypeTest testCase = new com.google.common.net.MediaTypeTest();
   testCase.testCreateImageType();

--- a/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -192,6 +192,12 @@ public class MediaTypeTest extends TestCase {
     assertEquals("yams", newType.subtype());
   }
 
+  public void testCreateFontType() {
+    MediaType newType = MediaType.createFontType("yams");
+    assertEquals("font", newType.type());
+    assertEquals("yams", newType.subtype());
+  }
+
   public void testCreateImageType() {
     MediaType newType = MediaType.createImageType("yams");
     assertEquals("image", newType.type());

--- a/guava/src/com/google/common/annotations/VisibleForTesting.java
+++ b/guava/src/com/google/common/annotations/VisibleForTesting.java
@@ -18,6 +18,13 @@ package com.google.common.annotations;
  * Annotates a program element that exists, or is more widely visible than otherwise necessary, only
  * for use in test code.
  *
+ * <p><b>Do not use this interface</b> for public or protected declarations: it is a fig leaf for
+ * bad design, and it does not prevent anyone from using the declaration---and experience has shown
+ * that they will. If the method breaks the encapsulation of its class, then its internal
+ * representation will be hard to change. Instead, use <a
+ * href="http://errorprone.info/bugpattern/RestrictedApiChecker">RestrictedApiChecker</a>, which
+ * enforces fine-grained visibility policies.
+ *
  * @author Johannes Henkel
  */
 @GwtCompatible

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -101,6 +101,7 @@ public final class MediaType {
   private static final String IMAGE_TYPE = "image";
   private static final String TEXT_TYPE = "text";
   private static final String VIDEO_TYPE = "video";
+  private static final String FONT_TYPE = "font";
 
   private static final String WILDCARD = "*";
 
@@ -140,6 +141,13 @@ public final class MediaType {
   public static final MediaType ANY_AUDIO_TYPE = createConstant(AUDIO_TYPE, WILDCARD);
   public static final MediaType ANY_VIDEO_TYPE = createConstant(VIDEO_TYPE, WILDCARD);
   public static final MediaType ANY_APPLICATION_TYPE = createConstant(APPLICATION_TYPE, WILDCARD);
+
+  /**
+   * Wildcard matching any "font" top-level media type.
+   *
+   * @since NEXT
+   */
+  public static final MediaType ANY_FONT_TYPE = createConstant(FONT_TYPE, WILDCARD);
 
   /* text types */
   public static final MediaType CACHE_MANIFEST_UTF_8 =
@@ -189,6 +197,7 @@ public final class MediaType {
    */
   public static final MediaType VTT_UTF_8 = createConstantUtf8(TEXT_TYPE, "vtt");
 
+  /* image types */
   /**
    * <a href="https://en.wikipedia.org/wiki/BMP_file_format">Bitmap file format</a> ({@code bmp}
    * files).
@@ -628,10 +637,9 @@ public final class MediaType {
   public static final MediaType RTF_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "rtf");
 
   /**
-   * SFNT fonts (which includes <a href="http://en.wikipedia.org/wiki/TrueType/">TrueType</a> and <a
-   * href="http://en.wikipedia.org/wiki/OpenType/">OpenType</a> fonts). This is <a
-   * href="http://www.iana.org/assignments/media-types/application/font-sfnt">registered</a> with
-   * the IANA.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_SFNT
+   * font/sfnt} to be the correct media type for SFNT, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 17.0
    */
@@ -664,18 +672,18 @@ public final class MediaType {
   public static final MediaType TAR = createConstant(APPLICATION_TYPE, "x-tar");
 
   /**
-   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF) <a
-   * href="http://www.w3.org/TR/WOFF/">defined</a> by the W3C. This is <a
-   * href="http://www.iana.org/assignments/media-types/application/font-woff">registered</a> with
-   * the IANA.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_WOFF
+   * font/woff} to be the correct media type for WOFF, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 17.0
    */
   public static final MediaType WOFF = createConstant(APPLICATION_TYPE, "font-woff");
 
   /**
-   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF)
-   * version 2 <a href="https://www.w3.org/TR/WOFF2/">defined</a> by the W3C.
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares {@link #FONT_WOFF2
+   * font/woff2} to be the correct media type for WOFF2, but this may be necessary in certain
+   * situations for compatibility.
    *
    * @since 20.0
    */
@@ -694,6 +702,62 @@ public final class MediaType {
   public static final MediaType XRD_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "xrd+xml");
 
   public static final MediaType ZIP = createConstant(APPLICATION_TYPE, "zip");
+
+  /* font types */
+
+  /**
+   * A collection of font outlines as defined by <a href="https://tools.ietf.org/html/rfc8081">RFC
+   * 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_COLLECTION = createConstant(FONT_TYPE, "collection");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_OTF = createConstant(FONT_TYPE, "otf");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/SFNT">Spline or Scalable Font Format</a> (SFNT). <a
+   * href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct media
+   * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
+   * for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_SFNT = createConstant(FONT_TYPE, "sfnt");
+
+  /**
+   * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_TTF = createConstant(FONT_TYPE, "ttf");
+
+  /**
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF). <a
+   * href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct media
+   * type for SFNT, but {@link #WOFF application/font-woff} may be necessary in certain situations
+   * for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_WOFF = createConstant(FONT_TYPE, "woff");
+
+  /**
+   * <a href="http://en.wikipedia.org/wiki/Web_Open_Font_Format">Web Open Font Format</a> (WOFF2).
+   * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a> declares this to be the correct
+   * media type for SFNT, but {@link #WOFF2 application/font-woff2} may be necessary in certain
+   * situations for compatibility.
+   *
+   * @since NEXT
+   */
+  public static final MediaType FONT_WOFF2 = createConstant(FONT_TYPE, "woff2");
 
   private final String type;
   private final String subtype;
@@ -929,6 +993,15 @@ public final class MediaType {
    */
   static MediaType createAudioType(String subtype) {
     return create(AUDIO_TYPE, subtype);
+  }
+
+  /**
+   * Creates a media type with the "font" type and the given subtype.
+   *
+   * @throws IllegalArgumentException if subtype is invalid
+   */
+  static MediaType createFontType(String subtype) {
+    return create(FONT_TYPE, subtype);
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Added support for the "font" Top-Level Media Type (https://tools.ietf.org/html/rfc8081)

RELNOTES=`net`: Added support for "font" Top-Level Media Type

45003f5fe824838cdce85fea05de84dcb6b54993

-------

<p> guava: disavow VisibleForTesting

Johannes and I invented this class in the early days of Blaze,
and in hindsight it was clearly a mistake; it encourages self-deception.
This change adds a comment discouraging its further use.

8bb1bf1b54f6152c14b69c3699c7fe7f07332a9a