### PR TITLE
MOE Sync 2020-08-21

### DIFF
--- a/android/guava/src/com/google/common/hash/AbstractByteHasher.java
+++ b/android/guava/src/com/google/common/hash/AbstractByteHasher.java
@@ -54,7 +54,7 @@ abstract class AbstractByteHasher extends AbstractHasher {
   protected void update(ByteBuffer b) {
     if (b.hasArray()) {
       update(b.array(), b.arrayOffset() + b.position(), b.remaining());
-      b.position(b.limit());
+      Java8Compatibility.position(b, b.limit());
     } else {
       for (int remaining = b.remaining(); remaining > 0; remaining--) {
         update(b.get());
@@ -67,7 +67,7 @@ abstract class AbstractByteHasher extends AbstractHasher {
     try {
       update(scratch.array(), 0, bytes);
     } finally {
-      scratch.clear();
+      Java8Compatibility.clear(scratch);
     }
     return this;
   }

--- a/android/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
+++ b/android/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
@@ -98,7 +98,7 @@ abstract class AbstractCompositeHashFunction extends AbstractHashFunction {
       public Hasher putBytes(ByteBuffer bytes) {
         int pos = bytes.position();
         for (Hasher hasher : hashers) {
-          bytes.position(pos);
+          Java8Compatibility.position(bytes, pos);
           hasher.putBytes(bytes);
         }
         return this;

--- a/android/guava/src/com/google/common/hash/AbstractHasher.java
+++ b/android/guava/src/com/google/common/hash/AbstractHasher.java
@@ -73,7 +73,7 @@ abstract class AbstractHasher implements Hasher {
   public Hasher putBytes(ByteBuffer b) {
     if (b.hasArray()) {
       putBytes(b.array(), b.arrayOffset() + b.position(), b.remaining());
-      b.position(b.limit());
+      Java8Compatibility.position(b, b.limit());
     } else {
       for (int remaining = b.remaining(); remaining > 0; remaining--) {
         putByte(b.get());

--- a/android/guava/src/com/google/common/hash/AbstractStreamingHasher.java
+++ b/android/guava/src/com/google/common/hash/AbstractStreamingHasher.java
@@ -80,13 +80,13 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
    * <p>This implementation simply pads with zeros and delegates to {@link #process(ByteBuffer)}.
    */
   protected void processRemaining(ByteBuffer bb) {
-    bb.position(bb.limit()); // move at the end
-    bb.limit(chunkSize + 7); // get ready to pad with longs
+    Java8Compatibility.position(bb, bb.limit()); // move at the end
+    Java8Compatibility.limit(bb, chunkSize + 7); // get ready to pad with longs
     while (bb.position() < chunkSize) {
       bb.putLong(0);
     }
-    bb.limit(chunkSize);
-    bb.flip();
+    Java8Compatibility.limit(bb, chunkSize);
+    Java8Compatibility.flip(bb);
     process(bb);
   }
 
@@ -179,10 +179,10 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
   @Override
   public final HashCode hash() {
     munch();
-    buffer.flip();
+    Java8Compatibility.flip(buffer);
     if (buffer.remaining() > 0) {
       processRemaining(buffer);
-      buffer.position(buffer.limit());
+      Java8Compatibility.position(buffer, buffer.limit());
     }
     return makeHash();
   }
@@ -203,7 +203,7 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
   }
 
   private void munch() {
-    buffer.flip();
+    Java8Compatibility.flip(buffer);
     while (buffer.remaining() >= chunkSize) {
       // we could limit the buffer to ensure process() does not read more than
       // chunkSize number of bytes, but we trust the implementations

--- a/android/guava/src/com/google/common/hash/Java8Compatibility.java
+++ b/android/guava/src/com/google/common/hash/Java8Compatibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.hash;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.nio.Buffer;
+
+/**
+ * Wrappers around {@link Buffer} methods that are covariantly overridden in Java 9+. See
+ * https://github.com/google/guava/issues/3990
+ */
+@GwtIncompatible
+final class Java8Compatibility {
+  static void clear(Buffer b) {
+    b.clear();
+  }
+
+  static void flip(Buffer b) {
+    b.flip();
+  }
+
+  static void limit(Buffer b, int limit) {
+    b.limit(limit);
+  }
+
+  static void position(Buffer b, int position) {
+    b.position(position);
+  }
+
+  private Java8Compatibility() {}
+}

--- a/android/guava/src/com/google/common/io/ByteStreams.java
+++ b/android/guava/src/com/google/common/io/ByteStreams.java
@@ -145,11 +145,11 @@ public final class ByteStreams {
     ByteBuffer buf = ByteBuffer.wrap(createBuffer());
     long total = 0;
     while (from.read(buf) != -1) {
-      buf.flip();
+      Java8Compatibility.flip(buf);
       while (buf.hasRemaining()) {
         total += to.write(buf);
       }
-      buf.clear();
+      Java8Compatibility.clear(buf);
     }
     return total;
   }

--- a/android/guava/src/com/google/common/io/CharStreams.java
+++ b/android/guava/src/com/google/common/io/CharStreams.java
@@ -83,10 +83,10 @@ public final class CharStreams {
       long total = 0;
       CharBuffer buf = createBuffer();
       while (from.read(buf) != -1) {
-        buf.flip();
+        Java8Compatibility.flip(buf);
         to.append(buf);
         total += buf.remaining();
-        buf.clear();
+        Java8Compatibility.clear(buf);
       }
       return total;
     }
@@ -243,7 +243,7 @@ public final class CharStreams {
     CharBuffer buf = createBuffer();
     while ((read = readable.read(buf)) != -1) {
       total += read;
-      buf.clear();
+      Java8Compatibility.clear(buf);
     }
     return total;
   }

--- a/android/guava/src/com/google/common/io/Java8Compatibility.java
+++ b/android/guava/src/com/google/common/io/Java8Compatibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.nio.Buffer;
+
+/**
+ * Wrappers around {@link Buffer} methods that are covariantly overridden in Java 9+. See
+ * https://github.com/google/guava/issues/3990
+ */
+@GwtIncompatible
+final class Java8Compatibility {
+  static void clear(Buffer b) {
+    b.clear();
+  }
+
+  static void flip(Buffer b) {
+    b.flip();
+  }
+
+  static void limit(Buffer b, int limit) {
+    b.limit(limit);
+  }
+
+  static void position(Buffer b, int position) {
+    b.position(position);
+  }
+
+  private Java8Compatibility() {}
+}

--- a/android/guava/src/com/google/common/io/LineReader.java
+++ b/android/guava/src/com/google/common/io/LineReader.java
@@ -70,7 +70,7 @@ public final class LineReader {
   @CanIgnoreReturnValue // to skip a line
   public String readLine() throws IOException {
     while (lines.peek() == null) {
-      cbuf.clear();
+      Java8Compatibility.clear(cbuf);
       // The default implementation of Reader#read(CharBuffer) allocates a
       // temporary char[], so we call Reader#read(char[], int, int) instead.
       int read = (reader != null) ? reader.read(buf, 0, buf.length) : readable.read(cbuf);

--- a/android/guava/src/com/google/common/io/ReaderInputStream.java
+++ b/android/guava/src/com/google/common/io/ReaderInputStream.java
@@ -104,7 +104,7 @@ final class ReaderInputStream extends InputStream {
     encoder.reset();
 
     charBuffer = CharBuffer.allocate(bufferSize);
-    charBuffer.flip();
+    Java8Compatibility.flip(charBuffer);
 
     byteBuffer = ByteBuffer.allocate(bufferSize);
   }
@@ -143,7 +143,7 @@ final class ReaderInputStream extends InputStream {
           return (totalBytesRead > 0) ? totalBytesRead : -1;
         }
         draining = false;
-        byteBuffer.clear();
+        Java8Compatibility.clear(byteBuffer);
       }
 
       while (true) {
@@ -189,8 +189,8 @@ final class ReaderInputStream extends InputStream {
   private static CharBuffer grow(CharBuffer buf) {
     char[] copy = Arrays.copyOf(buf.array(), buf.capacity() * 2);
     CharBuffer bigger = CharBuffer.wrap(copy);
-    bigger.position(buf.position());
-    bigger.limit(buf.limit());
+    Java8Compatibility.position(bigger, buf.position());
+    Java8Compatibility.limit(bigger, buf.limit());
     return bigger;
   }
 
@@ -207,7 +207,7 @@ final class ReaderInputStream extends InputStream {
     if (availableCapacity(charBuffer) == 0) {
       if (charBuffer.position() > 0) {
         // (2) There is room in the buffer. Move existing bytes to the beginning.
-        charBuffer.compact().flip();
+        Java8Compatibility.flip(charBuffer.compact());
       } else {
         // (3) Entire buffer is full, need bigger buffer.
         charBuffer = grow(charBuffer);
@@ -220,7 +220,7 @@ final class ReaderInputStream extends InputStream {
     if (numChars == -1) {
       endOfInput = true;
     } else {
-      charBuffer.limit(limit + numChars);
+      Java8Compatibility.limit(charBuffer, limit + numChars);
     }
   }
 
@@ -235,7 +235,7 @@ final class ReaderInputStream extends InputStream {
    * overflow must be due to a small output buffer.
    */
   private void startDraining(boolean overflow) {
-    byteBuffer.flip();
+    Java8Compatibility.flip(byteBuffer);
     if (overflow && byteBuffer.remaining() == 0) {
       byteBuffer = ByteBuffer.allocate(byteBuffer.capacity() * 2);
     } else {

--- a/guava/src/com/google/common/hash/AbstractByteHasher.java
+++ b/guava/src/com/google/common/hash/AbstractByteHasher.java
@@ -54,7 +54,7 @@ abstract class AbstractByteHasher extends AbstractHasher {
   protected void update(ByteBuffer b) {
     if (b.hasArray()) {
       update(b.array(), b.arrayOffset() + b.position(), b.remaining());
-      b.position(b.limit());
+      Java8Compatibility.position(b, b.limit());
     } else {
       for (int remaining = b.remaining(); remaining > 0; remaining--) {
         update(b.get());
@@ -67,7 +67,7 @@ abstract class AbstractByteHasher extends AbstractHasher {
     try {
       update(scratch.array(), 0, bytes);
     } finally {
-      scratch.clear();
+      Java8Compatibility.clear(scratch);
     }
     return this;
   }

--- a/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
+++ b/guava/src/com/google/common/hash/AbstractCompositeHashFunction.java
@@ -98,7 +98,7 @@ abstract class AbstractCompositeHashFunction extends AbstractHashFunction {
       public Hasher putBytes(ByteBuffer bytes) {
         int pos = bytes.position();
         for (Hasher hasher : hashers) {
-          bytes.position(pos);
+          Java8Compatibility.position(bytes, pos);
           hasher.putBytes(bytes);
         }
         return this;

--- a/guava/src/com/google/common/hash/AbstractHasher.java
+++ b/guava/src/com/google/common/hash/AbstractHasher.java
@@ -73,7 +73,7 @@ abstract class AbstractHasher implements Hasher {
   public Hasher putBytes(ByteBuffer b) {
     if (b.hasArray()) {
       putBytes(b.array(), b.arrayOffset() + b.position(), b.remaining());
-      b.position(b.limit());
+      Java8Compatibility.position(b, b.limit());
     } else {
       for (int remaining = b.remaining(); remaining > 0; remaining--) {
         putByte(b.get());

--- a/guava/src/com/google/common/hash/AbstractStreamingHasher.java
+++ b/guava/src/com/google/common/hash/AbstractStreamingHasher.java
@@ -80,13 +80,13 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
    * <p>This implementation simply pads with zeros and delegates to {@link #process(ByteBuffer)}.
    */
   protected void processRemaining(ByteBuffer bb) {
-    bb.position(bb.limit()); // move at the end
-    bb.limit(chunkSize + 7); // get ready to pad with longs
+    Java8Compatibility.position(bb, bb.limit()); // move at the end
+    Java8Compatibility.limit(bb, chunkSize + 7); // get ready to pad with longs
     while (bb.position() < chunkSize) {
       bb.putLong(0);
     }
-    bb.limit(chunkSize);
-    bb.flip();
+    Java8Compatibility.limit(bb, chunkSize);
+    Java8Compatibility.flip(bb);
     process(bb);
   }
 
@@ -179,10 +179,10 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
   @Override
   public final HashCode hash() {
     munch();
-    buffer.flip();
+    Java8Compatibility.flip(buffer);
     if (buffer.remaining() > 0) {
       processRemaining(buffer);
-      buffer.position(buffer.limit());
+      Java8Compatibility.position(buffer, buffer.limit());
     }
     return makeHash();
   }
@@ -203,7 +203,7 @@ abstract class AbstractStreamingHasher extends AbstractHasher {
   }
 
   private void munch() {
-    buffer.flip();
+    Java8Compatibility.flip(buffer);
     while (buffer.remaining() >= chunkSize) {
       // we could limit the buffer to ensure process() does not read more than
       // chunkSize number of bytes, but we trust the implementations

--- a/guava/src/com/google/common/hash/Java8Compatibility.java
+++ b/guava/src/com/google/common/hash/Java8Compatibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.hash;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.nio.Buffer;
+
+/**
+ * Wrappers around {@link Buffer} methods that are covariantly overridden in Java 9+. See
+ * https://github.com/google/guava/issues/3990
+ */
+@GwtIncompatible
+final class Java8Compatibility {
+  static void clear(Buffer b) {
+    b.clear();
+  }
+
+  static void flip(Buffer b) {
+    b.flip();
+  }
+
+  static void limit(Buffer b, int limit) {
+    b.limit(limit);
+  }
+
+  static void position(Buffer b, int position) {
+    b.position(position);
+  }
+
+  private Java8Compatibility() {}
+}

--- a/guava/src/com/google/common/io/ByteStreams.java
+++ b/guava/src/com/google/common/io/ByteStreams.java
@@ -145,11 +145,11 @@ public final class ByteStreams {
     ByteBuffer buf = ByteBuffer.wrap(createBuffer());
     long total = 0;
     while (from.read(buf) != -1) {
-      buf.flip();
+      Java8Compatibility.flip(buf);
       while (buf.hasRemaining()) {
         total += to.write(buf);
       }
-      buf.clear();
+      Java8Compatibility.clear(buf);
     }
     return total;
   }

--- a/guava/src/com/google/common/io/CharStreams.java
+++ b/guava/src/com/google/common/io/CharStreams.java
@@ -83,10 +83,10 @@ public final class CharStreams {
       long total = 0;
       CharBuffer buf = createBuffer();
       while (from.read(buf) != -1) {
-        buf.flip();
+        Java8Compatibility.flip(buf);
         to.append(buf);
         total += buf.remaining();
-        buf.clear();
+        Java8Compatibility.clear(buf);
       }
       return total;
     }
@@ -243,7 +243,7 @@ public final class CharStreams {
     CharBuffer buf = createBuffer();
     while ((read = readable.read(buf)) != -1) {
       total += read;
-      buf.clear();
+      Java8Compatibility.clear(buf);
     }
     return total;
   }

--- a/guava/src/com/google/common/io/Java8Compatibility.java
+++ b/guava/src/com/google/common/io/Java8Compatibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.common.io;
+
+import com.google.common.annotations.GwtIncompatible;
+import java.nio.Buffer;
+
+/**
+ * Wrappers around {@link Buffer} methods that are covariantly overridden in Java 9+. See
+ * https://github.com/google/guava/issues/3990
+ */
+@GwtIncompatible
+final class Java8Compatibility {
+  static void clear(Buffer b) {
+    b.clear();
+  }
+
+  static void flip(Buffer b) {
+    b.flip();
+  }
+
+  static void limit(Buffer b, int limit) {
+    b.limit(limit);
+  }
+
+  static void position(Buffer b, int position) {
+    b.position(position);
+  }
+
+  private Java8Compatibility() {}
+}

--- a/guava/src/com/google/common/io/LineReader.java
+++ b/guava/src/com/google/common/io/LineReader.java
@@ -70,7 +70,7 @@ public final class LineReader {
   @CanIgnoreReturnValue // to skip a line
   public String readLine() throws IOException {
     while (lines.peek() == null) {
-      cbuf.clear();
+      Java8Compatibility.clear(cbuf);
       // The default implementation of Reader#read(CharBuffer) allocates a
       // temporary char[], so we call Reader#read(char[], int, int) instead.
       int read = (reader != null) ? reader.read(buf, 0, buf.length) : readable.read(cbuf);

--- a/guava/src/com/google/common/io/ReaderInputStream.java
+++ b/guava/src/com/google/common/io/ReaderInputStream.java
@@ -104,7 +104,7 @@ final class ReaderInputStream extends InputStream {
     encoder.reset();
 
     charBuffer = CharBuffer.allocate(bufferSize);
-    charBuffer.flip();
+    Java8Compatibility.flip(charBuffer);
 
     byteBuffer = ByteBuffer.allocate(bufferSize);
   }
@@ -143,7 +143,7 @@ final class ReaderInputStream extends InputStream {
           return (totalBytesRead > 0) ? totalBytesRead : -1;
         }
         draining = false;
-        byteBuffer.clear();
+        Java8Compatibility.clear(byteBuffer);
       }
 
       while (true) {
@@ -189,8 +189,8 @@ final class ReaderInputStream extends InputStream {
   private static CharBuffer grow(CharBuffer buf) {
     char[] copy = Arrays.copyOf(buf.array(), buf.capacity() * 2);
     CharBuffer bigger = CharBuffer.wrap(copy);
-    bigger.position(buf.position());
-    bigger.limit(buf.limit());
+    Java8Compatibility.position(bigger, buf.position());
+    Java8Compatibility.limit(bigger, buf.limit());
     return bigger;
   }
 
@@ -207,7 +207,7 @@ final class ReaderInputStream extends InputStream {
     if (availableCapacity(charBuffer) == 0) {
       if (charBuffer.position() > 0) {
         // (2) There is room in the buffer. Move existing bytes to the beginning.
-        charBuffer.compact().flip();
+        Java8Compatibility.flip(charBuffer.compact());
       } else {
         // (3) Entire buffer is full, need bigger buffer.
         charBuffer = grow(charBuffer);
@@ -220,7 +220,7 @@ final class ReaderInputStream extends InputStream {
     if (numChars == -1) {
       endOfInput = true;
     } else {
-      charBuffer.limit(limit + numChars);
+      Java8Compatibility.limit(charBuffer, limit + numChars);
     }
   }
 
@@ -235,7 +235,7 @@ final class ReaderInputStream extends InputStream {
    * overflow must be due to a small output buffer.
    */
   private void startDraining(boolean overflow) {
-    byteBuffer.flip();
+    Java8Compatibility.flip(byteBuffer);
     if (overflow && byteBuffer.remaining() == 0) {
       byteBuffer = ByteBuffer.allocate(byteBuffer.capacity() * 2);
     } else {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't directly call ByteBuffer, etc. methods that have covariant returns in Java 9+.

Doing so produces a jar that doesn't work under Java 8.

This CL addresses the currently existing problematic calls (by calling the methods on the supertype Buffer instead), but we should also add safeguards.

The normal solution to this general problem is to use --release, but doing so here is complicated.

For more information, see https://github.com/google/guava/issues/3990

406a4eafa25ccd8f456622be19e2ce1e624bc227