### PR TITLE
Reuse ThreadFactory in MoreExecutors

### DIFF
--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -63,6 +63,9 @@ import java.util.concurrent.TimeoutException;
  */
 @GwtCompatible(emulated = true)
 public final class MoreExecutors {
+
+  private static final ThreadFactory DEFAULT_THREAD_FACTORY = Executors.defaultThreadFactory();
+
   private MoreExecutors() {}
 
   /**
@@ -825,7 +828,7 @@ public final class MoreExecutors {
   @GwtIncompatible // concurrency
   public static ThreadFactory platformThreadFactory() {
     if (!isAppEngineWithApiClasses()) {
-      return Executors.defaultThreadFactory();
+      return DEFAULT_THREAD_FACTORY;
     }
     try {
       return (ThreadFactory)


### PR DESCRIPTION
Currently we create a new ThreadFactory instance whenever we call ```MoreExecutors.newThread()```

Just changing it to reuse the same instance. The only usage of ```platformThreadFactory()``` is in ```MoreExecutors.newThread()``` and they set the name of the thread in that method. 