### PR TITLE
MOE Sync 2020-10-02

### DIFF
--- a/android/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
@@ -34,7 +34,6 @@ public class ForwardingCacheTest extends TestCase {
   private Cache<String, Boolean> forward;
   private Cache<String, Boolean> mock;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {

--- a/android/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
@@ -34,7 +34,6 @@ public class ForwardingLoadingCacheTest extends TestCase {
   private LoadingCache<String, Boolean> forward;
   private LoadingCache<String, Boolean> mock;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {

--- a/android/guava-tests/test/com/google/common/hash/FunnelsTest.java
+++ b/android/guava-tests/test/com/google/common/hash/FunnelsTest.java
@@ -93,7 +93,6 @@ public class FunnelsTest extends TestCase {
   }
 
   public void testSequential() {
-    // go/do-not-mock-common-types-lsc
     @SuppressWarnings({"unchecked", "DoNotMock"})
     Funnel<Object> elementFunnel = mock(Funnel.class);
     PrimitiveSink primitiveSink = mock(PrimitiveSink.class);

--- a/android/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
+++ b/android/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
@@ -35,7 +35,6 @@ public class HashingInputStreamTest extends TestCase {
   private static final byte[] testBytes = new byte[] {'y', 'a', 'm', 's'};
   private ByteArrayInputStream buffer;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {

--- a/android/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
+++ b/android/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
@@ -33,7 +33,6 @@ public class HashingOutputStreamTest extends TestCase {
   private HashFunction hashFunction;
   private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {

--- a/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -232,16 +232,16 @@ final class LittleEndianByteArray {
     LittleEndianBytes theGetter = JavaLittleEndianBytes.INSTANCE;
     try {
       /*
-        UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause crashes
-        on Android when running in 32-bit mode. For maximum safety, we shouldn't use
-        Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so as
-        a compromise, we enable the optimization only on platforms that we specifically know to
-        work.
-
-        In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(), which
-        will have an efficient native implementation in JDK 9.
-
-      */
+       * UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause
+       * crashes on Android when running in 32-bit mode. For maximum safety, we shouldn't use
+       * Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so
+       * as a compromise, we enable the optimization only on platforms that we specifically know to
+       * work.
+       *
+       * In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(),
+       * which will have an efficient native implementation in JDK 9.
+       *
+       */
       final String arch = System.getProperty("os.arch");
       if ("amd64".equals(arch)) {
         theGetter =

--- a/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeoutException;
  * debugging, and cancellation. Examples of frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <h4>{@link java.util.concurrent.CompletableFuture} / {@link java.util.concurrent.CompletionStage}

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -60,7 +60,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * monitoring, debugging, and cancellation. Examples of frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <p>If you do chain your operations manually, you may want to use {@link FluentFuture}.

--- a/android/guava/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -41,7 +41,7 @@ import java.util.concurrent.RejectedExecutionException;
  * frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <p>The main purpose of {@link #addListener addListener} is to support this chaining. You will

--- a/android/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
+++ b/android/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
@@ -65,7 +65,6 @@ public final class UncaughtExceptionHandlers {
     @Override
     public void uncaughtException(Thread t, Throwable e) {
       try {
-        // cannot use FormattingLogger due to a dependency loop
         logger.log(
             SEVERE, String.format(Locale.ROOT, "Caught an exception in %s.  Shutting down.", t), e);
       } catch (Throwable errorInLogging) {

--- a/futures/listenablefuture1/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/futures/listenablefuture1/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -41,7 +41,7 @@ import java.util.concurrent.RejectedExecutionException;
  * frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <p>The main purpose of {@link #addListener addListener} is to support this chaining. You will

--- a/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingCacheTest.java
@@ -34,7 +34,6 @@ public class ForwardingCacheTest extends TestCase {
   private Cache<String, Boolean> forward;
   private Cache<String, Boolean> mock;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {

--- a/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/ForwardingLoadingCacheTest.java
@@ -34,7 +34,6 @@ public class ForwardingLoadingCacheTest extends TestCase {
   private LoadingCache<String, Boolean> forward;
   private LoadingCache<String, Boolean> mock;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings({"unchecked", "DoNotMock"}) // mock
   @Override
   public void setUp() throws Exception {

--- a/guava-tests/test/com/google/common/hash/FunnelsTest.java
+++ b/guava-tests/test/com/google/common/hash/FunnelsTest.java
@@ -93,7 +93,6 @@ public class FunnelsTest extends TestCase {
   }
 
   public void testSequential() {
-    // go/do-not-mock-common-types-lsc
     @SuppressWarnings({"unchecked", "DoNotMock"})
     Funnel<Object> elementFunnel = mock(Funnel.class);
     PrimitiveSink primitiveSink = mock(PrimitiveSink.class);

--- a/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingInputStreamTest.java
@@ -35,7 +35,6 @@ public class HashingInputStreamTest extends TestCase {
   private static final byte[] testBytes = new byte[] {'y', 'a', 'm', 's'};
   private ByteArrayInputStream buffer;
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {

--- a/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingOutputStreamTest.java
@@ -33,7 +33,6 @@ public class HashingOutputStreamTest extends TestCase {
   private HashFunction hashFunction;
   private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
-  // go/do-not-mock-common-types-lsc
   @SuppressWarnings("DoNotMock")
   @Override
   protected void setUp() throws Exception {

--- a/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -232,16 +232,16 @@ final class LittleEndianByteArray {
     LittleEndianBytes theGetter = JavaLittleEndianBytes.INSTANCE;
     try {
       /*
-        UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause crashes
-        on Android when running in 32-bit mode. For maximum safety, we shouldn't use
-        Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so as
-        a compromise, we enable the optimization only on platforms that we specifically know to
-        work.
-
-        In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(), which
-        will have an efficient native implementation in JDK 9.
-
-      */
+       * UnsafeByteArray uses Unsafe.getLong() in an unsupported way, which is known to cause
+       * crashes on Android when running in 32-bit mode. For maximum safety, we shouldn't use
+       * Unsafe.getLong() at all, but the performance benefit on x86_64 is too great to ignore, so
+       * as a compromise, we enable the optimization only on platforms that we specifically know to
+       * work.
+       *
+       * In the future, the use of Unsafe.getLong() should be replaced by ByteBuffer.getLong(),
+       * which will have an efficient native implementation in JDK 9.
+       *
+       */
       final String arch = System.getProperty("os.arch");
       if ("amd64".equals(arch)) {
         theGetter =

--- a/guava/src/com/google/common/util/concurrent/FluentFuture.java
+++ b/guava/src/com/google/common/util/concurrent/FluentFuture.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeoutException;
  * debugging, and cancellation. Examples of frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <h4>{@link java.util.concurrent.CompletableFuture} / {@link java.util.concurrent.CompletionStage}

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -62,7 +62,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * monitoring, debugging, and cancellation. Examples of frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <p>If you do chain your operations manually, you may want to use {@link FluentFuture}.

--- a/guava/src/com/google/common/util/concurrent/ListenableFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ListenableFuture.java
@@ -41,7 +41,7 @@ import java.util.concurrent.RejectedExecutionException;
  * frameworks include:
  *
  * <ul>
- *   <li><a href="http://dagger.dev/producers.html">Dagger Producers</a>
+ *   <li><a href="https://dagger.dev/producers.html">Dagger Producers</a>
  * </ul>
  *
  * <p>The main purpose of {@link #addListener addListener} is to support this chaining. You will

--- a/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
+++ b/guava/src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java
@@ -65,7 +65,6 @@ public final class UncaughtExceptionHandlers {
     @Override
     public void uncaughtException(Thread t, Throwable e) {
       try {
-        // cannot use FormattingLogger due to a dependency loop
         logger.log(
             SEVERE, String.format(Locale.ROOT, "Caught an exception in %s.  Shutting down.", t), e);
       } catch (Throwable errorInLogging) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Begin tweaking Guava sources to satisfy Copybara.

- Change from http to https (and from github.io links to guava.dev/truth.dev while I'm at it).
- Remove go/ links.
- Add whitespace around MOE directives.
- Put MOE stripping directives alone in comments, moving other comment text to a separate comment.
- One particular case of that: Put MOE intracomment stripping into HTML comments... even when it happens in non-Javadoc comments (i.e., /* */). It seems that Copybara wants for intracomment directives to stand alone in *some* kind of comment?
- Add @GoogleInternal to some files that are currently omitted from Guava simply by not being in MOE filegroup targets.

This is surely not a complete set of changes, but it's enough to get me started.

b5dce621aed0d374d3abc000eb51cb513e7b496e