### PR TITLE
MOE Sync 2020-11-11

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableBiMapTest.java
@@ -506,6 +506,30 @@ public class ImmutableBiMapTest extends TestCase {
         assertThat(expected.getMessage()).contains("1");
       }
     }
+
+    // TODO(b/172823566): Use mainline testToImmutableBiMap once CollectorTester is usable to java7.
+    public void testToImmutableBiMap_java7_combine() {
+      ImmutableBiMap.Builder<String, Integer> zis =
+          ImmutableBiMap.<String, Integer>builder().put("one", 1);
+      ImmutableBiMap.Builder<String, Integer> zat =
+          ImmutableBiMap.<String, Integer>builder().put("two", 2).put("three", 3);
+      ImmutableBiMap<String, Integer> biMap = zis.combine(zat).build();
+      assertMapEquals(biMap, "one", 1, "two", 2, "three", 3);
+    }
+
+    // TODO(b/172823566): Use mainline testToImmutableBiMap once CollectorTester is usable to java7.
+    public void testToImmutableBiMap_exceptionOnDuplicateKey_java7_combine() {
+      ImmutableBiMap.Builder<String, Integer> zis =
+          ImmutableBiMap.<String, Integer>builder().put("one", 1).put("two", 2);
+      ImmutableBiMap.Builder<String, Integer> zat =
+          ImmutableBiMap.<String, Integer>builder().put("two", 22).put("three", 3);
+      try {
+        zis.combine(zat).build();
+        fail("Expected IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+        // expected
+      }
+    }
   }
 
   public static class BiMapSpecificTests extends TestCase {

--- a/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -652,6 +652,29 @@ public class ImmutableMapTest extends TestCase {
       assertSame(copy, ImmutableMap.copyOf(copy));
     }
 
+    // TODO(b/172823566): Use mainline testToImmutableMap once CollectorTester is usable to java7.
+    public void testToImmutableMap_java7_combine() {
+      ImmutableMap.Builder<String, Integer> zis =
+          ImmutableMap.<String, Integer>builder().put("one", 1);
+      ImmutableMap.Builder<String, Integer> zat =
+          ImmutableMap.<String, Integer>builder().put("two", 2).put("three", 3);
+      assertMapEquals(zis.combine(zat).build(), "one", 1, "two", 2, "three", 3);
+    }
+
+    // TODO(b/172823566): Use mainline testToImmutableMap once CollectorTester is usable to java7.
+    public void testToImmutableMap_exceptionOnDuplicateKey_java7_combine() {
+      ImmutableMap.Builder<String, Integer> zis =
+          ImmutableMap.<String, Integer>builder().put("one", 1).put("two", 2);
+      ImmutableMap.Builder<String, Integer> zat =
+          ImmutableMap.<String, Integer>builder().put("two", 22).put("three", 3);
+      try {
+        zis.combine(zat).build();
+        fail("Expected IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+        // expected
+      }
+    }
+
     public static void hashtableTestHelper(ImmutableList<Integer> sizes) {
       for (int size : sizes) {
         Builder<Integer, Integer> builder = ImmutableMap.builderWithExpectedSize(size);

--- a/android/guava-tests/test/com/google/common/collect/ImmutableRangeMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableRangeMapTest.java
@@ -15,6 +15,7 @@
 package com.google.common.collect;
 
 import static com.google.common.collect.BoundType.OPEN;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.testing.SerializableTester;
@@ -253,5 +254,22 @@ public class ImmutableRangeMapTest extends TestCase {
     SerializableTester.reserializeAndAssert(test.keySet());
 
     SerializableTester.reserializeAndAssert(nonEmptyRangeMap);
+  }
+
+  // TODO(b/172823566): Use mainline testToImmutableRangeMap once CollectorTester is usable to java7
+  public void testToImmutableRangeMap() {
+    Range<Integer> rangeOne = Range.closedOpen(1, 5);
+    Range<Integer> rangeTwo = Range.openClosed(6, 7);
+
+    ImmutableRangeMap.Builder<Integer, Integer> zis =
+        ImmutableRangeMap.<Integer, Integer>builder().put(rangeOne, 1);
+    ImmutableRangeMap.Builder<Integer, Integer> zat =
+        ImmutableRangeMap.<Integer, Integer>builder().put(rangeTwo, 6);
+
+    ImmutableRangeMap<Integer, Integer> rangeMap = zis.combine(zat).build();
+
+    assertThat(rangeMap.asMapOfRanges().entrySet())
+        .containsExactly(Maps.immutableEntry(rangeOne, 1), Maps.immutableEntry(rangeTwo, 6))
+        .inOrder();
   }
 }

--- a/android/guava-tests/test/com/google/common/collect/ImmutableRangeSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableRangeSetTest.java
@@ -590,4 +590,23 @@ public class ImmutableRangeSetTest extends AbstractRangeSetTest {
       }
     }
   }
+
+  // TODO(b/172823566): Use mainline testToImmutableRangeSet once CollectorTester is usable to java7
+  public void testToImmutableRangeSet_java7_combine() {
+    Range<Integer> rangeOne = Range.closedOpen(1, 3);
+    Range<Integer> rangeTwo = Range.closedOpen(7, 9);
+    Range<Integer> rangeThree = Range.closedOpen(4, 5);
+    Range<Integer> rangeFour = Range.closedOpen(6, 7);
+
+    ImmutableRangeSet.Builder<Integer> zis =
+        ImmutableRangeSet.<Integer>builder().add(rangeOne).add(rangeTwo);
+    ImmutableRangeSet.Builder<Integer> zat =
+        ImmutableRangeSet.<Integer>builder().add(rangeThree).add(rangeFour);
+
+    ImmutableRangeSet<Integer> rangeSet = zis.combine(zat).build();
+
+    assertThat(rangeSet.asRanges())
+        .containsExactly(Range.closedOpen(1, 3), Range.closedOpen(4, 5), Range.closedOpen(6, 9))
+        .inOrder();
+  }
 }

--- a/android/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableSortedMapTest.java
@@ -667,6 +667,31 @@ public class ImmutableSortedMapTest extends TestCase {
       assertMapEquals(map, "two", 2, "three", 3, "one", 1, "four", 4, "five", 5);
       assertSame(comparator, map.comparator());
     }
+
+    // TODO(b/172823566): Use mainline testToImmutableSortedMap once CollectorTester is usable.
+    public void testToImmutableSortedMap_java7_combine() {
+      ImmutableSortedMap.Builder<String, Integer> zis =
+          ImmutableSortedMap.<String, Integer>naturalOrder().put("one", 1).put("four", 4);
+      ImmutableSortedMap.Builder<String, Integer> zat =
+          ImmutableSortedMap.<String, Integer>naturalOrder().put("two", 2).put("three", 3);
+      ImmutableSortedMap<String, Integer> sortedMap = zis.combine(zat).build();
+      assertMapEquals(sortedMap, "four", 4, "one", 1, "three", 3, "two", 2);
+    }
+
+    // TODO(b/172823566): Use mainline testToImmutableSortedMap once CollectorTester is usable.
+    public void testToImmutableSortedMap_exceptionOnDuplicateKey_java7_combine() {
+      ImmutableSortedMap.Builder<String, Integer> zis =
+          ImmutableSortedMap.<String, Integer>naturalOrder().put("one", 1).put("two", 2);
+      ImmutableSortedMap.Builder<String, Integer> zat =
+          ImmutableSortedMap.<String, Integer>naturalOrder().put("two", 22).put("three", 3);
+      try {
+        ImmutableSortedMap.Builder<String, Integer> combined = zis.combine(zat);
+        combined.build();
+        fail("Expected IllegalArgumentException");
+      } catch (IllegalArgumentException expected) {
+        // expected
+      }
+    }
   }
 
   public void testNullGet() {

--- a/android/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -708,6 +708,30 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     assertSame(STRING_LENGTH, set.comparator());
   }
 
+  // TODO(b/172823566): Use mainline testToImmutableSortedSet once CollectorTester is usable.
+  public void testToImmutableSortedSet_java7() {
+    // Note that a Collector should generally enforce consistent comparator between builders
+    ImmutableSortedSet.Builder<String> zis =
+        ImmutableSortedSet.<String>naturalOrder().add("c", "b", "c");
+    ImmutableSortedSet.Builder<String> zat =
+        ImmutableSortedSet.<String>naturalOrder().add("a", "b", "d", "c");
+    ImmutableSortedSet<String> sortedSet = zis.combine(zat).build();
+    assertThat(sortedSet).containsExactly("a", "b", "c", "d").inOrder();
+  }
+
+  // TODO(b/172823566): Use mainline testToImmutableSortedSet_customComparator once CollectorTester
+  //  is usable to java7.
+  public void testToImmutableSortedSet_customComparator_java7() {
+    // Note that a Collector should generally enforce consistent comparator between builders.
+    // So no tests for non-matching comparator shenanigans.
+    ImmutableSortedSet.Builder<String> zis =
+        ImmutableSortedSet.<String>orderedBy(STRING_LENGTH).add("ccc", "bb", "ccc");
+    ImmutableSortedSet.Builder<String> zat =
+        ImmutableSortedSet.<String>orderedBy(STRING_LENGTH).add("a", "bb", "dddd", "ccc");
+    ImmutableSortedSet<String> sortedSet = zis.combine(zat).build();
+    assertThat(sortedSet).containsExactly("a", "bb", "ccc", "dddd").inOrder();
+  }
+
   public void testEquals_bothDefaultOrdering() {
     SortedSet<String> set = of("a", "b", "c");
     assertEquals(set, Sets.newTreeSet(asList("a", "b", "c")));

--- a/android/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -240,6 +240,13 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
       return this;
     }
 
+    @Override
+    @CanIgnoreReturnValue
+    Builder<K, V> combine(ImmutableMap.Builder<K, V> builder) {
+      super.combine(builder);
+      return this;
+    }
+
     /**
      * Returns a newly-created immutable bimap. The iteration order of the returned bimap is the
      * order in which entries were inserted into the builder, unless {@link #orderEntriesByValue}

--- a/android/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMap.java
@@ -315,6 +315,20 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    Builder<K, V> combine(Builder<K, V> other) {
+      checkNotNull(other);
+      ensureCapacity(this.size + other.size);
+      System.arraycopy(
+          other.alternatingKeysAndValues,
+          0,
+          this.alternatingKeysAndValues,
+          this.size * 2,
+          other.size * 2);
+      this.size += other.size;
+      return this;
+    }
+
     /*
      * TODO(kevinb): Should build() and the ImmutableBiMap & ImmutableSortedMap
      * versions throw an IllegalStateException instead?

--- a/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -114,6 +114,12 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
       return this;
     }
 
+    @CanIgnoreReturnValue
+    Builder<K, V> combine(Builder<K, V> builder) {
+      entries.addAll(builder.entries);
+      return this;
+    }
+
     /**
      * Returns an {@code ImmutableRangeMap} containing the associations previously added to this
      * builder.

--- a/android/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -747,6 +747,12 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
       return this;
     }
 
+    @CanIgnoreReturnValue
+    Builder<C> combine(Builder<C> builder) {
+      addAll(builder.ranges);
+      return this;
+    }
+
     /**
      * Returns an {@code ImmutableRangeSet} containing the ranges added to this builder.
      *

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -499,6 +499,15 @@ public final class ImmutableSortedMap<K, V> extends ImmutableSortedMapFauxveride
       throw new UnsupportedOperationException("Not available on ImmutableSortedMap.Builder");
     }
 
+    @CanIgnoreReturnValue
+    Builder<K, V> combine(ImmutableSortedMap.Builder<K, V> other) {
+      ensureCapacity(size + other.size);
+      System.arraycopy(other.keys, 0, this.keys, this.size, other.size);
+      System.arraycopy(other.values, 0, this.values, this.size, other.size);
+      size += other.size;
+      return this;
+    }
+
     /**
      * Returns a newly-created immutable sorted map.
      *

--- a/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -480,6 +480,13 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSortedSetFauxveride
       return this;
     }
 
+    @CanIgnoreReturnValue
+    @Override
+    Builder<E> combine(ImmutableSet.Builder<E> builder) {
+      super.combine(builder);
+      return this;
+    }
+
     /**
      * Returns a newly-created {@code ImmutableSortedSet} based on the contents of the {@code
      * Builder} and its comparator.

--- a/guava-tests/test/com/google/common/collect/ImmutableRangeMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableRangeMapTest.java
@@ -256,7 +256,7 @@ public class ImmutableRangeMapTest extends TestCase {
     SerializableTester.reserializeAndAssert(nonEmptyRangeMap);
   }
 
-  public void testToImmutableRangeSet() {
+  public void testToImmutableRangeMap() {
     Range<Integer> rangeOne = Range.closedOpen(1, 5);
     Range<Integer> rangeTwo = Range.openClosed(6, 7);
     ImmutableRangeMap<Integer, Integer> rangeMap =

--- a/guava/src/com/google/common/collect/HashBiMap.java
+++ b/guava/src/com/google/common/collect/HashBiMap.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Maps.IteratorBasedAbstractMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.RetainedWith;
-import com.google.j2objc.annotations.WeakOuter;
+import com.google.j2objc.annotations.Weak;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -88,11 +88,11 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     final int keyHash;
     final int valueHash;
 
-    @Nullable BiEntry<K, V> nextInKToVBucket;
-    @Nullable BiEntry<K, V> nextInVToKBucket;
+    @Weak @Nullable BiEntry<K, V> nextInKToVBucket;
+    @Weak @Nullable BiEntry<K, V> nextInVToKBucket;
 
-    @Nullable BiEntry<K, V> nextInKeyInsertionOrder;
-    @Nullable BiEntry<K, V> prevInKeyInsertionOrder;
+    @Weak @Nullable BiEntry<K, V> nextInKeyInsertionOrder;
+    @Weak @Nullable BiEntry<K, V> prevInKeyInsertionOrder;
 
     BiEntry(K key, int keyHash, V value, int valueHash) {
       super(key, value);
@@ -105,8 +105,8 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
 
   private transient BiEntry<K, V>[] hashTableKToV;
   private transient BiEntry<K, V>[] hashTableVToK;
-  private transient @Nullable BiEntry<K, V> firstInKeyInsertionOrder;
-  private transient @Nullable BiEntry<K, V> lastInKeyInsertionOrder;
+  @Weak private transient @Nullable BiEntry<K, V> firstInKeyInsertionOrder;
+  @Weak private transient @Nullable BiEntry<K, V> lastInKeyInsertionOrder;
   private transient int size;
   private transient int mask;
   private transient int modCount;
@@ -453,7 +453,6 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     return new KeySet();
   }
 
-  @WeakOuter
   private final class KeySet extends Maps.KeySet<K, V> {
     KeySet() {
       super(HashBiMap.this);
@@ -625,7 +624,6 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
       return new InverseKeySet();
     }
 
-    @WeakOuter
     private final class InverseKeySet extends Maps.KeySet<V, K> {
       InverseKeySet() {
         super(Inverse.this);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Backport `combine` to java7 for `ImmutableMap`.

This is so that Java8 code relying on the Java7 branch of Guava can still efficiently collect Guava collections.

The Java8/Java7 implementations branched once again, where Java8 uses an array of Entries, whereas Java7 uses an array of alternating key/value pairs. Either way, the implementations were pretty trivial this time.

2afe372fb9fd390ceb671003588c053b7d463399

-------

<p> Backport combine to java7 for `ImmutableRangeSet`/`ImmutableRangeSet`.

This is so that Java8 code relying on the Java7 branch of Guava can still efficiently collect Guava collections.

I saved this for last, but they turned out to be the easiest to do. Tests are kind of crap, but honestly, baseline tests also seemed a little bit light to me.

a742fca6c4f0f96bfedac86b0722efec196b9052

-------

<p> Backport `combine` to java7 for Sorted collections & (Immutable)BiMap.

This is so that Java8 code relying on the Java7 branch of Guava can still efficiently collect Guava collections.

4c7fe5993f6938d60ecbf90494c93b827253101e

-------

<p> Fix memory leaks and potential crashes in HashBiMap, which occur in transpiled ObjC code.

450bf69d33c855032e3698ee96bae3994cc0377e