### PR TITLE
MOE Sync 2020-07-22

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/UninterruptiblesTest.java
@@ -17,12 +17,14 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.util.concurrent.InterruptionUtil.repeatedlyInterruptTestThread;
+import static com.google.common.util.concurrent.Uninterruptibles.awaitTerminationUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.joinUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.putUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.takeUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.tryAcquireUninterruptibly;
 import static com.google.common.util.concurrent.Uninterruptibles.tryLockUninterruptibly;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -36,6 +38,7 @@ import java.util.Date;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -465,6 +468,37 @@ public class UninterruptiblesTest extends TestCase {
     assertInterrupted();
   }
 
+  // executor.awaitTermination Testcases
+  public void testTryAwaitTerminationUninterruptiblyLongTimeUnit_success() {
+    ExecutorService executor = newFixedThreadPool(1);
+    requestInterruptIn(500);
+    executor.execute(new SleepTask(1000));
+    executor.shutdown();
+    assertTrue(awaitTerminationUninterruptibly(executor, LONG_DELAY_MS, MILLISECONDS));
+    assertTrue(executor.isTerminated());
+    assertInterrupted();
+  }
+
+  public void testTryAwaitTerminationUninterruptiblyLongTimeUnit_failure() {
+    ExecutorService executor = newFixedThreadPool(1);
+    requestInterruptIn(500);
+    executor.execute(new SleepTask(10000));
+    executor.shutdown();
+    assertFalse(awaitTerminationUninterruptibly(executor, 1000, MILLISECONDS));
+    assertFalse(executor.isTerminated());
+    assertInterrupted();
+  }
+
+  public void testTryAwaitTerminationInfiniteTimeout() {
+    ExecutorService executor = newFixedThreadPool(1);
+    requestInterruptIn(500);
+    executor.execute(new SleepTask(1000));
+    executor.shutdown();
+    awaitTerminationUninterruptibly(executor);
+    assertTrue(executor.isTerminated());
+    assertInterrupted();
+  }
+
   /**
    * Wrapper around {@link Stopwatch} which also contains an "expected completion time." Creating a
    * {@code Completion} starts the underlying stopwatch.
@@ -752,6 +786,15 @@ public class UninterruptiblesTest extends TestCase {
     protected void doAction() {
       semaphore.release(10);
     }
+  }
+
+  private static final class SleepTask extends DelayedActionRunnable {
+    SleepTask(long tMinus) {
+      super(tMinus);
+    }
+
+    @Override
+    protected void doAction() {}
   }
 
   private static void sleepSuccessfully(long sleepMillis) {

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -14,6 +14,7 @@
 
 package com.google.common.util.concurrent;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Internal.toNanosSaturated;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -27,6 +28,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -501,6 +503,63 @@ public final class Uninterruptibles {
       while (true) {
         try {
           return lock.tryLock(remainingNanos, NANOSECONDS);
+        } catch (InterruptedException e) {
+          interrupted = true;
+          remainingNanos = end - System.nanoTime();
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
+   * awaitTermination(long, TimeUnit)} uninterruptibly with no timeout.
+   *
+   * @since NEXT
+   */
+  @Beta
+  @GwtIncompatible // concurrency
+  public static void awaitTerminationUninterruptibly(ExecutorService executor) {
+    // TODO(cpovirk): We could optimize this to avoid calling nanoTime() at all.
+    verify(awaitTerminationUninterruptibly(executor, Long.MAX_VALUE, NANOSECONDS));
+  }
+
+  /**
+   * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
+   * awaitTermination(long, TimeUnit)} uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @Beta
+  @GwtIncompatible // concurrency
+  public static boolean awaitTerminationUninterruptibly(
+      ExecutorService executor, Duration timeout) {
+    return awaitTerminationUninterruptibly(executor, toNanosSaturated(timeout), NANOSECONDS);
+  }
+
+  /**
+   * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
+   * awaitTermination(long, TimeUnit)} uninterruptibly.
+   *
+   * @since NEXT
+   */
+  @Beta
+  @GwtIncompatible // concurrency
+  @SuppressWarnings("GoodTime")
+  public static boolean awaitTerminationUninterruptibly(
+      ExecutorService executor, long timeout, TimeUnit unit) {
+    boolean interrupted = false;
+    try {
+      long remainingNanos = unit.toNanos(timeout);
+      long end = System.nanoTime() + remainingNanos;
+
+      while (true) {
+        try {
+          return executor.awaitTermination(remainingNanos, NANOSECONDS);
         } catch (InterruptedException e) {
           interrupted = true;
           remainingNanos = end - System.nanoTime();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add awaitTerminationUninterruptibly.

Fixes #3908
Fixes #1315
Somewhat relevant to https://github.com/google/guava/issues/3655
Vaguely relevant to https://github.com/google/error-prone/issues/1490, since it creates a `@CheckReturnValue` variant of a `java.util.concurrent` method that returns `false` to indicate timeout.

RELNOTES=`util.concurrent`: Added `awaitTerminationUninterruptibly`.

1ec90b045a45b4603ea5bd1c296f284ec1c438db