### PR TITLE
MOE Sync 2020-06-30

### DIFF
--- a/android/guava/src/com/google/common/base/Converter.java
+++ b/android/guava/src/com/google/common/base/Converter.java
@@ -118,7 +118,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
   private final boolean handleNullAutomatically;
 
   // We lazily cache the reverse view to avoid allocating on every call to reverse().
-  @LazyInit @NullableDecl private transient Converter<B, A> reverse;
+  @LazyInit @RetainedWith @NullableDecl private transient Converter<B, A> reverse;
 
   /** Constructor for use by subclasses. */
   protected Converter() {
@@ -242,7 +242,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
 
   private static final class ReverseConverter<A, B> extends Converter<B, A>
       implements Serializable {
-    @RetainedWith final Converter<A, B> original;
+    final Converter<A, B> original;
 
     ReverseConverter(Converter<A, B> original) {
       this.original = original;

--- a/guava/src/com/google/common/base/Converter.java
+++ b/guava/src/com/google/common/base/Converter.java
@@ -118,7 +118,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
   private final boolean handleNullAutomatically;
 
   // We lazily cache the reverse view to avoid allocating on every call to reverse().
-  @LazyInit private transient @Nullable Converter<B, A> reverse;
+  @LazyInit @RetainedWith private transient @Nullable Converter<B, A> reverse;
 
   /** Constructor for use by subclasses. */
   protected Converter() {
@@ -241,7 +241,7 @@ public abstract class Converter<A, B> implements Function<A, B> {
 
   private static final class ReverseConverter<A, B> extends Converter<B, A>
       implements Serializable {
-    @RetainedWith final Converter<A, B> original;
+    final Converter<A, B> original;
 
     ReverseConverter(Converter<A, B> original) {
       this.original = original;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix Converter.java by moving @RetainedWith annotation to the correct side of the cycle.

The annotation should be placed inside the "parent" object, and not the "child" object.

Reference: https://developers.google.com/j2objc/javadoc/annotations/reference/com/google/j2objc/annotations/RetainedWith

RELNOTES=N/A

58ad44a9ac2fde40095f28c504c95c6fed902d1f