### PR TITLE
MOE Sync 2020-06-10

### DIFF
--- a/android/guava/src/com/google/common/base/Converter.java
+++ b/android/guava/src/com/google/common/base/Converter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.errorprone.annotations.concurrent.LazyInit;
+import com.google.j2objc.annotations.RetainedWith;
 import java.io.Serializable;
 import java.util.Iterator;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -241,7 +242,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
 
   private static final class ReverseConverter<A, B> extends Converter<B, A>
       implements Serializable {
-    final Converter<A, B> original;
+    @RetainedWith final Converter<A, B> original;
 
     ReverseConverter(Converter<A, B> original) {
       this.original = original;

--- a/guava/src/com/google/common/base/Converter.java
+++ b/guava/src/com/google/common/base/Converter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.errorprone.annotations.concurrent.LazyInit;
+import com.google.j2objc.annotations.RetainedWith;
 import java.io.Serializable;
 import java.util.Iterator;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -240,7 +241,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
 
   private static final class ReverseConverter<A, B> extends Converter<B, A>
       implements Serializable {
-    final Converter<A, B> original;
+    @RetainedWith final Converter<A, B> original;
 
     ReverseConverter(Converter<A, B> original) {
       this.original = original;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Break retain-cycle in Converter.java, when used in J2ObjC target.

4e820ef25352203e042bc4fc45547fae3da7c55d