### PR TITLE
MOE Sync 2020-06-05

### DIFF
--- a/android/guava/src/com/google/common/math/BigIntegerMath.java
+++ b/android/guava/src/com/google/common/math/BigIntegerMath.java
@@ -21,7 +21,9 @@ import static com.google.common.math.MathPreconditions.checkPositive;
 import static com.google.common.math.MathPreconditions.checkRoundingUnnecessary;
 import static java.math.RoundingMode.CEILING;
 import static java.math.RoundingMode.FLOOR;
+import static java.math.RoundingMode.HALF_DOWN;
 import static java.math.RoundingMode.HALF_EVEN;
+import static java.math.RoundingMode.UNNECESSARY;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -56,7 +58,7 @@ public final class BigIntegerMath {
    */
   @Beta
   public static BigInteger ceilingPowerOfTwo(BigInteger x) {
-    return BigInteger.ZERO.setBit(log2(x, RoundingMode.CEILING));
+    return BigInteger.ZERO.setBit(log2(x, CEILING));
   }
 
   /**
@@ -68,7 +70,7 @@ public final class BigIntegerMath {
    */
   @Beta
   public static BigInteger floorPowerOfTwo(BigInteger x) {
-    return BigInteger.ZERO.setBit(log2(x, RoundingMode.FLOOR));
+    return BigInteger.ZERO.setBit(log2(x, FLOOR));
   }
 
   /** Returns {@code true} if {@code x} represents a power of two. */
@@ -307,6 +309,57 @@ public final class BigIntegerMath {
   }
 
   /**
+   * Returns {@code x}, rounded to a {@code double} with the specified rounding mode. If {@code x}
+   * is precisely representable as a {@code double}, its {@code double} value will be returned;
+   * otherwise, the rounding will choose between the two nearest representable values with {@code
+   * mode}.
+   *
+   * <p>For the case of {@link RoundingMode#HALF_DOWN}, {@code HALF_UP}, and {@code HALF_EVEN},
+   * infinite {@code double} values are considered infinitely far away. For example, 2^2000 is not
+   * representable as a double, but {@code roundToDouble(BigInteger.valueOf(2).pow(2000), HALF_UP)}
+   * will return {@code Double.MAX_VALUE}, not {@code Double.POSITIVE_INFINITY}.
+   *
+   * <p>For the case of {@link RoundingMode#HALF_EVEN}, this implementation uses the IEEE 754
+   * default rounding mode: if the two nearest representable values are equally near, the one with
+   * the least significant bit zero is chosen. (In such cases, both of the nearest representable
+   * values are even integers; this method returns the one that is a multiple of a greater power of
+   * two.)
+   *
+   * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
+   *     is not precisely representable as a {@code double}
+   * @since NEXT
+   */
+  @GwtIncompatible
+  public static double roundToDouble(BigInteger x, RoundingMode mode) {
+    return BigIntegerToDoubleRounder.INSTANCE.roundToDouble(x, mode);
+  }
+
+  @GwtIncompatible
+  private static class BigIntegerToDoubleRounder extends ToDoubleRounder<BigInteger> {
+    private static final BigIntegerToDoubleRounder INSTANCE = new BigIntegerToDoubleRounder();
+
+    @Override
+    double roundToDoubleArbitrarily(BigInteger bigInteger) {
+      return DoubleUtils.bigToDouble(bigInteger);
+    }
+
+    @Override
+    int sign(BigInteger bigInteger) {
+      return bigInteger.signum();
+    }
+
+    @Override
+    BigInteger toX(double d, RoundingMode mode) {
+      return DoubleMath.roundToBigInteger(d, mode);
+    }
+
+    @Override
+    BigInteger minus(BigInteger a, BigInteger b) {
+      return a.subtract(b);
+    }
+  }
+
+  /**
    * Returns the result of dividing {@code p} by {@code q}, rounding using the specified {@code
    * RoundingMode}.
    *
@@ -432,7 +485,7 @@ public final class BigIntegerMath {
     long numeratorAccum = n;
     long denominatorAccum = 1;
 
-    int bits = LongMath.log2(n, RoundingMode.CEILING);
+    int bits = LongMath.log2(n, CEILING);
 
     int numeratorBits = bits;
 

--- a/android/guava/src/com/google/common/math/ToDoubleRounder.java
+++ b/android/guava/src/com/google/common/math/ToDoubleRounder.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.math;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.math.MathPreconditions.checkRoundingUnnecessary;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.math.RoundingMode;
+
+/**
+ * Helper type to implement rounding {@code X} to a representable {@code double} value according to
+ * a {@link RoundingMode}.
+ */
+@GwtIncompatible
+abstract class ToDoubleRounder<X extends Number & Comparable<X>> {
+  /**
+   * Returns x rounded to either the greatest double less than or equal to the precise value of x,
+   * or the least double greater than or equal to the precise value of x.
+   */
+  abstract double roundToDoubleArbitrarily(X x);
+
+  /** Returns the sign of x: either -1, 0, or 1. */
+  abstract int sign(X x);
+
+  /** Returns d's value as an X, rounded with the specified mode. */
+  abstract X toX(double d, RoundingMode mode);
+
+  /** Returns a - b, guaranteed that both arguments are nonnegative. */
+  abstract X minus(X a, X b);
+
+  /** Rounds {@code x} to a {@code double}. */
+  final double roundToDouble(X x, RoundingMode mode) {
+    checkNotNull(x, "x");
+    checkNotNull(mode, "mode");
+    double roundArbitrarily = roundToDoubleArbitrarily(x);
+    if (Double.isInfinite(roundArbitrarily)) {
+      switch (mode) {
+        case DOWN:
+        case HALF_EVEN:
+        case HALF_DOWN:
+        case HALF_UP:
+          return Double.MAX_VALUE * sign(x);
+        case FLOOR:
+          return (roundArbitrarily == Double.POSITIVE_INFINITY)
+              ? Double.MAX_VALUE
+              : Double.NEGATIVE_INFINITY;
+        case CEILING:
+          return (roundArbitrarily == Double.POSITIVE_INFINITY)
+              ? Double.POSITIVE_INFINITY
+              : -Double.MAX_VALUE;
+        case UP:
+          return roundArbitrarily;
+        case UNNECESSARY:
+          throw new ArithmeticException(x + " cannot be represented precisely as a double");
+      }
+    }
+    X roundArbitrarilyAsX = toX(roundArbitrarily, RoundingMode.UNNECESSARY);
+    int cmpXToRoundArbitrarily = x.compareTo(roundArbitrarilyAsX);
+    switch (mode) {
+      case UNNECESSARY:
+        checkRoundingUnnecessary(cmpXToRoundArbitrarily == 0);
+        return roundArbitrarily;
+      case FLOOR:
+        return (cmpXToRoundArbitrarily >= 0)
+            ? roundArbitrarily
+            : DoubleUtils.nextDown(roundArbitrarily);
+      case CEILING:
+        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+      case DOWN:
+        if (sign(x) >= 0) {
+          return (cmpXToRoundArbitrarily >= 0)
+              ? roundArbitrarily
+              : DoubleUtils.nextDown(roundArbitrarily);
+        } else {
+          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        }
+      case UP:
+        if (sign(x) >= 0) {
+          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        } else {
+          return (cmpXToRoundArbitrarily >= 0)
+              ? roundArbitrarily
+              : DoubleUtils.nextDown(roundArbitrarily);
+        }
+      case HALF_DOWN:
+      case HALF_UP:
+      case HALF_EVEN:
+        {
+          X roundFloor;
+          double roundFloorAsDouble;
+          X roundCeiling;
+          double roundCeilingAsDouble;
+
+          if (cmpXToRoundArbitrarily >= 0) {
+            roundFloorAsDouble = roundArbitrarily;
+            roundFloor = roundArbitrarilyAsX;
+            roundCeilingAsDouble = Math.nextUp(roundArbitrarily);
+            if (roundCeilingAsDouble == Double.POSITIVE_INFINITY) {
+              return roundFloorAsDouble;
+            }
+            roundCeiling = toX(roundCeilingAsDouble, RoundingMode.CEILING);
+          } else {
+            roundCeilingAsDouble = roundArbitrarily;
+            roundCeiling = roundArbitrarilyAsX;
+            roundFloorAsDouble = DoubleUtils.nextDown(roundArbitrarily);
+            if (roundFloorAsDouble == Double.NEGATIVE_INFINITY) {
+              return roundCeilingAsDouble;
+            }
+            roundFloor = toX(roundFloorAsDouble, RoundingMode.FLOOR);
+          }
+
+          X deltaToFloor = minus(x, roundFloor);
+          X deltaToCeiling = minus(roundCeiling, x);
+          int diff = deltaToFloor.compareTo(deltaToCeiling);
+          if (diff < 0) { // closer to floor
+            return roundFloorAsDouble;
+          } else if (diff > 0) { // closer to ceiling
+            return roundCeilingAsDouble;
+          }
+          // halfway between the representable values; do the half-whatever logic
+          switch (mode) {
+            case HALF_EVEN:
+              return ((DoubleUtils.getSignificand(roundFloorAsDouble) & 1L) == 0)
+                  ? roundFloorAsDouble
+                  : roundCeilingAsDouble;
+            case HALF_DOWN:
+              return (sign(x) >= 0) ? roundFloorAsDouble : roundCeilingAsDouble;
+            case HALF_UP:
+              return (sign(x) >= 0) ? roundCeilingAsDouble : roundFloorAsDouble;
+            default:
+              throw new AssertionError("impossible");
+          }
+        }
+    }
+    throw new AssertionError("impossible");
+  }
+}

--- a/guava/src/com/google/common/math/BigIntegerMath.java
+++ b/guava/src/com/google/common/math/BigIntegerMath.java
@@ -21,7 +21,9 @@ import static com.google.common.math.MathPreconditions.checkPositive;
 import static com.google.common.math.MathPreconditions.checkRoundingUnnecessary;
 import static java.math.RoundingMode.CEILING;
 import static java.math.RoundingMode.FLOOR;
+import static java.math.RoundingMode.HALF_DOWN;
 import static java.math.RoundingMode.HALF_EVEN;
+import static java.math.RoundingMode.UNNECESSARY;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
@@ -56,7 +58,7 @@ public final class BigIntegerMath {
    */
   @Beta
   public static BigInteger ceilingPowerOfTwo(BigInteger x) {
-    return BigInteger.ZERO.setBit(log2(x, RoundingMode.CEILING));
+    return BigInteger.ZERO.setBit(log2(x, CEILING));
   }
 
   /**
@@ -68,7 +70,7 @@ public final class BigIntegerMath {
    */
   @Beta
   public static BigInteger floorPowerOfTwo(BigInteger x) {
-    return BigInteger.ZERO.setBit(log2(x, RoundingMode.FLOOR));
+    return BigInteger.ZERO.setBit(log2(x, FLOOR));
   }
 
   /** Returns {@code true} if {@code x} represents a power of two. */
@@ -307,6 +309,57 @@ public final class BigIntegerMath {
   }
 
   /**
+   * Returns {@code x}, rounded to a {@code double} with the specified rounding mode. If {@code x}
+   * is precisely representable as a {@code double}, its {@code double} value will be returned;
+   * otherwise, the rounding will choose between the two nearest representable values with {@code
+   * mode}.
+   *
+   * <p>For the case of {@link RoundingMode#HALF_DOWN}, {@code HALF_UP}, and {@code HALF_EVEN},
+   * infinite {@code double} values are considered infinitely far away. For example, 2^2000 is not
+   * representable as a double, but {@code roundToDouble(BigInteger.valueOf(2).pow(2000), HALF_UP)}
+   * will return {@code Double.MAX_VALUE}, not {@code Double.POSITIVE_INFINITY}.
+   *
+   * <p>For the case of {@link RoundingMode#HALF_EVEN}, this implementation uses the IEEE 754
+   * default rounding mode: if the two nearest representable values are equally near, the one with
+   * the least significant bit zero is chosen. (In such cases, both of the nearest representable
+   * values are even integers; this method returns the one that is a multiple of a greater power of
+   * two.)
+   *
+   * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
+   *     is not precisely representable as a {@code double}
+   * @since NEXT
+   */
+  @GwtIncompatible
+  public static double roundToDouble(BigInteger x, RoundingMode mode) {
+    return BigIntegerToDoubleRounder.INSTANCE.roundToDouble(x, mode);
+  }
+
+  @GwtIncompatible
+  private static class BigIntegerToDoubleRounder extends ToDoubleRounder<BigInteger> {
+    private static final BigIntegerToDoubleRounder INSTANCE = new BigIntegerToDoubleRounder();
+
+    @Override
+    double roundToDoubleArbitrarily(BigInteger bigInteger) {
+      return DoubleUtils.bigToDouble(bigInteger);
+    }
+
+    @Override
+    int sign(BigInteger bigInteger) {
+      return bigInteger.signum();
+    }
+
+    @Override
+    BigInteger toX(double d, RoundingMode mode) {
+      return DoubleMath.roundToBigInteger(d, mode);
+    }
+
+    @Override
+    BigInteger minus(BigInteger a, BigInteger b) {
+      return a.subtract(b);
+    }
+  }
+
+  /**
    * Returns the result of dividing {@code p} by {@code q}, rounding using the specified {@code
    * RoundingMode}.
    *
@@ -432,7 +485,7 @@ public final class BigIntegerMath {
     long numeratorAccum = n;
     long denominatorAccum = 1;
 
-    int bits = LongMath.log2(n, RoundingMode.CEILING);
+    int bits = LongMath.log2(n, CEILING);
 
     int numeratorBits = bits;
 

--- a/guava/src/com/google/common/math/ToDoubleRounder.java
+++ b/guava/src/com/google/common/math/ToDoubleRounder.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.math;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.math.MathPreconditions.checkRoundingUnnecessary;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.math.RoundingMode;
+
+/**
+ * Helper type to implement rounding {@code X} to a representable {@code double} value according to
+ * a {@link RoundingMode}.
+ */
+@GwtIncompatible
+abstract class ToDoubleRounder<X extends Number & Comparable<X>> {
+  /**
+   * Returns x rounded to either the greatest double less than or equal to the precise value of x,
+   * or the least double greater than or equal to the precise value of x.
+   */
+  abstract double roundToDoubleArbitrarily(X x);
+
+  /** Returns the sign of x: either -1, 0, or 1. */
+  abstract int sign(X x);
+
+  /** Returns d's value as an X, rounded with the specified mode. */
+  abstract X toX(double d, RoundingMode mode);
+
+  /** Returns a - b, guaranteed that both arguments are nonnegative. */
+  abstract X minus(X a, X b);
+
+  /** Rounds {@code x} to a {@code double}. */
+  final double roundToDouble(X x, RoundingMode mode) {
+    checkNotNull(x, "x");
+    checkNotNull(mode, "mode");
+    double roundArbitrarily = roundToDoubleArbitrarily(x);
+    if (Double.isInfinite(roundArbitrarily)) {
+      switch (mode) {
+        case DOWN:
+        case HALF_EVEN:
+        case HALF_DOWN:
+        case HALF_UP:
+          return Double.MAX_VALUE * sign(x);
+        case FLOOR:
+          return (roundArbitrarily == Double.POSITIVE_INFINITY)
+              ? Double.MAX_VALUE
+              : Double.NEGATIVE_INFINITY;
+        case CEILING:
+          return (roundArbitrarily == Double.POSITIVE_INFINITY)
+              ? Double.POSITIVE_INFINITY
+              : -Double.MAX_VALUE;
+        case UP:
+          return roundArbitrarily;
+        case UNNECESSARY:
+          throw new ArithmeticException(x + " cannot be represented precisely as a double");
+      }
+    }
+    X roundArbitrarilyAsX = toX(roundArbitrarily, RoundingMode.UNNECESSARY);
+    int cmpXToRoundArbitrarily = x.compareTo(roundArbitrarilyAsX);
+    switch (mode) {
+      case UNNECESSARY:
+        checkRoundingUnnecessary(cmpXToRoundArbitrarily == 0);
+        return roundArbitrarily;
+      case FLOOR:
+        return (cmpXToRoundArbitrarily >= 0)
+            ? roundArbitrarily
+            : DoubleUtils.nextDown(roundArbitrarily);
+      case CEILING:
+        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+      case DOWN:
+        if (sign(x) >= 0) {
+          return (cmpXToRoundArbitrarily >= 0)
+              ? roundArbitrarily
+              : DoubleUtils.nextDown(roundArbitrarily);
+        } else {
+          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        }
+      case UP:
+        if (sign(x) >= 0) {
+          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        } else {
+          return (cmpXToRoundArbitrarily >= 0)
+              ? roundArbitrarily
+              : DoubleUtils.nextDown(roundArbitrarily);
+        }
+      case HALF_DOWN:
+      case HALF_UP:
+      case HALF_EVEN:
+        {
+          X roundFloor;
+          double roundFloorAsDouble;
+          X roundCeiling;
+          double roundCeilingAsDouble;
+
+          if (cmpXToRoundArbitrarily >= 0) {
+            roundFloorAsDouble = roundArbitrarily;
+            roundFloor = roundArbitrarilyAsX;
+            roundCeilingAsDouble = Math.nextUp(roundArbitrarily);
+            if (roundCeilingAsDouble == Double.POSITIVE_INFINITY) {
+              return roundFloorAsDouble;
+            }
+            roundCeiling = toX(roundCeilingAsDouble, RoundingMode.CEILING);
+          } else {
+            roundCeilingAsDouble = roundArbitrarily;
+            roundCeiling = roundArbitrarilyAsX;
+            roundFloorAsDouble = DoubleUtils.nextDown(roundArbitrarily);
+            if (roundFloorAsDouble == Double.NEGATIVE_INFINITY) {
+              return roundCeilingAsDouble;
+            }
+            roundFloor = toX(roundFloorAsDouble, RoundingMode.FLOOR);
+          }
+
+          X deltaToFloor = minus(x, roundFloor);
+          X deltaToCeiling = minus(roundCeiling, x);
+          int diff = deltaToFloor.compareTo(deltaToCeiling);
+          if (diff < 0) { // closer to floor
+            return roundFloorAsDouble;
+          } else if (diff > 0) { // closer to ceiling
+            return roundCeilingAsDouble;
+          }
+          // halfway between the representable values; do the half-whatever logic
+          switch (mode) {
+            case HALF_EVEN:
+              return ((DoubleUtils.getSignificand(roundFloorAsDouble) & 1L) == 0)
+                  ? roundFloorAsDouble
+                  : roundCeilingAsDouble;
+            case HALF_DOWN:
+              return (sign(x) >= 0) ? roundFloorAsDouble : roundCeilingAsDouble;
+            case HALF_UP:
+              return (sign(x) >= 0) ? roundCeilingAsDouble : roundFloorAsDouble;
+            default:
+              throw new AssertionError("impossible");
+          }
+        }
+    }
+    throw new AssertionError("impossible");
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement BigIntegerMath.roundToDouble, which rounds to the nearest representable double value.

Partially implements https://github.com/google/guava/issues/3895

RELNOTES=`math`: Added `BigIntegerMath.roundToDouble`.

d01a196043e7d1620f2880da5d35a31da9acd898