### PR TITLE
MOE Sync 2020-08-04

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
+++ b/android/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.testing.SerializableTester;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -57,6 +58,15 @@ final class LenientSerializableTester {
     Multiset<E> copy = reserialize(original);
     assertEquals(original, copy);
     assertTrue(copy instanceof ImmutableMultiset);
+    return copy;
+  }
+
+  @CanIgnoreReturnValue
+  @GwtIncompatible // SerializableTester
+  static <E> Collection<E> reserializeAndAssertElementsEqual(Collection<E> original) {
+    Collection<E> copy = reserialize(original);
+    assertTrue(Iterables.elementsEqual(original, copy));
+    assertTrue(copy instanceof ImmutableCollection);
     return copy;
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -351,15 +351,14 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
    * <p>Since the bimap is immutable, ImmutableBiMap doesn't require special logic for keeping the
    * bimap and its inverse in sync during serialization, the way AbstractBiMap does.
    */
-  private static class SerializedForm extends ImmutableMap.SerializedForm {
-    SerializedForm(ImmutableBiMap<?, ?> bimap) {
+  private static class SerializedForm<K, V> extends ImmutableMap.SerializedForm<K, V> {
+    SerializedForm(ImmutableBiMap<K, V> bimap) {
       super(bimap);
     }
 
     @Override
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>();
-      return createMap(builder);
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(size);
     }
 
     private static final long serialVersionUID = 0;
@@ -367,6 +366,6 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
 
   @Override
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 }

--- a/android/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMap.java
@@ -706,37 +706,85 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    * reconstructed using public factory methods. This ensures that the implementation types remain
    * as implementation details.
    */
-  static class SerializedForm implements Serializable {
-    private final Object[] keys;
-    private final Object[] values;
+  static class SerializedForm<K, V> implements Serializable {
+    // This object retains references to collections returned by keySet() and value(). This saves
+    // bytes when the both the map and its keySet or value collection are written to the same
+    // instance of ObjectOutputStream.
 
-    SerializedForm(ImmutableMap<?, ?> map) {
-      keys = new Object[map.size()];
-      values = new Object[map.size()];
-      int i = 0;
-      for (Entry<?, ?> entry : map.entrySet()) {
-        keys[i] = entry.getKey();
-        values[i] = entry.getValue();
-        i++;
+    // TODO(b/160980469): remove support for the old serialization format after some time
+    private static final boolean USE_LEGACY_SERIALIZATION = true;
+
+    private final Object keys;
+    private final Object values;
+
+    SerializedForm(ImmutableMap<K, V> map) {
+      if (USE_LEGACY_SERIALIZATION) {
+        Object[] keys = new Object[map.size()];
+        Object[] values = new Object[map.size()];
+        int i = 0;
+        for (Entry<?, ?> entry : map.entrySet()) {
+          keys[i] = entry.getKey();
+          values[i] = entry.getValue();
+          i++;
+        }
+        this.keys = keys;
+        this.values = values;
+        return;
       }
+      this.keys = map.keySet();
+      this.values = map.values();
     }
 
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>(keys.length);
-      return createMap(builder);
+    @SuppressWarnings("unchecked")
+    final Object readResolve() {
+      if (!(this.keys instanceof ImmutableSet)) {
+        return legacyReadResolve();
+      }
+
+      ImmutableSet<K> keySet = (ImmutableSet<K>) this.keys;
+      ImmutableCollection<V> values = (ImmutableCollection<V>) this.values;
+
+      Builder<K, V> builder = makeBuilder(keySet.size());
+
+      UnmodifiableIterator<K> keyIter = keySet.iterator();
+      UnmodifiableIterator<V> valueIter = values.iterator();
+
+      while (keyIter.hasNext()) {
+        builder.put(keyIter.next(), valueIter.next());
+      }
+
+      return builder.build();
     }
 
-    Object createMap(Builder<Object, Object> builder) {
+    @SuppressWarnings("unchecked")
+    final Object legacyReadResolve() {
+      K[] keys = (K[]) this.keys;
+      V[] values = (V[]) this.values;
+
+      Builder<K, V> builder = makeBuilder(keys.length);
+
       for (int i = 0; i < keys.length; i++) {
         builder.put(keys[i], values[i]);
       }
       return builder.build();
     }
 
+    /**
+     * Returns a builder that builds the unserialized type. Subclasses should override this method.
+     */
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(size);
+    }
+
     private static final long serialVersionUID = 0;
   }
 
+  /**
+   * Returns a serializable form of this object. Non-public subclasses should not override this
+   * method. Publicly-accessible subclasses must override this method and should return a subclass
+   * of SerializedForm whose readResolve() method returns objects of the subclass type.
+   */
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 }

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -881,19 +881,17 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
    * are reconstructed using public factory methods. This ensures that the implementation types
    * remain as implementation details.
    */
-  private static class SerializedForm extends ImmutableMap.SerializedForm {
-    private final Comparator<Object> comparator;
+  private static class SerializedForm<K, V> extends ImmutableMap.SerializedForm<K, V> {
+    private final Comparator<? super K> comparator;
 
-    @SuppressWarnings("unchecked")
-    SerializedForm(ImmutableSortedMap<?, ?> sortedMap) {
+    SerializedForm(ImmutableSortedMap<K, V> sortedMap) {
       super(sortedMap);
-      comparator = (Comparator<Object>) sortedMap.comparator();
+      comparator = sortedMap.comparator();
     }
 
     @Override
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>(comparator);
-      return createMap(builder);
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(comparator);
     }
 
     private static final long serialVersionUID = 0;
@@ -901,7 +899,7 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
 
   @Override
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 
   // This class is never actually serialized directly, but we have to make the

--- a/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
+++ b/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.testing.SerializableTester;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -57,6 +58,15 @@ final class LenientSerializableTester {
     Multiset<E> copy = reserialize(original);
     assertEquals(original, copy);
     assertTrue(copy instanceof ImmutableMultiset);
+    return copy;
+  }
+
+  @CanIgnoreReturnValue
+  @GwtIncompatible // SerializableTester
+  static <E> Collection<E> reserializeAndAssertElementsEqual(Collection<E> original) {
+    Collection<E> copy = reserialize(original);
+    assertTrue(Iterables.elementsEqual(original, copy));
+    assertTrue(copy instanceof ImmutableCollection);
     return copy;
   }
 

--- a/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -413,15 +413,14 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableBiMapFauxverideShim<
    * <p>Since the bimap is immutable, ImmutableBiMap doesn't require special logic for keeping the
    * bimap and its inverse in sync during serialization, the way AbstractBiMap does.
    */
-  private static class SerializedForm extends ImmutableMap.SerializedForm {
-    SerializedForm(ImmutableBiMap<?, ?> bimap) {
+  private static class SerializedForm<K, V> extends ImmutableMap.SerializedForm<K, V> {
+    SerializedForm(ImmutableBiMap<K, V> bimap) {
       super(bimap);
     }
 
     @Override
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>();
-      return createMap(builder);
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(size);
     }
 
     private static final long serialVersionUID = 0;
@@ -429,6 +428,6 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableBiMapFauxverideShim<
 
   @Override
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 }

--- a/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/guava/src/com/google/common/collect/ImmutableMap.java
@@ -891,37 +891,85 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
    * reconstructed using public factory methods. This ensures that the implementation types remain
    * as implementation details.
    */
-  static class SerializedForm implements Serializable {
-    private final Object[] keys;
-    private final Object[] values;
+  static class SerializedForm<K, V> implements Serializable {
+    // This object retains references to collections returned by keySet() and value(). This saves
+    // bytes when the both the map and its keySet or value collection are written to the same
+    // instance of ObjectOutputStream.
 
-    SerializedForm(ImmutableMap<?, ?> map) {
-      keys = new Object[map.size()];
-      values = new Object[map.size()];
-      int i = 0;
-      for (Entry<?, ?> entry : map.entrySet()) {
-        keys[i] = entry.getKey();
-        values[i] = entry.getValue();
-        i++;
+    // TODO(b/160980469): remove support for the old serialization format after some time
+    private static final boolean USE_LEGACY_SERIALIZATION = true;
+
+    private final Object keys;
+    private final Object values;
+
+    SerializedForm(ImmutableMap<K, V> map) {
+      if (USE_LEGACY_SERIALIZATION) {
+        Object[] keys = new Object[map.size()];
+        Object[] values = new Object[map.size()];
+        int i = 0;
+        for (Entry<?, ?> entry : map.entrySet()) {
+          keys[i] = entry.getKey();
+          values[i] = entry.getValue();
+          i++;
+        }
+        this.keys = keys;
+        this.values = values;
+        return;
       }
+      this.keys = map.keySet();
+      this.values = map.values();
     }
 
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>(keys.length);
-      return createMap(builder);
+    @SuppressWarnings("unchecked")
+    final Object readResolve() {
+      if (!(this.keys instanceof ImmutableSet)) {
+        return legacyReadResolve();
+      }
+
+      ImmutableSet<K> keySet = (ImmutableSet<K>) this.keys;
+      ImmutableCollection<V> values = (ImmutableCollection<V>) this.values;
+
+      Builder<K, V> builder = makeBuilder(keySet.size());
+
+      UnmodifiableIterator<K> keyIter = keySet.iterator();
+      UnmodifiableIterator<V> valueIter = values.iterator();
+
+      while (keyIter.hasNext()) {
+        builder.put(keyIter.next(), valueIter.next());
+      }
+
+      return builder.build();
     }
 
-    Object createMap(Builder<Object, Object> builder) {
+    @SuppressWarnings("unchecked")
+    final Object legacyReadResolve() {
+      K[] keys = (K[]) this.keys;
+      V[] values = (V[]) this.values;
+
+      Builder<K, V> builder = makeBuilder(keys.length);
+
       for (int i = 0; i < keys.length; i++) {
         builder.put(keys[i], values[i]);
       }
       return builder.build();
     }
 
+    /**
+     * Returns a builder that builds the unserialized type. Subclasses should override this method.
+     */
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(size);
+    }
+
     private static final long serialVersionUID = 0;
   }
 
+  /**
+   * Returns a serializable form of this object. Non-public subclasses should not override this
+   * method. Publicly-accessible subclasses must override this method and should return a subclass
+   * of SerializedForm whose readResolve() method returns objects of the subclass type.
+   */
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 }

--- a/guava/src/com/google/common/collect/ImmutableMapKeySet.java
+++ b/guava/src/com/google/common/collect/ImmutableMapKeySet.java
@@ -19,8 +19,6 @@ package com.google.common.collect;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
-import java.io.Serializable;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -73,26 +71,5 @@ final class ImmutableMapKeySet<K, V> extends IndexedImmutableSet<K> {
   @Override
   boolean isPartialView() {
     return true;
-  }
-
-  @GwtIncompatible // serialization
-  @Override
-  Object writeReplace() {
-    return new KeySetSerializedForm<K>(map);
-  }
-
-  @GwtIncompatible // serialization
-  private static class KeySetSerializedForm<K> implements Serializable {
-    final ImmutableMap<K, ?> map;
-
-    KeySetSerializedForm(ImmutableMap<K, ?> map) {
-      this.map = map;
-    }
-
-    Object readResolve() {
-      return map.keySet();
-    }
-
-    private static final long serialVersionUID = 0;
   }
 }

--- a/guava/src/com/google/common/collect/ImmutableMapValues.java
+++ b/guava/src/com/google/common/collect/ImmutableMapValues.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
-import java.io.Serializable;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -98,26 +97,5 @@ final class ImmutableMapValues<K, V> extends ImmutableCollection<V> {
   public void forEach(Consumer<? super V> action) {
     checkNotNull(action);
     map.forEach((k, v) -> action.accept(v));
-  }
-
-  @GwtIncompatible // serialization
-  @Override
-  Object writeReplace() {
-    return new SerializedForm<V>(map);
-  }
-
-  @GwtIncompatible // serialization
-  private static class SerializedForm<V> implements Serializable {
-    final ImmutableMap<?, V> map;
-
-    SerializedForm(ImmutableMap<?, V> map) {
-      this.map = map;
-    }
-
-    Object readResolve() {
-      return map.values();
-    }
-
-    private static final long serialVersionUID = 0;
   }
 }

--- a/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -916,19 +916,17 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
    * are reconstructed using public factory methods. This ensures that the implementation types
    * remain as implementation details.
    */
-  private static class SerializedForm extends ImmutableMap.SerializedForm {
-    private final Comparator<Object> comparator;
+  private static class SerializedForm<K, V> extends ImmutableMap.SerializedForm<K, V> {
+    private final Comparator<? super K> comparator;
 
-    @SuppressWarnings("unchecked")
-    SerializedForm(ImmutableSortedMap<?, ?> sortedMap) {
+    SerializedForm(ImmutableSortedMap<K, V> sortedMap) {
       super(sortedMap);
-      comparator = (Comparator<Object>) sortedMap.comparator();
+      comparator = sortedMap.comparator();
     }
 
     @Override
-    Object readResolve() {
-      Builder<Object, Object> builder = new Builder<>(comparator);
-      return createMap(builder);
+    Builder<K, V> makeBuilder(int size) {
+      return new Builder<>(comparator);
     }
 
     private static final long serialVersionUID = 0;
@@ -936,7 +934,7 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
 
   @Override
   Object writeReplace() {
-    return new SerializedForm(this);
+    return new SerializedForm<>(this);
   }
 
   // This class is never actually serialized directly, but we have to make the

--- a/guava/src/com/google/common/collect/RegularImmutableMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableMap.java
@@ -22,11 +22,9 @@ import static com.google.common.collect.CollectPreconditions.checkEntryNotNull;
 import static com.google.common.collect.ImmutableMapEntry.createEntryArray;
 
 import com.google.common.annotations.GwtCompatible;
-import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMapEntry.NonTerminalImmutableMapEntry;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.io.Serializable;
 import java.util.function.BiConsumer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -207,10 +205,10 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
   }
 
   @GwtCompatible(emulated = true)
-  private static final class KeySet<K, V> extends IndexedImmutableSet<K> {
-    private final RegularImmutableMap<K, V> map;
+  private static final class KeySet<K> extends IndexedImmutableSet<K> {
+    private final RegularImmutableMap<K, ?> map;
 
-    KeySet(RegularImmutableMap<K, V> map) {
+    KeySet(RegularImmutableMap<K, ?> map) {
       this.map = map;
     }
 
@@ -232,27 +230,6 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     @Override
     public int size() {
       return map.size();
-    }
-
-    @GwtIncompatible // serialization
-    @Override
-    Object writeReplace() {
-      return new SerializedForm<K>(map);
-    }
-
-    @GwtIncompatible // serialization
-    private static class SerializedForm<K> implements Serializable {
-      final ImmutableMap<K, ?> map;
-
-      SerializedForm(ImmutableMap<K, ?> map) {
-        this.map = map;
-      }
-
-      Object readResolve() {
-        return map.keySet();
-      }
-
-      private static final long serialVersionUID = 0;
     }
   }
 
@@ -282,27 +259,6 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     @Override
     boolean isPartialView() {
       return true;
-    }
-
-    @GwtIncompatible // serialization
-    @Override
-    Object writeReplace() {
-      return new SerializedForm<V>(map);
-    }
-
-    @GwtIncompatible // serialization
-    private static class SerializedForm<V> implements Serializable {
-      final ImmutableMap<?, V> map;
-
-      SerializedForm(ImmutableMap<?, V> map) {
-        this.map = map;
-      }
-
-      Object readResolve() {
-        return map.values();
-      }
-
-      private static final long serialVersionUID = 0;
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ensure that the set returned by ImmutableMap<K, V>.keySet() is serializable when K is serializable, and similarly for values().

Set<T> should be serializable when T is serializable but that is not always the case for the set returned by ImmutableMap.keySet() due to a reference from the returned set back to the original map. When serializing this set, the original map is serialized is well. This change changes this so that only the keys are serialized.

RELNOTES=`collect`: Ensure that the set returned by `ImmutableMap<K, V>.keySet()` is serializable when `K` is serializable (and similarly for `values()`).

cf94f5601b32662a236f5534c1a7d4ceab132e76