### PR TITLE
MOE Sync 2020-08-27

### DIFF
--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -398,6 +398,11 @@ public final class Files {
    * be exploited to create security vulnerabilities, especially when executable files are to be
    * written into the directory.
    *
+   * <p>Depending on the environmment that this code is run in, the system temporary directory (and
+   * thus the directory this method creates) may be more visible that a program would like - files
+   * written to this directory may be read or overwritten by hostile programs running on the same
+   * machine.
+   *
    * <p>This method assumes that the temporary volume is writable, has free inodes and free blocks,
    * and that it will not be called thousands of times per second.
    *
@@ -406,8 +411,15 @@ public final class Files {
    *
    * @return the newly-created directory
    * @throws IllegalStateException if the directory could not be created
+   * @deprecated For Android users, see the <a
+   *     href="https://developer.android.com/training/data-storage" target="_blank">Data and File
+   *     Storage overview</a> to select an appropriate temporary directory (perhaps {@code
+   *     context.getCacheDir()}). For developers on Java 7 or later, use {@link
+   *     java.nio.file.Files#createTempDirectory}, transforming it to a {@link File} using {@link
+   *     java.nio.file.Path#toFile() toFile()} if needed.
    */
   @Beta
+  @Deprecated
   public static File createTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
     @SuppressWarnings("GoodTime") // reading system time without TimeSource

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -398,6 +398,11 @@ public final class Files {
    * be exploited to create security vulnerabilities, especially when executable files are to be
    * written into the directory.
    *
+   * <p>Depending on the environmment that this code is run in, the system temporary directory (and
+   * thus the directory this method creates) may be more visible that a program would like - files
+   * written to this directory may be read or overwritten by hostile programs running on the same
+   * machine.
+   *
    * <p>This method assumes that the temporary volume is writable, has free inodes and free blocks,
    * and that it will not be called thousands of times per second.
    *
@@ -406,8 +411,15 @@ public final class Files {
    *
    * @return the newly-created directory
    * @throws IllegalStateException if the directory could not be created
+   * @deprecated For Android users, see the <a
+   *     href="https://developer.android.com/training/data-storage" target="_blank">Data and File
+   *     Storage overview</a> to select an appropriate temporary directory (perhaps {@code
+   *     context.getCacheDir()}). For developers on Java 7 or later, use {@link
+   *     java.nio.file.Files#createTempDirectory}, transforming it to a {@link File} using {@link
+   *     java.nio.file.Path#toFile() toFile()} if needed.
    */
   @Beta
+  @Deprecated
   public static File createTempDir() {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
     @SuppressWarnings("GoodTime") // reading system time without TimeSource


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Deprecate Files.createTempDir(), noting that better alternatives exist for Android as well as for users running Java 7 or later.

RELNOTES=`io`: Deprecated `Files.createTempDir()`.

9258dd9071c850dde0461f0f0cad81105442fdce