### PR TITLE
MOE Sync 2020-08-12

### DIFF
--- a/android/guava/src/com/google/common/primitives/Doubles.java
+++ b/android/guava/src/com/google/common/primitives/Doubles.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.base.Strings.lenientFormat;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 
@@ -253,8 +254,13 @@ public final class Doubles extends DoublesMethodsForWeb {
    */
   @Beta
   public static double constrainToRange(double value, double min, double max) {
-    checkArgument(min <= max, "min (%s) must be less than or equal to max (%s)", min, max);
-    return Math.min(Math.max(value, min), max);
+    // avoid auto-boxing by not using Preconditions.checkArgument(); see Guava issue 3984
+    // Reject NaN by testing for the good case (min <= max) instead of the bad (min > max).
+    if (min <= max) {
+      return Math.min(Math.max(value, min), max);
+    }
+    throw new IllegalArgumentException(
+        lenientFormat("min (%s) must be less than or equal to max (%s)", min, max));
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Floats.java
+++ b/android/guava/src/com/google/common/primitives/Floats.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.base.Strings.lenientFormat;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.POSITIVE_INFINITY;
 
@@ -250,8 +251,13 @@ public final class Floats extends FloatsMethodsForWeb {
    */
   @Beta
   public static float constrainToRange(float value, float min, float max) {
-    checkArgument(min <= max, "min (%s) must be less than or equal to max (%s)", min, max);
-    return Math.min(Math.max(value, min), max);
+    // avoid auto-boxing by not using Preconditions.checkArgument(); see Guava issue 3984
+    // Reject NaN by testing for the good case (min <= max) instead of the bad (min > max).
+    if (min <= max) {
+      return Math.min(Math.max(value, min), max);
+    }
+    throw new IllegalArgumentException(
+        lenientFormat("min (%s) must be less than or equal to max (%s)", min, max));
   }
 
   /**

--- a/guava/src/com/google/common/collect/ImmutableMapKeySet.java
+++ b/guava/src/com/google/common/collect/ImmutableMapKeySet.java
@@ -19,6 +19,8 @@ package com.google.common.collect;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
+import java.io.Serializable;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -71,5 +73,22 @@ final class ImmutableMapKeySet<K, V> extends IndexedImmutableSet<K> {
   @Override
   boolean isPartialView() {
     return true;
+  }
+
+  // No longer used for new writes, but kept so that old data can still be read.
+  @GwtIncompatible // serialization
+  @SuppressWarnings("unused")
+  private static class KeySetSerializedForm<K> implements Serializable {
+    final ImmutableMap<K, ?> map;
+
+    KeySetSerializedForm(ImmutableMap<K, ?> map) {
+      this.map = map;
+    }
+
+    Object readResolve() {
+      return map.keySet();
+    }
+
+    private static final long serialVersionUID = 0;
   }
 }

--- a/guava/src/com/google/common/collect/ImmutableMapValues.java
+++ b/guava/src/com/google/common/collect/ImmutableMapValues.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
+import java.io.Serializable;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -97,5 +98,22 @@ final class ImmutableMapValues<K, V> extends ImmutableCollection<V> {
   public void forEach(Consumer<? super V> action) {
     checkNotNull(action);
     map.forEach((k, v) -> action.accept(v));
+  }
+
+  // No longer used for new writes, but kept so that old data can still be read.
+  @GwtIncompatible // serialization
+  @SuppressWarnings("unused")
+  private static class SerializedForm<V> implements Serializable {
+    final ImmutableMap<?, V> map;
+
+    SerializedForm(ImmutableMap<?, V> map) {
+      this.map = map;
+    }
+
+    Object readResolve() {
+      return map.values();
+    }
+
+    private static final long serialVersionUID = 0;
   }
 }

--- a/guava/src/com/google/common/collect/Multimaps.java
+++ b/guava/src/com/google/common/collect/Multimaps.java
@@ -104,7 +104,6 @@ public final class Multimaps {
    *
    * @since 21.0
    */
-  @Beta
   public static <T, K, V, M extends Multimap<K, V>> Collector<T, ?, M> toMultimap(
       java.util.function.Function<? super T, ? extends K> keyFunction,
       java.util.function.Function<? super T, ? extends V> valueFunction,

--- a/guava/src/com/google/common/collect/RegularImmutableMap.java
+++ b/guava/src/com/google/common/collect/RegularImmutableMap.java
@@ -22,9 +22,11 @@ import static com.google.common.collect.CollectPreconditions.checkEntryNotNull;
 import static com.google.common.collect.ImmutableMapEntry.createEntryArray;
 
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMapEntry.NonTerminalImmutableMapEntry;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.Serializable;
 import java.util.function.BiConsumer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -231,6 +233,23 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     public int size() {
       return map.size();
     }
+
+    // No longer used for new writes, but kept so that old data can still be read.
+    @GwtIncompatible // serialization
+    @SuppressWarnings("unused")
+    private static class SerializedForm<K> implements Serializable {
+      final ImmutableMap<K, ?> map;
+
+      SerializedForm(ImmutableMap<K, ?> map) {
+        this.map = map;
+      }
+
+      Object readResolve() {
+        return map.keySet();
+      }
+
+      private static final long serialVersionUID = 0;
+    }
   }
 
   @Override
@@ -259,6 +278,23 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     @Override
     boolean isPartialView() {
       return true;
+    }
+
+    // No longer used for new writes, but kept so that old data can still be read.
+    @GwtIncompatible // serialization
+    @SuppressWarnings("unused")
+    private static class SerializedForm<V> implements Serializable {
+      final ImmutableMap<?, V> map;
+
+      SerializedForm(ImmutableMap<?, V> map) {
+        this.map = map;
+      }
+
+      Object readResolve() {
+        return map.values();
+      }
+
+      private static final long serialVersionUID = 0;
     }
   }
 

--- a/guava/src/com/google/common/primitives/Doubles.java
+++ b/guava/src/com/google/common/primitives/Doubles.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.base.Strings.lenientFormat;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 
@@ -255,8 +256,13 @@ public final class Doubles extends DoublesMethodsForWeb {
    */
   @Beta
   public static double constrainToRange(double value, double min, double max) {
-    checkArgument(min <= max, "min (%s) must be less than or equal to max (%s)", min, max);
-    return Math.min(Math.max(value, min), max);
+    // avoid auto-boxing by not using Preconditions.checkArgument(); see Guava issue 3984
+    // Reject NaN by testing for the good case (min <= max) instead of the bad (min > max).
+    if (min <= max) {
+      return Math.min(Math.max(value, min), max);
+    }
+    throw new IllegalArgumentException(
+        lenientFormat("min (%s) must be less than or equal to max (%s)", min, max));
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Floats.java
+++ b/guava/src/com/google/common/primitives/Floats.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.base.Strings.lenientFormat;
 import static java.lang.Float.NEGATIVE_INFINITY;
 import static java.lang.Float.POSITIVE_INFINITY;
 
@@ -250,8 +251,13 @@ public final class Floats extends FloatsMethodsForWeb {
    */
   @Beta
   public static float constrainToRange(float value, float min, float max) {
-    checkArgument(min <= max, "min (%s) must be less than or equal to max (%s)", min, max);
-    return Math.min(Math.max(value, min), max);
+    // avoid auto-boxing by not using Preconditions.checkArgument(); see Guava issue 3984
+    // Reject NaN by testing for the good case (min <= max) instead of the bad (min > max).
+    if (min <= max) {
+      return Math.min(Math.max(value, min), max);
+    }
+    throw new IllegalArgumentException(
+        lenientFormat("min (%s) must be less than or equal to max (%s)", min, max));
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Avoid boxing in Doubles.constrainToRange() and Floats.constrainToRange().

Fixes https://github.com/google/guava/issues/3984

f850db59358a3b5f9b2da96b7feea06802077b19

-------

<p> Remove `@Beta` from `Multimaps.toMultimap`.

Fixes https://github.com/google/guava/issues/3957

RELNOTES=`collect`: Removed `@Beta` from `Multimaps.toMultimap`.

b9fe10a7b1c67518d9c6b86fc6611473943c188c

-------

<p> Bring back previously deleted SerializedForms so that old data can still be read.

RELNOTES=`collect`: Data that was previously serialized, and that originated from ImmutableMap.keySet() or .values(), is now deserializable again.

d66fda44e127d00e401cadde1834454feffade86