### PR TITLE
Verify maximumWeight before setting

### DIFF
--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -477,8 +477,8 @@ public final class CacheBuilder<K, V> {
         this.maximumWeight);
     checkState(
         this.maximumSize == UNSET_INT, "maximum size was already set to %s", this.maximumSize);
-    this.maximumWeight = maximumWeight;
     checkArgument(maximumWeight >= 0, "maximum weight must not be negative");
+    this.maximumWeight = maximumWeight;
     return this;
   }
 


### PR DESCRIPTION
The maximumWeight builder method is the only method that does the argument verification before the assignment.
It looks like a typo, and does not affect anyone in practice, but it is still better to have the implementation uniform.