### PR TITLE
MOE Sync 2020-07-10

### DIFF
--- a/android/guava/src/com/google/common/io/ByteStreams.java
+++ b/android/guava/src/com/google/common/io/ByteStreams.java
@@ -40,7 +40,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
+import java.util.Queue;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -165,7 +165,7 @@ public final class ByteStreams {
    * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
    * input stream.
    */
-  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
+  private static byte[] toByteArrayInternal(InputStream in, Queue<byte[]> bufs, int totalLen)
       throws IOException {
     // Starting with an 8k buffer, double the size of each sucessive buffer. Buffers are retained
     // in a deque so that there's no copying between buffers while reading and so all of the bytes
@@ -196,11 +196,11 @@ public final class ByteStreams {
     }
   }
 
-  private static byte[] combineBuffers(Deque<byte[]> bufs, int totalLen) {
+  private static byte[] combineBuffers(Queue<byte[]> bufs, int totalLen) {
     byte[] result = new byte[totalLen];
     int remaining = totalLen;
     while (remaining > 0) {
-      byte[] buf = bufs.removeFirst();
+      byte[] buf = bufs.remove();
       int bytesToCopy = Math.min(remaining, buf.length);
       int resultOffset = totalLen - remaining;
       System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
@@ -253,7 +253,7 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
+    Queue<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
     bufs.add(bytes);
     bufs.add(new byte[] {(byte) b});
     return toByteArrayInternal(in, bufs, bytes.length + 1);

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -40,7 +40,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
+import java.util.Queue;
 
 /**
  * Provides utility methods for working with byte arrays and I/O streams.
@@ -165,7 +165,7 @@ public final class ByteStreams {
    * a total combined length of {@code totalLen} bytes) followed by all bytes remaining in the given
    * input stream.
    */
-  private static byte[] toByteArrayInternal(InputStream in, Deque<byte[]> bufs, int totalLen)
+  private static byte[] toByteArrayInternal(InputStream in, Queue<byte[]> bufs, int totalLen)
       throws IOException {
     // Starting with an 8k buffer, double the size of each sucessive buffer. Buffers are retained
     // in a deque so that there's no copying between buffers while reading and so all of the bytes
@@ -196,11 +196,11 @@ public final class ByteStreams {
     }
   }
 
-  private static byte[] combineBuffers(Deque<byte[]> bufs, int totalLen) {
+  private static byte[] combineBuffers(Queue<byte[]> bufs, int totalLen) {
     byte[] result = new byte[totalLen];
     int remaining = totalLen;
     while (remaining > 0) {
-      byte[] buf = bufs.removeFirst();
+      byte[] buf = bufs.remove();
       int bytesToCopy = Math.min(remaining, buf.length);
       int resultOffset = totalLen - remaining;
       System.arraycopy(buf, 0, result, resultOffset, bytesToCopy);
@@ -253,7 +253,7 @@ public final class ByteStreams {
     }
 
     // the stream was longer, so read the rest normally
-    Deque<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
+    Queue<byte[]> bufs = new ArrayDeque<byte[]>(TO_BYTE_ARRAY_DEQUE_SIZE + 2);
     bufs.add(bytes);
     bufs.add(new byte[] {(byte) b});
     return toByteArrayInternal(in, bufs, bytes.length + 1);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Declare static types as Queue instead of Deque.

This may slightly clarify how the object is used.

(I was looking through com.google.common for Deque instances that were used as stacks, so I noticed this one that was used only as a queue.)

752dd15c34f206b2103e2bd338610177088c4feb