### PR TITLE
MOE Sync 2020-10-16

### DIFF
--- a/android/guava/src/com/google/common/io/Files.java
+++ b/android/guava/src/com/google/common/io/Files.java
@@ -24,9 +24,9 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.TreeTraverser;
 import com.google.common.graph.SuccessorsFunction;
 import com.google.common.graph.Traverser;
 import com.google.common.hash.HashCode;
@@ -825,36 +825,6 @@ public final class Files {
   }
 
   /**
-   * Returns a {@link TreeTraverser} instance for {@link File} trees.
-   *
-   * <p><b>Warning:</b> {@code File} provides no support for symbolic links, and as such there is no
-   * way to ensure that a symbolic link to a directory is not followed when traversing the tree. In
-   * this case, iterables created by this traverser could contain files that are outside of the
-   * given directory or even be infinite if there is a symbolic link loop.
-   *
-   * @since 15.0
-   * @deprecated The returned {@link TreeTraverser} type is deprecated. Use the replacement method
-   *     {@link #fileTraverser()} instead with the same semantics as this method.
-   */
-  @Deprecated
-  static TreeTraverser<File> fileTreeTraverser() {
-    return FILE_TREE_TRAVERSER;
-  }
-
-  private static final TreeTraverser<File> FILE_TREE_TRAVERSER =
-      new TreeTraverser<File>() {
-        @Override
-        public Iterable<File> children(File file) {
-          return fileTreeChildren(file);
-        }
-
-        @Override
-        public String toString() {
-          return "Files.fileTreeTraverser()";
-        }
-      };
-
-  /**
    * Returns a {@link Traverser} instance for the file and directory tree. The returned traverser
    * starts from a {@link File} and will return all files and directories it encounters.
    *
@@ -885,21 +855,17 @@ public final class Files {
       new SuccessorsFunction<File>() {
         @Override
         public Iterable<File> successors(File file) {
-          return fileTreeChildren(file);
+          // check isDirectory() just because it may be faster than listFiles() on a non-directory
+          if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+              return Collections.unmodifiableList(Arrays.asList(files));
+            }
+          }
+
+          return ImmutableList.of();
         }
       };
-
-  private static Iterable<File> fileTreeChildren(File file) {
-    // check isDirectory() just because it may be faster than listFiles() on a non-directory
-    if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null) {
-        return Collections.unmodifiableList(Arrays.asList(files));
-      }
-    }
-
-    return Collections.emptyList();
-  }
 
   /**
    * Returns a predicate that returns the result of {@link File#isDirectory} on input files.

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -24,9 +24,9 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.TreeTraverser;
 import com.google.common.graph.SuccessorsFunction;
 import com.google.common.graph.Traverser;
 import com.google.common.hash.HashCode;
@@ -825,36 +825,6 @@ public final class Files {
   }
 
   /**
-   * Returns a {@link TreeTraverser} instance for {@link File} trees.
-   *
-   * <p><b>Warning:</b> {@code File} provides no support for symbolic links, and as such there is no
-   * way to ensure that a symbolic link to a directory is not followed when traversing the tree. In
-   * this case, iterables created by this traverser could contain files that are outside of the
-   * given directory or even be infinite if there is a symbolic link loop.
-   *
-   * @since 15.0
-   * @deprecated The returned {@link TreeTraverser} type is deprecated. Use the replacement method
-   *     {@link #fileTraverser()} instead with the same semantics as this method.
-   */
-  @Deprecated
-  static TreeTraverser<File> fileTreeTraverser() {
-    return FILE_TREE_TRAVERSER;
-  }
-
-  private static final TreeTraverser<File> FILE_TREE_TRAVERSER =
-      new TreeTraverser<File>() {
-        @Override
-        public Iterable<File> children(File file) {
-          return fileTreeChildren(file);
-        }
-
-        @Override
-        public String toString() {
-          return "Files.fileTreeTraverser()";
-        }
-      };
-
-  /**
    * Returns a {@link Traverser} instance for the file and directory tree. The returned traverser
    * starts from a {@link File} and will return all files and directories it encounters.
    *
@@ -885,21 +855,17 @@ public final class Files {
       new SuccessorsFunction<File>() {
         @Override
         public Iterable<File> successors(File file) {
-          return fileTreeChildren(file);
+          // check isDirectory() just because it may be faster than listFiles() on a non-directory
+          if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+              return Collections.unmodifiableList(Arrays.asList(files));
+            }
+          }
+
+          return ImmutableList.of();
         }
       };
-
-  private static Iterable<File> fileTreeChildren(File file) {
-    // check isDirectory() just because it may be faster than listFiles() on a non-directory
-    if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null) {
-        return Collections.unmodifiableList(Arrays.asList(files));
-      }
-    }
-
-    return Collections.emptyList();
-  }
 
   /**
    * Returns a predicate that returns the result of {@link File#isDirectory} on input files.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove deprecated method Files.fileTreeTraverser() that isn't being used anymore.

295dd8008d06d73a99ffe076d1c302113b5a8f54