### PR TITLE
MOE Sync 2020-10-16

### DIFF
--- a/android/guava/src/com/google/common/math/LongMath.java
+++ b/android/guava/src/com/google/common/math/LongMath.java
@@ -1005,8 +1005,29 @@ public final class LongMath {
       checkNonNegative("n", n);
       return false;
     }
-    if (n == 2 || n == 3 || n == 5 || n == 7 || n == 11 || n == 13) {
-      return true;
+    if (n < 66) {
+      // Encode all primes less than 66 into mask without 0 and 1.
+      long mask =
+          (1L << (2 - 2))
+              | (1L << (3 - 2))
+              | (1L << (5 - 2))
+              | (1L << (7 - 2))
+              | (1L << (11 - 2))
+              | (1L << (13 - 2))
+              | (1L << (17 - 2))
+              | (1L << (19 - 2))
+              | (1L << (23 - 2))
+              | (1L << (29 - 2))
+              | (1L << (31 - 2))
+              | (1L << (37 - 2))
+              | (1L << (41 - 2))
+              | (1L << (43 - 2))
+              | (1L << (47 - 2))
+              | (1L << (53 - 2))
+              | (1L << (59 - 2))
+              | (1L << (61 - 2));
+      // Look up n within the mask.
+      return ((mask >> ((int) n - 2)) & 1) != 0;
     }
 
     if ((SIEVE_30 & (1 << (n % 30))) != 0) {

--- a/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -1040,6 +1040,7 @@ public final class ClosingFuture<V> {
    * @return {@code false} if the step could not be cancelled, typically because it has already
    *     completed normally; {@code true} otherwise
    */
+  @CanIgnoreReturnValue
   public boolean cancel(boolean mayInterruptIfRunning) {
     logger.log(FINER, "cancelling {0}", this);
     boolean cancelled = future.cancel(mayInterruptIfRunning);

--- a/guava/src/com/google/common/math/LongMath.java
+++ b/guava/src/com/google/common/math/LongMath.java
@@ -1005,8 +1005,29 @@ public final class LongMath {
       checkNonNegative("n", n);
       return false;
     }
-    if (n == 2 || n == 3 || n == 5 || n == 7 || n == 11 || n == 13) {
-      return true;
+    if (n < 66) {
+      // Encode all primes less than 66 into mask without 0 and 1.
+      long mask =
+          (1L << (2 - 2))
+              | (1L << (3 - 2))
+              | (1L << (5 - 2))
+              | (1L << (7 - 2))
+              | (1L << (11 - 2))
+              | (1L << (13 - 2))
+              | (1L << (17 - 2))
+              | (1L << (19 - 2))
+              | (1L << (23 - 2))
+              | (1L << (29 - 2))
+              | (1L << (31 - 2))
+              | (1L << (37 - 2))
+              | (1L << (41 - 2))
+              | (1L << (43 - 2))
+              | (1L << (47 - 2))
+              | (1L << (53 - 2))
+              | (1L << (59 - 2))
+              | (1L << (61 - 2));
+      // Look up n within the mask.
+      return ((mask >> ((int) n - 2)) & 1) != 0;
     }
 
     if ((SIEVE_30 & (1 << (n % 30))) != 0) {

--- a/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -1039,6 +1039,7 @@ public final class ClosingFuture<V> {
    * @return {@code false} if the step could not be cancelled, typically because it has already
    *     completed normally; {@code true} otherwise
    */
+  @CanIgnoreReturnValue
   public boolean cancel(boolean mayInterruptIfRunning) {
     logger.log(FINER, "cancelling {0}", this);
     boolean cancelled = future.cancel(mayInterruptIfRunning);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Encode all primes less-than 66 into a bitmask

Use a bitmask to make prime computation for all values less-than 66 O(1) and avoid any remainder calculations in these cases.

a2fcd41b7c10847d22943e083da450749a99c72b

-------

<p> Added `@CanIgnoreReturnValue` to `cancel`.

a4cf89bfc87cf95cdfad56d9a9c384c9e6dd0b33