### PR TITLE
Added power support for the travis.yml file with ppc64le, added "maven" on packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 
 language: java
-
+arch:
+ - amd64
+ - ppc64le
 jdk:
   - openjdk8
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4j
 script: travis_wait 60 mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
 
 before_install:
-travis_retry travis_wait mvn install --projects janusgraph-${MODULE} --also-make \
+script: travis_retry travis_wait mvn install --projects janusgraph-${MODULE} --also-make \
           -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version ${INSTALL_ARGS};
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4j
 
 # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
 script: travis_wait 60 mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
-
-before_install:
-script: travis_retry travis_wait mvn install --projects janusgraph-${MODULE} --also-make \
-          -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version ${INSTALL_ARGS};
-
 after_success:
   - util/deploy_snapshot.sh
   - util/update_snapshot_docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ arch:
 jdk:
   - openjdk8
   - openjdk11
+# git strips the wrapper jar file so we have to force its download during the build
+install:
+- mvn -N io.takari:maven:wrapper
+- ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,11 @@ arch:
 jdk:
   - openjdk8
   - openjdk11
-# git strips the wrapper jar file so we have to force its download during the build
-install:
-- mvn -N io.takari:maven:wrapper
-- ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-
 addons:
   apt:
     packages:
       - openjdk-8-source
+      - maven
 
 install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4j
 # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
 script: travis_wait 60 mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
 
+before_install:
+travis_retry travis_wait mvn install --projects janusgraph-${MODULE} --also-make \
+          -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version ${INSTALL_ARGS};
+
 after_success:
   - util/deploy_snapshot.sh
   - util/update_snapshot_docs.sh


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing

added "maven"  packages like below.
packages:
      - maven
