### PR TITLE
MOE Sync 2020-09-18

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/TreeRangeSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/TreeRangeSetTest.java
@@ -285,6 +285,19 @@ public class TreeRangeSetTest extends AbstractRangeSetTest {
     }
   }
 
+  public void testSubRangeSetAdd() {
+    TreeRangeSet<Integer> set = TreeRangeSet.create();
+    Range<Integer> range = Range.closedOpen(0, 5);
+    set.subRangeSet(range).add(range);
+  }
+
+  public void testSubRangeSetReplaceAdd() {
+    TreeRangeSet<Integer> set = TreeRangeSet.create();
+    Range<Integer> range = Range.closedOpen(0, 5);
+    set.add(range);
+    set.subRangeSet(range).add(range);
+  }
+
   public void testComplement() {
     for (Range<Integer> range1 : QUERY_RANGES) {
       for (Range<Integer> range2 : QUERY_RANGES) {

--- a/android/guava-tests/test/com/google/common/util/concurrent/JdkFutureAdaptersTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/JdkFutureAdaptersTest.java
@@ -233,6 +233,7 @@ public class JdkFutureAdaptersTest extends TestCase {
     }
   }
 
+  @SuppressWarnings("IsInstanceIncompatibleType") // intentional.
   public void testListenInPoolThreadRunsListenerAfterRuntimeException() throws Exception {
     RuntimeExceptionThrowingFuture<String> input = new RuntimeExceptionThrowingFuture<>();
     /*

--- a/android/guava/src/com/google/common/collect/ForwardingMap.java
+++ b/android/guava/src/com/google/common/collect/ForwardingMap.java
@@ -76,8 +76,8 @@ public abstract class ForwardingMap<K, V> extends ForwardingObject implements Ma
 
   @CanIgnoreReturnValue
   @Override
-  public V remove(Object object) {
-    return delegate().remove(object);
+  public V remove(Object key) {
+    return delegate().remove(key);
   }
 
   @Override

--- a/android/guava/src/com/google/common/collect/TreeRangeSet.java
+++ b/android/guava/src/com/google/common/collect/TreeRangeSet.java
@@ -896,7 +896,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
           "Cannot add range %s to subRangeSet(%s)",
           rangeToAdd,
           restriction);
-      super.add(rangeToAdd);
+      TreeRangeSet.this.add(rangeToAdd);
     }
 
     @Override

--- a/guava-tests/test/com/google/common/collect/TreeRangeSetTest.java
+++ b/guava-tests/test/com/google/common/collect/TreeRangeSetTest.java
@@ -285,6 +285,19 @@ public class TreeRangeSetTest extends AbstractRangeSetTest {
     }
   }
 
+  public void testSubRangeSetAdd() {
+    TreeRangeSet<Integer> set = TreeRangeSet.create();
+    Range<Integer> range = Range.closedOpen(0, 5);
+    set.subRangeSet(range).add(range);
+  }
+
+  public void testSubRangeSetReplaceAdd() {
+    TreeRangeSet<Integer> set = TreeRangeSet.create();
+    Range<Integer> range = Range.closedOpen(0, 5);
+    set.add(range);
+    set.subRangeSet(range).add(range);
+  }
+
   public void testComplement() {
     for (Range<Integer> range1 : QUERY_RANGES) {
       for (Range<Integer> range2 : QUERY_RANGES) {

--- a/guava-tests/test/com/google/common/util/concurrent/JdkFutureAdaptersTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/JdkFutureAdaptersTest.java
@@ -233,6 +233,7 @@ public class JdkFutureAdaptersTest extends TestCase {
     }
   }
 
+  @SuppressWarnings("IsInstanceIncompatibleType") // intentional.
   public void testListenInPoolThreadRunsListenerAfterRuntimeException() throws Exception {
     RuntimeExceptionThrowingFuture<String> input = new RuntimeExceptionThrowingFuture<>();
     /*

--- a/guava/src/com/google/common/collect/ForwardingMap.java
+++ b/guava/src/com/google/common/collect/ForwardingMap.java
@@ -76,8 +76,8 @@ public abstract class ForwardingMap<K, V> extends ForwardingObject implements Ma
 
   @CanIgnoreReturnValue
   @Override
-  public V remove(Object object) {
-    return delegate().remove(object);
+  public V remove(Object key) {
+    return delegate().remove(key);
   }
 
   @Override

--- a/guava/src/com/google/common/collect/TreeRangeSet.java
+++ b/guava/src/com/google/common/collect/TreeRangeSet.java
@@ -891,7 +891,7 @@ public class TreeRangeSet<C extends Comparable<?>> extends AbstractRangeSet<C>
           "Cannot add range %s to subRangeSet(%s)",
           rangeToAdd,
           restriction);
-      super.add(rangeToAdd);
+      TreeRangeSet.this.add(rangeToAdd);
     }
 
     @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix UnsupportedOperationException from TreeRangeSet.subRangeSet(...).add(...).

Fixes #4019, #4002

3685507ce36e24f111cabb45c6d5c5dd26565aad

-------

<p> Deal with Class#isInstance checks which are guaranteed to be false.

2fa82f2cb6e1d2f6c29b7986be6e95063b65bf71

-------

<p> Change `ForwardingMap.remove(Object)` parameter name from `object` to `key` to match `Map.remove(Object key)`.

Fixes https://github.com/google/guava/issues/4028

204904cbe79852e29aec2e461273f9b6112bd2f9