### PR TITLE
MOE Sync 2020-08-25

### DIFF
--- a/android/guava-tests/test/com/google/common/eventbus/EventBusTest.java
+++ b/android/guava-tests/test/com/google/common/eventbus/EventBusTest.java
@@ -289,6 +289,18 @@ public class EventBusTest extends TestCase {
     assertEquals(1, calls.get());
   }
 
+  public void testPrimitiveSubscribeFails() {
+    class SubscribesToPrimitive {
+      @Subscribe
+      public void toInt(int i) {}
+    }
+    try {
+      bus.register(new SubscribesToPrimitive());
+      fail("should have thrown");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   /** Records thrown exception information. */
   private static final class RecordingSubscriberExceptionHandler
       implements SubscriberExceptionHandler {

--- a/android/guava/src/com/google/common/eventbus/Subscribe.java
+++ b/android/guava/src/com/google/common/eventbus/Subscribe.java
@@ -23,9 +23,10 @@ import java.lang.annotation.Target;
 /**
  * Marks a method as an event subscriber.
  *
- * <p>The type of event will be indicated by the method's first (and only) parameter. If this
- * annotation is applied to methods with zero parameters, or more than one parameter, the object
- * containing the method will not be able to register for event delivery from the {@link EventBus}.
+ * <p>The type of event will be indicated by the method's first (and only) parameter, which cannot
+ * be primitive. If this annotation is applied to methods with zero parameters, or more than one
+ * parameter, the object containing the method will not be able to register for event delivery from
+ * the {@link EventBus}.
  *
  * <p>Unless also annotated with @{@link AllowConcurrentEvents}, event subscriber methods will be
  * invoked serially by each event bus that they are registered with.

--- a/guava-tests/test/com/google/common/eventbus/EventBusTest.java
+++ b/guava-tests/test/com/google/common/eventbus/EventBusTest.java
@@ -289,6 +289,18 @@ public class EventBusTest extends TestCase {
     assertEquals(1, calls.get());
   }
 
+  public void testPrimitiveSubscribeFails() {
+    class SubscribesToPrimitive {
+      @Subscribe
+      public void toInt(int i) {}
+    }
+    try {
+      bus.register(new SubscribesToPrimitive());
+      fail("should have thrown");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   /** Records thrown exception information. */
   private static final class RecordingSubscriberExceptionHandler
       implements SubscriberExceptionHandler {

--- a/guava/src/com/google/common/eventbus/Subscribe.java
+++ b/guava/src/com/google/common/eventbus/Subscribe.java
@@ -23,9 +23,10 @@ import java.lang.annotation.Target;
 /**
  * Marks a method as an event subscriber.
  *
- * <p>The type of event will be indicated by the method's first (and only) parameter. If this
- * annotation is applied to methods with zero parameters, or more than one parameter, the object
- * containing the method will not be able to register for event delivery from the {@link EventBus}.
+ * <p>The type of event will be indicated by the method's first (and only) parameter, which cannot
+ * be primitive. If this annotation is applied to methods with zero parameters, or more than one
+ * parameter, the object containing the method will not be able to register for event delivery from
+ * the {@link EventBus}.
  *
  * <p>Unless also annotated with @{@link AllowConcurrentEvents}, event subscriber methods will be
  * invoked serially by each event bus that they are registered with.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Throw if @Subscribe is applied to a method that takes a primitive parameter.

Fixes https://github.com/google/guava/issues/3992.

RELNOTES=Prevent @Subscribe being applied to a method that takes a primitive, as that will never be called.

9fe4ecdc84e628c7da0aa68fc6257932dc9dbced