### PR TITLE
MOE Sync 2020-10-14

### DIFF
--- a/android/guava/src/com/google/common/collect/Interner.java
+++ b/android/guava/src/com/google/common/collect/Interner.java
@@ -22,8 +22,12 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.DoNotMock;
 
 /**
- * Provides equivalent behavior to {@link String#intern} for other immutable types. Common
- * implementations are available from the {@link Interners} class.
+ * Provides similar behavior to {@link String#intern} for any immutable type. Common implementations
+ * are available from the {@link Interners} class.
+ *
+ * <p>Note that {@code String.intern()} has some well-known performance limitations, and should
+ * generally be avoided. Prefer {@link Interners#newWeakInterner} or another {@code Interner}
+ * implementation even for {@code String} interning.
  *
  * @author Kevin Bourrillion
  * @since 3.0

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -974,6 +974,11 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * callbacks, but any callback added through this method is guaranteed to be called once the
    * computation is complete.
    *
+   * <p>Exceptions thrown by a {@code callback} will be propagated up to the executor. Any exception
+   * thrown during {@code Executor.execute} (e.g., a {@code RejectedExecutionException} or an
+   * exception thrown by {@linkplain MoreExecutors#directExecutor direct execution}) will be caught
+   * and logged.
+   *
    * <p>Example:
    *
    * <pre>{@code

--- a/guava/src/com/google/common/collect/Interner.java
+++ b/guava/src/com/google/common/collect/Interner.java
@@ -22,8 +22,12 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.DoNotMock;
 
 /**
- * Provides equivalent behavior to {@link String#intern} for other immutable types. Common
- * implementations are available from the {@link Interners} class.
+ * Provides similar behavior to {@link String#intern} for any immutable type. Common implementations
+ * are available from the {@link Interners} class.
+ *
+ * <p>Note that {@code String.intern()} has some well-known performance limitations, and should
+ * generally be avoided. Prefer {@link Interners#newWeakInterner} or another {@code Interner}
+ * implementation even for {@code String} interning.
  *
  * @author Kevin Bourrillion
  * @since 3.0

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -1007,6 +1007,11 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * callbacks, but any callback added through this method is guaranteed to be called once the
    * computation is complete.
    *
+   * <p>Exceptions thrown by a {@code callback} will be propagated up to the executor. Any exception
+   * thrown during {@code Executor.execute} (e.g., a {@code RejectedExecutionException} or an
+   * exception thrown by {@linkplain MoreExecutors#directExecutor direct execution}) will be caught
+   * and logged.
+   *
    * <p>Example:
    *
    * <pre>{@code


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Clarify that Interner should be preferred instead of String.intern(); the existing language implies it's intended _only_ for other types.

See also https://github.com/google/guava/issues/399#issuecomment-61307754

1034a2ee444ad03ec869638efa53b3ae880c7f4d

-------

<p> Document what happens when FutureCallback throws exception.

Fixes #5250, #2058

3d573ac2514c53d678c3855b28d9223fea9c7e8f