### PR TITLE
MOE Sync 2020-07-16

### DIFF
--- a/android/guava-tests/test/com/google/common/graph/TraverserTest.java
+++ b/android/guava-tests/test/com/google/common/graph/TraverserTest.java
@@ -383,8 +383,8 @@ public class TraverserTest {
   @Test
   public void forGraph_depthFirstPreOrder_infinite() {
     Iterable<Integer> result =
-        Traverser.forGraph(fixedSuccessors(Iterables.cycle(1, 2, 3))).breadthFirst(0);
-    assertThat(Iterables.limit(result, 2)).containsExactly(0, 1).inOrder();
+        Traverser.forGraph(fixedSuccessors(Iterables.cycle(1, 2, 3))).depthFirstPreOrder(0);
+    assertThat(Iterables.limit(result, 3)).containsExactly(0, 1, 2).inOrder();
   }
 
   @Test

--- a/android/guava/src/com/google/common/graph/Traverser.java
+++ b/android/guava/src/com/google/common/graph/Traverser.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
@@ -59,6 +60,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * @since 23.1
  */
 @Beta
+@DoNotMock(
+    "Call forGraph or forTree, passing a lambda or a Graph with the desired edges (built with"
+        + " GraphBuilder)")
 public abstract class Traverser<N> {
   private final SuccessorsFunction<N> successorFunction;
 

--- a/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -89,7 +89,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
   @WeakOuter
   private abstract class CombinedFutureInterruptibleTask<T> extends InterruptibleTask<T> {
     private final Executor listenerExecutor;
-    boolean thrownByExecute = true;
 
     CombinedFutureInterruptibleTask(Executor listenerExecutor) {
       this.listenerExecutor = checkNotNull(listenerExecutor);
@@ -104,9 +103,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
       try {
         listenerExecutor.execute(this);
       } catch (RejectedExecutionException e) {
-        if (thrownByExecute) {
-          CombinedFuture.this.setException(e);
-        }
+        CombinedFuture.this.setException(e);
       }
     }
 
@@ -153,7 +150,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     ListenableFuture<V> runInterruptibly() throws Exception {
-      thrownByExecute = false;
       ListenableFuture<V> result = callable.call();
       return checkNotNull(
           result,
@@ -184,7 +180,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     V runInterruptibly() throws Exception {
-      thrownByExecute = false;
       return callable.call();
     }
 

--- a/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -973,31 +973,12 @@ public final class MoreExecutors {
       return delegate;
     }
     return new Executor() {
-      boolean thrownFromDelegate = true;
-
       @Override
-      public void execute(final Runnable command) {
+      public void execute(Runnable command) {
         try {
-          delegate.execute(
-              new Runnable() {
-                @Override
-                public void run() {
-                  thrownFromDelegate = false;
-                  command.run();
-                }
-
-                @Override
-                public String toString() {
-                  return command.toString();
-                }
-              });
+          delegate.execute(command);
         } catch (RejectedExecutionException e) {
-          if (thrownFromDelegate) {
-            // wrap exception?
-            future.setException(e);
-          }
-          // otherwise it must have been thrown from a transitive call and the delegate runnable
-          // should have handled it.
+          future.setException(e);
         }
       }
     };

--- a/guava-tests/test/com/google/common/graph/TraverserTest.java
+++ b/guava-tests/test/com/google/common/graph/TraverserTest.java
@@ -383,8 +383,8 @@ public class TraverserTest {
   @Test
   public void forGraph_depthFirstPreOrder_infinite() {
     Iterable<Integer> result =
-        Traverser.forGraph(fixedSuccessors(Iterables.cycle(1, 2, 3))).breadthFirst(0);
-    assertThat(Iterables.limit(result, 2)).containsExactly(0, 1).inOrder();
+        Traverser.forGraph(fixedSuccessors(Iterables.cycle(1, 2, 3))).depthFirstPreOrder(0);
+    assertThat(Iterables.limit(result, 3)).containsExactly(0, 1, 2).inOrder();
   }
 
   @Test

--- a/guava/src/com/google/common/graph/Traverser.java
+++ b/guava/src/com/google/common/graph/Traverser.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.DoNotMock;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
@@ -59,6 +60,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @since 23.1
  */
 @Beta
+@DoNotMock(
+    "Call forGraph or forTree, passing a lambda or a Graph with the desired edges (built with"
+        + " GraphBuilder)")
 public abstract class Traverser<N> {
   private final SuccessorsFunction<N> successorFunction;
 

--- a/guava/src/com/google/common/util/concurrent/CombinedFuture.java
+++ b/guava/src/com/google/common/util/concurrent/CombinedFuture.java
@@ -89,7 +89,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
   @WeakOuter
   private abstract class CombinedFutureInterruptibleTask<T> extends InterruptibleTask<T> {
     private final Executor listenerExecutor;
-    boolean thrownByExecute = true;
 
     CombinedFutureInterruptibleTask(Executor listenerExecutor) {
       this.listenerExecutor = checkNotNull(listenerExecutor);
@@ -104,9 +103,7 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
       try {
         listenerExecutor.execute(this);
       } catch (RejectedExecutionException e) {
-        if (thrownByExecute) {
-          CombinedFuture.this.setException(e);
-        }
+        CombinedFuture.this.setException(e);
       }
     }
 
@@ -153,7 +150,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     ListenableFuture<V> runInterruptibly() throws Exception {
-      thrownByExecute = false;
       ListenableFuture<V> result = callable.call();
       return checkNotNull(
           result,
@@ -184,7 +180,6 @@ final class CombinedFuture<V> extends AggregateFuture<Object, V> {
 
     @Override
     V runInterruptibly() throws Exception {
-      thrownByExecute = false;
       return callable.call();
     }
 

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -1078,31 +1078,12 @@ public final class MoreExecutors {
       return delegate;
     }
     return new Executor() {
-      boolean thrownFromDelegate = true;
-
       @Override
-      public void execute(final Runnable command) {
+      public void execute(Runnable command) {
         try {
-          delegate.execute(
-              new Runnable() {
-                @Override
-                public void run() {
-                  thrownFromDelegate = false;
-                  command.run();
-                }
-
-                @Override
-                public String toString() {
-                  return command.toString();
-                }
-              });
+          delegate.execute(command);
         } catch (RejectedExecutionException e) {
-          if (thrownFromDelegate) {
-            // wrap exception?
-            future.setException(e);
-          }
-          // otherwise it must have been thrown from a transitive call and the delegate runnable
-          // should have handled it.
+          future.setException(e);
         }
       }
     };


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Unconditionally call setException for RejectedExecutionException.

Under JDK11, the write to thrownByExecute / thrownFromDelegate is upsetting TSAN. I *suspect* that TSAN is incorrect (and that it is likely to identify the same "problem" in other code).

However, we years ago questioned whether the code I'm removing served any real purpose...
(fixes https://github.com/google/guava/issues/2877)
...so now seems like a good time to get rid of it and, at minimum, hopefully eliminate the current TSAN failure.

The code that we're running in the executor is under our control. (That is, we're the ones who implement Runnable.run().) We're catching exceptions (and thus any RejectedExecutionException) in the obvious places. Occasionally we do call listeners, but naturally we do that only after completing the future or at least calling setFuture (after which a stray setException(rejectedExecutionException) would be a no-op).

The one(?) exception to that is that InterruptibleTask.run() can call currentThread.interrupt(), which we learned a few years ago can call arbitrary code through nio callbacks. At some point, though, I throw my hands up and say "whatever."

(If the interrupt were to be a problem, it would have to be with an executor that executes tasks inline, like directExecutor. But I note that rejectionPropagatingExecutor, at least, already defends against this for directExecutor itself (by skipping the RejectedExecutionException logic entirely). So the danger exists only with CombinedFutureInterruptibleTask or with a non-directExecutor that can execute tasks inline without catching exceptions -- and again, only in concert with nio interrupt callbacks. I think.)

238c383c13d05a75bb6b590f1542e5f4b11f0634

-------

<p> Add @DoNotMock to Traverser.

RELNOTES=Add @DoNotMock to Traverser

83e545cd90bbd64b71ac66ff51267bca670bf8f9