### PR TITLE
MOE Sync 2020-10-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Guava's Maven group ID is `com.google.guava`, and its artifact ID is `guava`.
 Guava provides two different "flavors": one for use on a (Java 8+) JRE and one
 for use on Android or Java 7 or by any library that wants to be compatible with
 either of those. These flavors are specified in the Maven version field as
-either `29.0-jre` or `29.0-android`. For more about depending on Guava, see
+either `30.0-jre` or `30.0-android`. For more about depending on Guava, see
 [using Guava in your build].
 
 To add a dependency on Guava using Maven, use the following:
@@ -32,9 +32,9 @@ To add a dependency on Guava using Maven, use the following:
 <dependency>
   <groupId>com.google.guava</groupId>
   <artifactId>guava</artifactId>
-  <version>29.0-jre</version>
+  <version>30.0-jre</version>
   <!-- or, for Android: -->
-  <version>29.0-android</version>
+  <version>30.0-android</version>
 </dependency>
 ```
 
@@ -45,16 +45,16 @@ dependencies {
   // Pick one:
 
   // 1. Use Guava in your implementation only:
-  implementation("com.google.guava:guava:29.0-jre")
+  implementation("com.google.guava:guava:30.0-jre")
 
   // 2. Use Guava types in your public API:
-  api("com.google.guava:guava:29.0-jre")
+  api("com.google.guava:guava:30.0-jre")
 
   // 3. Android - Use Guava in your implementation only:
-  implementation("com.google.guava:guava:29.0-android")
+  implementation("com.google.guava:guava:30.0-android")
 
   // 4. Android - Use Guava types in your public API:
-  api("com.google.guava:guava:29.0-android")
+  api("com.google.guava:guava:30.0-android")
 }
 ```
 

--- a/android/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
@@ -50,6 +50,9 @@ import java.util.Iterator;
  * verify() method, which is called <em>after</em> each sequence and is guaranteed to be called
  * using the latest values obtained from {@link IteratorTester#newTargetIterator()}.
  *
+ * <p>The value you pass to the parameter {@code steps} should be greater than the length of your
+ * iterator, so that this class can check that your iterator behaves correctly when it is exhausted.
+ *
  * <p>For example, to test {@link java.util.Collections#unmodifiableList(java.util.List)
  * Collections.unmodifiableList}'s iterator:
  *
@@ -61,7 +64,7 @@ import java.util.Iterator;
  *         Arrays.asList("a", "b", "c", "d", "e"));
  * IteratorTester<String> iteratorTester =
  *     new IteratorTester<String>(
- *         5,
+ *         6,
  *         IteratorFeature.UNMODIFIABLE,
  *         expectedElements,
  *         IteratorTester.KnownOrder.KNOWN_ORDER) {
@@ -75,7 +78,7 @@ import java.util.Iterator;
  * }</pre>
  *
  * <p><b>Note</b>: It is necessary to use {@code IteratorTester.KnownOrder} as shown above, rather
- * than {@code KnownOrder} directly, because otherwise the code is not compilable.
+ * than {@code KnownOrder} directly, because otherwise the code cannot be compiled.
  *
  * @author Kevin Bourrillion
  * @author Chris Povirk

--- a/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -17,6 +17,7 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -171,7 +172,7 @@ public class ServiceManagerTest extends TestCase {
     Service b = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b);
     assertFalse(manager.isHealthy());
     manager.startAsync().awaitHealthy();
@@ -195,7 +196,7 @@ public class ServiceManagerTest extends TestCase {
     Service e = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b, c, d, e));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b, c, d, e);
     try {
       manager.startAsync().awaitHealthy();
@@ -219,7 +220,7 @@ public class ServiceManagerTest extends TestCase {
     Service b = new FailRunService();
     ServiceManager manager = new ServiceManager(asList(a, b));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b);
     try {
       manager.startAsync().awaitHealthy();
@@ -242,7 +243,7 @@ public class ServiceManagerTest extends TestCase {
     Service c = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b, c));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
 
     manager.startAsync().awaitHealthy();
     assertTrue(listener.healthyCalled);
@@ -292,7 +293,7 @@ public class ServiceManagerTest extends TestCase {
     Service a = new FailStartService();
     ServiceManager manager = new ServiceManager(asList(a));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     try {
       manager.startAsync().awaitHealthy();
       fail();
@@ -309,7 +310,7 @@ public class ServiceManagerTest extends TestCase {
     Service a = new FailStartService();
     ServiceManager manager = new ServiceManager(asList(a));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     try {
       manager.startAsync().awaitHealthy();
       fail();
@@ -334,7 +335,8 @@ public class ServiceManagerTest extends TestCase {
           public void failure(Service service) {
             manager.stopAsync();
           }
-        });
+        },
+        directExecutor());
     manager.startAsync();
     manager.awaitStopped(10, TimeUnit.MILLISECONDS);
   }
@@ -408,7 +410,7 @@ public class ServiceManagerTest extends TestCase {
     logger.addHandler(logHandler);
     ServiceManager manager = new ServiceManager(Arrays.<Service>asList());
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     manager.startAsync().awaitHealthy();
     assertTrue(manager.isHealthy());
     assertTrue(listener.healthyCalled);
@@ -476,7 +478,8 @@ public class ServiceManagerTest extends TestCase {
             // block until after the service manager is shutdown
             Uninterruptibles.awaitUninterruptibly(failLeave);
           }
-        });
+        },
+        directExecutor());
     manager.startAsync();
     afterStarted.countDown();
     // We do not call awaitHealthy because, due to races, that method may throw an exception.  But

--- a/android/guava/src/com/google/common/collect/Comparators.java
+++ b/android/guava/src/com/google/common/collect/Comparators.java
@@ -116,7 +116,7 @@ public final class Comparators {
    * @param a first value to compare, returned if less than or equal to b.
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i>.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T extends Comparable<? super T>> T min(T a, T b) {
@@ -136,7 +136,7 @@ public final class Comparators {
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> using the given
    *     comparator.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T> T min(@NullableDecl T a, @NullableDecl T b, Comparator<T> comparator) {
@@ -154,7 +154,7 @@ public final class Comparators {
    * @param a first value to compare, returned if greater than or equal to b.
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i>.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T extends Comparable<? super T>> T max(T a, T b) {
@@ -174,7 +174,7 @@ public final class Comparators {
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> using the given
    *     comparator.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T> T max(@NullableDecl T a, @NullableDecl T b, Comparator<T> comparator) {

--- a/android/guava/src/com/google/common/math/BigDecimalMath.java
+++ b/android/guava/src/com/google/common/math/BigDecimalMath.java
@@ -22,7 +22,7 @@ import java.math.RoundingMode;
  * A class for arithmetic on {@link BigDecimal} that is not covered by its built-in methods.
  *
  * @author Louis Wasserman
- * @since NEXT
+ * @since 30.0
  */
 @GwtIncompatible
 public class BigDecimalMath {
@@ -47,7 +47,7 @@ public class BigDecimalMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   public static double roundToDouble(BigDecimal x, RoundingMode mode) {
     return BigDecimalToDoubleRounder.INSTANCE.roundToDouble(x, mode);

--- a/android/guava/src/com/google/common/math/BigIntegerMath.java
+++ b/android/guava/src/com/google/common/math/BigIntegerMath.java
@@ -327,7 +327,7 @@ public final class BigIntegerMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   @GwtIncompatible
   public static double roundToDouble(BigInteger x, RoundingMode mode) {

--- a/android/guava/src/com/google/common/math/LongMath.java
+++ b/android/guava/src/com/google/common/math/LongMath.java
@@ -1239,7 +1239,7 @@ public final class LongMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   @SuppressWarnings("deprecation")
   @GwtIncompatible

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -270,14 +270,14 @@ public final class HttpHeaders {
    * The HTTP <a href="https://wicg.github.io/cross-origin-embedder-policy/#COEP">{@code
    * Cross-Origin-Embedder-Policy}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String CROSS_ORIGIN_EMBEDDER_POLICY = "Cross-Origin-Embedder-Policy";
   /**
    * The HTTP <a href="https://wicg.github.io/cross-origin-embedder-policy/#COEP-RO">{@code
    * Cross-Origin-Embedder-Policy-Report-Only}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String CROSS_ORIGIN_EMBEDDER_POLICY_REPORT_ONLY =
       "Cross-Origin-Embedder-Policy-Report-Only";
@@ -478,49 +478,49 @@ public final class HttpHeaders {
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua">{@code Sec-CH-UA}</a>
    * header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA = "Sec-CH-UA";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-arch">{@code
    * Sec-CH-UA-Arch}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_ARCH = "Sec-CH-UA-Arch";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-model">{@code
    * Sec-CH-UA-Model}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_MODEL = "Sec-CH-UA-Model";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-platform">{@code
    * Sec-CH-UA-Platform}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_PLATFORM = "Sec-CH-UA-Platform";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-platform-version">{@code
    * Sec-CH-UA-Platform-Version}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_PLATFORM_VERSION = "Sec-CH-UA-Platform-Version";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-full-version">{@code
    * Sec-CH-UA-Full-Version}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_FULL_VERSION = "Sec-CH-UA-Full-Version";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-mobile">{@code
    * Sec-CH-UA-Mobile}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_MOBILE = "Sec-CH-UA-Mobile";
 

--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -145,7 +145,7 @@ public final class MediaType {
   /**
    * Wildcard matching any "font" top-level media type.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType ANY_FONT_TYPE = createConstant(FONT_TYPE, WILDCARD);
 
@@ -709,7 +709,7 @@ public final class MediaType {
    * A collection of font outlines as defined by <a href="https://tools.ietf.org/html/rfc8081">RFC
    * 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_COLLECTION = createConstant(FONT_TYPE, "collection");
 
@@ -717,7 +717,7 @@ public final class MediaType {
    * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
    * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_OTF = createConstant(FONT_TYPE, "otf");
 
@@ -727,7 +727,7 @@ public final class MediaType {
    * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
    * for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_SFNT = createConstant(FONT_TYPE, "sfnt");
 
@@ -735,7 +735,7 @@ public final class MediaType {
    * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
    * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_TTF = createConstant(FONT_TYPE, "ttf");
 
@@ -745,7 +745,7 @@ public final class MediaType {
    * type for SFNT, but {@link #WOFF application/font-woff} may be necessary in certain situations
    * for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_WOFF = createConstant(FONT_TYPE, "woff");
 
@@ -755,7 +755,7 @@ public final class MediaType {
    * media type for SFNT, but {@link #WOFF2 application/font-woff2} may be necessary in certain
    * situations for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_WOFF2 = createConstant(FONT_TYPE, "woff2");
 

--- a/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -186,7 +186,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
  * automatic-closing approach described above is safer.
  *
  * @param <V> the type of the value of this step
- * @since NEXT
+ * @since 30.0
  */
 // TODO(dpb): Consider reusing one CloseableList for the entire pipeline, modulo combinations.
 @Beta // @Beta for one release.

--- a/android/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/android/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -30,7 +30,6 @@ import static com.google.common.util.concurrent.Service.State.STOPPING;
 import static com.google.common.util.concurrent.Service.State.TERMINATED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
@@ -249,34 +248,6 @@ public final class ServiceManager implements ServiceManagerBridge {
    */
   public void addListener(Listener listener, Executor executor) {
     state.addListener(listener, executor);
-  }
-
-  /**
-   * Registers a {@link Listener} to be run when this {@link ServiceManager} changes state. The
-   * listener will not have previous state changes replayed, so it is suggested that listeners are
-   * added before any of the managed services are {@linkplain Service#startAsync started}.
-   *
-   * <p>{@code addListener} guarantees execution ordering across calls to a given listener but not
-   * across calls to multiple listeners. Specifically, a given listener will have its callbacks
-   * invoked in the same order as the underlying service enters those states. Additionally, at most
-   * one of the listener's callbacks will execute at once. However, multiple listeners' callbacks
-   * may execute concurrently, and listeners may execute in an order different from the one in which
-   * they were registered.
-   *
-   * <p>RuntimeExceptions thrown by a listener will be caught and logged.
-   *
-   * @param listener the listener to run when the manager changes state
-   * @since 15.0
-   * @deprecated Use {@linkplain #addListener(Listener, Executor) the overload that accepts an
-   *     executor}. For equivalent behavior, pass {@link MoreExecutors#directExecutor}. However,
-   *     consider whether another executor would be more appropriate, as discussed in the docs for
-   *     {@link ListenableFuture#addListener ListenableFuture.addListener}. This method is scheduled
-   *     for deletion in October 2020.
-   */
-  @Beta
-  @Deprecated
-  public void addListener(Listener listener) {
-    state.addListener(listener, directExecutor());
   }
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/android/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -374,7 +374,7 @@ public final class Uninterruptibles {
    * Invokes {@code lock.}{@link Lock#tryLock(long, TimeUnit) tryLock(timeout, unit)}
    * uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
@@ -403,7 +403,7 @@ public final class Uninterruptibles {
    * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
    * awaitTermination(long, TimeUnit)} uninterruptibly with no timeout.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   @GwtIncompatible // concurrency
@@ -416,7 +416,7 @@ public final class Uninterruptibles {
    * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
    * awaitTermination(long, TimeUnit)} uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   @GwtIncompatible // concurrency

--- a/guava-testlib/README.md
+++ b/guava-testlib/README.md
@@ -13,7 +13,7 @@ To add a dependency on Guava testlib using Maven, use the following:
 <dependency>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-testlib</artifactId>
-  <version>29.0-jre</version>
+  <version>30.0-jre</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -22,7 +22,7 @@ To add a dependency using Gradle:
 
 ```gradle
 dependencies {
-  test 'com.google.guava:guava-testlib:29.0-jre'
+  test 'com.google.guava:guava-testlib:30.0-jre'
 }
 ```
 

--- a/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/IteratorTester.java
@@ -50,6 +50,9 @@ import java.util.Iterator;
  * verify() method, which is called <em>after</em> each sequence and is guaranteed to be called
  * using the latest values obtained from {@link IteratorTester#newTargetIterator()}.
  *
+ * <p>The value you pass to the parameter {@code steps} should be greater than the length of your
+ * iterator, so that this class can check that your iterator behaves correctly when it is exhausted.
+ *
  * <p>For example, to test {@link java.util.Collections#unmodifiableList(java.util.List)
  * Collections.unmodifiableList}'s iterator:
  *
@@ -61,7 +64,7 @@ import java.util.Iterator;
  *         Arrays.asList("a", "b", "c", "d", "e"));
  * IteratorTester<String> iteratorTester =
  *     new IteratorTester<String>(
- *         5,
+ *         6,
  *         IteratorFeature.UNMODIFIABLE,
  *         expectedElements,
  *         IteratorTester.KnownOrder.KNOWN_ORDER) {
@@ -75,7 +78,7 @@ import java.util.Iterator;
  * }</pre>
  *
  * <p><b>Note</b>: It is necessary to use {@code IteratorTester.KnownOrder} as shown above, rather
- * than {@code KnownOrder} directly, because otherwise the code is not compilable.
+ * than {@code KnownOrder} directly, because otherwise the code cannot be compiled.
  *
  * @author Kevin Bourrillion
  * @author Chris Povirk

--- a/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -17,6 +17,7 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -171,7 +172,7 @@ public class ServiceManagerTest extends TestCase {
     Service b = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b);
     assertFalse(manager.isHealthy());
     manager.startAsync().awaitHealthy();
@@ -195,7 +196,7 @@ public class ServiceManagerTest extends TestCase {
     Service e = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b, c, d, e));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b, c, d, e);
     try {
       manager.startAsync().awaitHealthy();
@@ -219,7 +220,7 @@ public class ServiceManagerTest extends TestCase {
     Service b = new FailRunService();
     ServiceManager manager = new ServiceManager(asList(a, b));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     assertState(manager, Service.State.NEW, a, b);
     try {
       manager.startAsync().awaitHealthy();
@@ -242,7 +243,7 @@ public class ServiceManagerTest extends TestCase {
     Service c = new NoOpService();
     ServiceManager manager = new ServiceManager(asList(a, b, c));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
 
     manager.startAsync().awaitHealthy();
     assertTrue(listener.healthyCalled);
@@ -292,7 +293,7 @@ public class ServiceManagerTest extends TestCase {
     Service a = new FailStartService();
     ServiceManager manager = new ServiceManager(asList(a));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     try {
       manager.startAsync().awaitHealthy();
       fail();
@@ -309,7 +310,7 @@ public class ServiceManagerTest extends TestCase {
     Service a = new FailStartService();
     ServiceManager manager = new ServiceManager(asList(a));
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     try {
       manager.startAsync().awaitHealthy();
       fail();
@@ -334,7 +335,8 @@ public class ServiceManagerTest extends TestCase {
           public void failure(Service service) {
             manager.stopAsync();
           }
-        });
+        },
+        directExecutor());
     manager.startAsync();
     manager.awaitStopped(10, TimeUnit.MILLISECONDS);
   }
@@ -408,7 +410,7 @@ public class ServiceManagerTest extends TestCase {
     logger.addHandler(logHandler);
     ServiceManager manager = new ServiceManager(Arrays.<Service>asList());
     RecordingListener listener = new RecordingListener();
-    manager.addListener(listener);
+    manager.addListener(listener, directExecutor());
     manager.startAsync().awaitHealthy();
     assertTrue(manager.isHealthy());
     assertTrue(listener.healthyCalled);
@@ -476,7 +478,8 @@ public class ServiceManagerTest extends TestCase {
             // block until after the service manager is shutdown
             Uninterruptibles.awaitUninterruptibly(failLeave);
           }
-        });
+        },
+        directExecutor());
     manager.startAsync();
     afterStarted.countDown();
     // We do not call awaitHealthy because, due to races, that method may throw an exception.  But

--- a/guava/src/com/google/common/collect/Comparators.java
+++ b/guava/src/com/google/common/collect/Comparators.java
@@ -203,7 +203,7 @@ public final class Comparators {
    * @param a first value to compare, returned if less than or equal to b.
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i>.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T extends Comparable<? super T>> T min(T a, T b) {
@@ -223,7 +223,7 @@ public final class Comparators {
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> using the given
    *     comparator.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T> T min(@Nullable T a, @Nullable T b, Comparator<T> comparator) {
@@ -241,7 +241,7 @@ public final class Comparators {
    * @param a first value to compare, returned if greater than or equal to b.
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i>.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T extends Comparable<? super T>> T max(T a, T b) {
@@ -261,7 +261,7 @@ public final class Comparators {
    * @param b second value to compare.
    * @throws ClassCastException if the parameters are not <i>mutually comparable</i> using the given
    *     comparator.
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   public static <T> T max(@Nullable T a, @Nullable T b, Comparator<T> comparator) {

--- a/guava/src/com/google/common/math/BigDecimalMath.java
+++ b/guava/src/com/google/common/math/BigDecimalMath.java
@@ -22,7 +22,7 @@ import java.math.RoundingMode;
  * A class for arithmetic on {@link BigDecimal} that is not covered by its built-in methods.
  *
  * @author Louis Wasserman
- * @since NEXT
+ * @since 30.0
  */
 @GwtIncompatible
 public class BigDecimalMath {
@@ -47,7 +47,7 @@ public class BigDecimalMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   public static double roundToDouble(BigDecimal x, RoundingMode mode) {
     return BigDecimalToDoubleRounder.INSTANCE.roundToDouble(x, mode);

--- a/guava/src/com/google/common/math/BigIntegerMath.java
+++ b/guava/src/com/google/common/math/BigIntegerMath.java
@@ -327,7 +327,7 @@ public final class BigIntegerMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   @GwtIncompatible
   public static double roundToDouble(BigInteger x, RoundingMode mode) {

--- a/guava/src/com/google/common/math/LongMath.java
+++ b/guava/src/com/google/common/math/LongMath.java
@@ -1239,7 +1239,7 @@ public final class LongMath {
    *
    * @throws ArithmeticException if {@code mode} is {@link RoundingMode#UNNECESSARY} and {@code x}
    *     is not precisely representable as a {@code double}
-   * @since NEXT
+   * @since 30.0
    */
   @SuppressWarnings("deprecation")
   @GwtIncompatible

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -270,14 +270,14 @@ public final class HttpHeaders {
    * The HTTP <a href="https://wicg.github.io/cross-origin-embedder-policy/#COEP">{@code
    * Cross-Origin-Embedder-Policy}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String CROSS_ORIGIN_EMBEDDER_POLICY = "Cross-Origin-Embedder-Policy";
   /**
    * The HTTP <a href="https://wicg.github.io/cross-origin-embedder-policy/#COEP-RO">{@code
    * Cross-Origin-Embedder-Policy-Report-Only}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String CROSS_ORIGIN_EMBEDDER_POLICY_REPORT_ONLY =
       "Cross-Origin-Embedder-Policy-Report-Only";
@@ -478,49 +478,49 @@ public final class HttpHeaders {
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua">{@code Sec-CH-UA}</a>
    * header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA = "Sec-CH-UA";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-arch">{@code
    * Sec-CH-UA-Arch}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_ARCH = "Sec-CH-UA-Arch";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-model">{@code
    * Sec-CH-UA-Model}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_MODEL = "Sec-CH-UA-Model";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-platform">{@code
    * Sec-CH-UA-Platform}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_PLATFORM = "Sec-CH-UA-Platform";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-platform-version">{@code
    * Sec-CH-UA-Platform-Version}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_PLATFORM_VERSION = "Sec-CH-UA-Platform-Version";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-full-version">{@code
    * Sec-CH-UA-Full-Version}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_FULL_VERSION = "Sec-CH-UA-Full-Version";
   /**
    * The HTTP <a href="https://wicg.github.io/ua-client-hints/#sec-ch-mobile">{@code
    * Sec-CH-UA-Mobile}</a> header field name.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final String SEC_CH_UA_MOBILE = "Sec-CH-UA-Mobile";
 

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -145,7 +145,7 @@ public final class MediaType {
   /**
    * Wildcard matching any "font" top-level media type.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType ANY_FONT_TYPE = createConstant(FONT_TYPE, WILDCARD);
 
@@ -709,7 +709,7 @@ public final class MediaType {
    * A collection of font outlines as defined by <a href="https://tools.ietf.org/html/rfc8081">RFC
    * 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_COLLECTION = createConstant(FONT_TYPE, "collection");
 
@@ -717,7 +717,7 @@ public final class MediaType {
    * <a href="https://en.wikipedia.org/wiki/OpenType">Open Type Font Format</a> (OTF) as defined by
    * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_OTF = createConstant(FONT_TYPE, "otf");
 
@@ -727,7 +727,7 @@ public final class MediaType {
    * type for SFNT, but {@link #SFNT application/font-sfnt} may be necessary in certain situations
    * for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_SFNT = createConstant(FONT_TYPE, "sfnt");
 
@@ -735,7 +735,7 @@ public final class MediaType {
    * <a href="https://en.wikipedia.org/wiki/TrueType">True Type Font Format</a> (TTF) as defined by
    * <a href="https://tools.ietf.org/html/rfc8081">RFC 8081</a>.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_TTF = createConstant(FONT_TYPE, "ttf");
 
@@ -745,7 +745,7 @@ public final class MediaType {
    * type for SFNT, but {@link #WOFF application/font-woff} may be necessary in certain situations
    * for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_WOFF = createConstant(FONT_TYPE, "woff");
 
@@ -755,7 +755,7 @@ public final class MediaType {
    * media type for SFNT, but {@link #WOFF2 application/font-woff2} may be necessary in certain
    * situations for compatibility.
    *
-   * @since NEXT
+   * @since 30.0
    */
   public static final MediaType FONT_WOFF2 = createConstant(FONT_TYPE, "woff2");
 

--- a/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -185,7 +185,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * automatic-closing approach described above is safer.
  *
  * @param <V> the type of the value of this step
- * @since NEXT
+ * @since 30.0
  */
 // TODO(dpb): Consider reusing one CloseableList for the entire pipeline, modulo combinations.
 @Beta // @Beta for one release.

--- a/guava/src/com/google/common/util/concurrent/ServiceManager.java
+++ b/guava/src/com/google/common/util/concurrent/ServiceManager.java
@@ -31,7 +31,6 @@ import static com.google.common.util.concurrent.Service.State.STOPPING;
 import static com.google.common.util.concurrent.Service.State.TERMINATED;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
@@ -251,34 +250,6 @@ public final class ServiceManager implements ServiceManagerBridge {
    */
   public void addListener(Listener listener, Executor executor) {
     state.addListener(listener, executor);
-  }
-
-  /**
-   * Registers a {@link Listener} to be run when this {@link ServiceManager} changes state. The
-   * listener will not have previous state changes replayed, so it is suggested that listeners are
-   * added before any of the managed services are {@linkplain Service#startAsync started}.
-   *
-   * <p>{@code addListener} guarantees execution ordering across calls to a given listener but not
-   * across calls to multiple listeners. Specifically, a given listener will have its callbacks
-   * invoked in the same order as the underlying service enters those states. Additionally, at most
-   * one of the listener's callbacks will execute at once. However, multiple listeners' callbacks
-   * may execute concurrently, and listeners may execute in an order different from the one in which
-   * they were registered.
-   *
-   * <p>RuntimeExceptions thrown by a listener will be caught and logged.
-   *
-   * @param listener the listener to run when the manager changes state
-   * @since 15.0
-   * @deprecated Use {@linkplain #addListener(Listener, Executor) the overload that accepts an
-   *     executor}. For equivalent behavior, pass {@link MoreExecutors#directExecutor}. However,
-   *     consider whether another executor would be more appropriate, as discussed in the docs for
-   *     {@link ListenableFuture#addListener ListenableFuture.addListener}. This method is scheduled
-   *     for deletion in October 2020.
-   */
-  @Beta
-  @Deprecated
-  public void addListener(Listener listener) {
-    state.addListener(listener, directExecutor());
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
+++ b/guava/src/com/google/common/util/concurrent/Uninterruptibles.java
@@ -478,7 +478,7 @@ public final class Uninterruptibles {
    * Invokes {@code lock.}{@link Lock#tryLock(long, TimeUnit) tryLock(timeout, unit)}
    * uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @GwtIncompatible // concurrency
   @Beta
@@ -490,7 +490,7 @@ public final class Uninterruptibles {
    * Invokes {@code lock.}{@link Lock#tryLock(long, TimeUnit) tryLock(timeout, unit)}
    * uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @GwtIncompatible // concurrency
   @SuppressWarnings("GoodTime") // should accept a java.time.Duration
@@ -519,7 +519,7 @@ public final class Uninterruptibles {
    * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
    * awaitTermination(long, TimeUnit)} uninterruptibly with no timeout.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   @GwtIncompatible // concurrency
@@ -532,7 +532,7 @@ public final class Uninterruptibles {
    * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
    * awaitTermination(long, TimeUnit)} uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   @GwtIncompatible // concurrency
@@ -545,7 +545,7 @@ public final class Uninterruptibles {
    * Invokes {@code executor.}{@link ExecutorService#awaitTermination(long, TimeUnit)
    * awaitTermination(long, TimeUnit)} uninterruptibly.
    *
-   * @since NEXT
+   * @since 30.0
    */
   @Beta
   @GwtIncompatible // concurrency


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Prepare for release 30.0.

06c1d37ea914125b88bc27d0a570df84fe900a4f

-------

<p> Remove deprecated 1-arg ServiceManager.addListener.

[]

RELNOTES=`util.concurrent`: Removed the deprecated 1-arg `ServiceManager.addListener(Listener)`. Use the 2-arg `addListener(Listener, Executor)` overload, setting the executor to `directExecutor()` for equivalent behavior.

d13ebb04258a0caecea56d908a391e7e694004b2

-------

<p> Update IteratorTester example with a greater "steps" value

This allows IteratorTester to check the edge case that when an iterator has been exhausted (that is, "next" has been called repeatedly until "hasNext" returns false) then calling "next" on the iterator again exhibits the same behavior as the user's chosen "known good" reference implementation.

Fixes #5281

b094a4b3f43645298a7c9bce9b5d72184d7ff4cf