### PR TITLE
MOE Sync 2020-06-23

### DIFF
--- a/cycle_whitelist.txt
+++ b/cycle_whitelist.txt
@@ -13,8 +13,6 @@ NAMESPACE junit.framework
 NAMESPACE org.junit
 
 # ***** REAL CYCLES *****
-# Inverses (currently not solvable by weakening a reference)
-FIELD com.google.common.base.Converter.reverse
 # Cycle exists until future completes
 FIELD com.google.common.util.concurrent.AbstractFuture.Listener.executor com.google.common.util.concurrent.ExecutionSequencer.TaskNonReentrantExecutor
 
@@ -23,6 +21,7 @@ FIELD com.google.common.util.concurrent.AbstractFuture.Listener.executor com.goo
 # The Runnable type is so generic that it produces too many false positives.
 TYPE java.lang.Runnable
 
+FIELD com.google.common.base.Converter.reverse
 FIELD com.google.common.collect.AbstractBiMap.EntrySet.iterator.$.entry com.google.common.collect.AbstractBiMap.EntrySet.iterator.$.next.$
 FIELD com.google.common.collect.AbstractMapBasedMultimap.map
 FIELD com.google.common.collect.AbstractMultimap.asMap com.google.common.collect.AbstractMapBasedMultimap.NavigableAsMap
@@ -36,6 +35,7 @@ FIELD com.google.common.collect.ImmutableRangeSet.ranges
 FIELD com.google.common.collect.ImmutableSet.asList
 FIELD com.google.common.collect.Maps.FilteredMapValues.unfiltered
 FIELD com.google.common.collect.Sets.SubSet.inputSet
+FIELD com.google.common.collect.SingletonImmutableBiMap.inverse
 FIELD com.google.common.collect.TreeTraverser.PostOrderNode.childIterator
 FIELD com.google.common.collect.TreeTraverser.PreOrderIterator.stack
 FIELD com.google.common.util.concurrent.AbstractFuture.Listener.executor com.google.common.util.concurrent.MoreExecutors.rejectionPropagatingExecutor.$


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix memory leak in SingletonImmutableBiMap which would appear in transpiled J2ObjC code.

The @RetainedWith annotation can not be used on both sides of the retain-cycle. The RegularImmutableBiMap does not have this problem, because it uses Inverse inner class. This CL applies similar trick in SingletonImmutableBiMap, although without additional inner class.

RELNOTES=Update SingletonImmutableBiMap to avoid retain-cycle in transpiled Obj-C code.

d7d07d50c7ae699b71c9a239212f4c3728180327