### PR TITLE
MOE Sync 2020-10-13

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
@@ -50,19 +50,21 @@ import java.util.Iterator;
  * verify() method, which is called <em>after</em> each sequence and is guaranteed to be called
  * using the latest values obtained from {@link IteratorTester#newTargetIterator()}.
  *
- * <p>For example, to test {@link java.util.ArrayList#iterator() ArrayList.iterator()}:
+ * <p>For example, to test {@link java.util.Collections#unmodifiableList(java.util.List)
+ * Collections.unmodifiableList}'s iterator:
  *
  * <pre>{@code
  * List<String> expectedElements =
  *     Arrays.asList("a", "b", "c", "d", "e");
  * List<String> actualElements =
- *     new ArrayList<>(Arrays.asList("a", "b", "c", "d", "e"));
+ *     Collections.unmodifiableList(
+ *         Arrays.asList("a", "b", "c", "d", "e"));
  * IteratorTester<String> iteratorTester =
  *     new IteratorTester<String>(
  *         5,
- *         IteratorFeature.MODIFIABLE,
+ *         IteratorFeature.UNMODIFIABLE,
  *         expectedElements,
- *         KnownOrder.KNOWN_ORDER) {
+ *         IteratorTester.KnownOrder.KNOWN_ORDER) {
  *       @Override
  *       protected Iterator<String> newTargetIterator() {
  *         return actualElements.iterator();
@@ -71,6 +73,9 @@ import java.util.Iterator;
  * iteratorTester.test();
  * iteratorTester.testForEachRemaining();
  * }</pre>
+ *
+ * <p><b>Note</b>: It is necessary to use {@code IteratorTester.KnownOrder} as shown above, rather
+ * than {@code KnownOrder} directly, because otherwise the code is not compilable.
  *
  * @author Kevin Bourrillion
  * @author Chris Povirk

--- a/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -2627,8 +2627,8 @@ public class FuturesTest extends TestCase {
     assertThat(futureResult.toString())
         .matches(
             "CombinedFuture@\\w+\\[status=PENDING,"
-                + " info=\\[futures=\\[SettableFuture@\\w+\\[status=SUCCESS, result=\\[1]],"
-                + " SettableFuture@\\w+\\[status=PENDING]]]]");
+                + " info=\\[futures=\\[SettableFuture@\\w+\\[status=SUCCESS,"
+                + " result=\\[java.lang.Integer@\\w+]], SettableFuture@\\w+\\[status=PENDING]]]]");
 
     // Backing futures complete
     Boolean booleanPartial = true;
@@ -2649,7 +2649,7 @@ public class FuturesTest extends TestCase {
     String expectedResult = createCombinedResult(integerPartial, booleanPartial);
     assertEquals(expectedResult, futureResult.get());
     assertThat(futureResult.toString())
-        .matches("CombinedFuture@\\w+\\[status=SUCCESS, result=\\[" + expectedResult + "]]");
+        .matches("CombinedFuture@\\w+\\[status=SUCCESS, result=\\[java.lang.String@\\w+]]");
   }
 
   public void testWhenAllComplete_asyncError() throws Exception {

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -1158,7 +1158,7 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
     try {
       V value = getUninterruptibly(this);
       builder.append("SUCCESS, result=[");
-      appendUserObject(builder, value);
+      appendResultObject(builder, value);
       builder.append("]");
     } catch (ExecutionException e) {
       builder.append("FAILURE, cause=[").append(e.getCause()).append("]");
@@ -1166,6 +1166,24 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
       builder.append("CANCELLED"); // shouldn't be reachable
     } catch (RuntimeException e) {
       builder.append("UNKNOWN, cause=[").append(e.getClass()).append(" thrown from get()]");
+    }
+  }
+
+  /**
+   * Any object can be the result of a Future, and not every object has a reasonable toString()
+   * implementation. Using a reconstruction of the default Object.toString() prevents OOMs and stack
+   * overflows, and helps avoid sensitive data inadvertently ending up in exception messages.
+   */
+  private void appendResultObject(StringBuilder builder, Object o) {
+    if (o == null) {
+      builder.append("null");
+    } else if (o == this) {
+      builder.append("this future");
+    } else {
+      builder
+          .append(o.getClass().getName())
+          .append("@")
+          .append(Integer.toHexString(System.identityHashCode(o)));
     }
   }
 

--- a/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
@@ -50,19 +50,21 @@ import java.util.Iterator;
  * verify() method, which is called <em>after</em> each sequence and is guaranteed to be called
  * using the latest values obtained from {@link IteratorTester#newTargetIterator()}.
  *
- * <p>For example, to test {@link java.util.ArrayList#iterator() ArrayList.iterator()}:
+ * <p>For example, to test {@link java.util.Collections#unmodifiableList(java.util.List)
+ * Collections.unmodifiableList}'s iterator:
  *
  * <pre>{@code
  * List<String> expectedElements =
  *     Arrays.asList("a", "b", "c", "d", "e");
  * List<String> actualElements =
- *     new ArrayList<>(Arrays.asList("a", "b", "c", "d", "e"));
+ *     Collections.unmodifiableList(
+ *         Arrays.asList("a", "b", "c", "d", "e"));
  * IteratorTester<String> iteratorTester =
  *     new IteratorTester<String>(
  *         5,
- *         IteratorFeature.MODIFIABLE,
+ *         IteratorFeature.UNMODIFIABLE,
  *         expectedElements,
- *         KnownOrder.KNOWN_ORDER) {
+ *         IteratorTester.KnownOrder.KNOWN_ORDER) {
  *       @Override
  *       protected Iterator<String> newTargetIterator() {
  *         return actualElements.iterator();
@@ -71,6 +73,9 @@ import java.util.Iterator;
  * iteratorTester.test();
  * iteratorTester.testForEachRemaining();
  * }</pre>
+ *
+ * <p><b>Note</b>: It is necessary to use {@code IteratorTester.KnownOrder} as shown above, rather
+ * than {@code KnownOrder} directly, because otherwise the code is not compilable.
  *
  * @author Kevin Bourrillion
  * @author Chris Povirk

--- a/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -2627,8 +2627,8 @@ public class FuturesTest extends TestCase {
     assertThat(futureResult.toString())
         .matches(
             "CombinedFuture@\\w+\\[status=PENDING,"
-                + " info=\\[futures=\\[SettableFuture@\\w+\\[status=SUCCESS, result=\\[1]],"
-                + " SettableFuture@\\w+\\[status=PENDING]]]]");
+                + " info=\\[futures=\\[SettableFuture@\\w+\\[status=SUCCESS,"
+                + " result=\\[java.lang.Integer@\\w+]], SettableFuture@\\w+\\[status=PENDING]]]]");
 
     // Backing futures complete
     Boolean booleanPartial = true;
@@ -2649,7 +2649,7 @@ public class FuturesTest extends TestCase {
     String expectedResult = createCombinedResult(integerPartial, booleanPartial);
     assertEquals(expectedResult, futureResult.get());
     assertThat(futureResult.toString())
-        .matches("CombinedFuture@\\w+\\[status=SUCCESS, result=\\[" + expectedResult + "]]");
+        .matches("CombinedFuture@\\w+\\[status=SUCCESS, result=\\[java.lang.String@\\w+]]");
   }
 
   public void testWhenAllComplete_asyncError() throws Exception {

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -1156,7 +1156,7 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
     try {
       V value = getUninterruptibly(this);
       builder.append("SUCCESS, result=[");
-      appendUserObject(builder, value);
+      appendResultObject(builder, value);
       builder.append("]");
     } catch (ExecutionException e) {
       builder.append("FAILURE, cause=[").append(e.getCause()).append("]");
@@ -1164,6 +1164,24 @@ public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
       builder.append("CANCELLED"); // shouldn't be reachable
     } catch (RuntimeException e) {
       builder.append("UNKNOWN, cause=[").append(e.getClass()).append(" thrown from get()]");
+    }
+  }
+
+  /**
+   * Any object can be the result of a Future, and not every object has a reasonable toString()
+   * implementation. Using a reconstruction of the default Object.toString() prevents OOMs and stack
+   * overflows, and helps avoid sensitive data inadvertently ending up in exception messages.
+   */
+  private void appendResultObject(StringBuilder builder, Object o) {
+    if (o == null) {
+      builder.append("null");
+    } else if (o == this) {
+      builder.append("this future");
+    } else {
+      builder
+          .append(o.getClass().getName())
+          .append("@")
+          .append(Integer.toHexString(System.identityHashCode(o)));
     }
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't call toString() on the results of successful futures.

RELNOTES=AbstractFuture.toString() no longer includes the toString() of the result.

771629df701dfe565024db1cabfe19d7a5b2abfc

-------

<p> Fix example in documentation for `IteratorTester`

I made a mistake and accidentally included an example that does not
compile. Specifically, importing `KnownOrder` as-is does not compile;
instead one needs to import `IteratorTester.KnownOrder`. See #5254 for
more information.

I also changed the example to use `Collections#unmodifiableList`
rather than `ArrayList` because `ArrayList#iterator` does not satisfy
all the requirements of `IteratorFeature#MODIFIABLE`.

Fixes #5276

448afdbd4fc53f8d8f636516e54bfcbad9d6b3c0