### PR TITLE
MOE Sync 2020-11-17

### DIFF
--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -137,42 +137,6 @@ public final class Sets {
     }
   }
 
-  private static final class Accumulator<E extends Enum<E>> {
-    static final Collector<Enum<?>, ?, ImmutableSet<? extends Enum<?>>> TO_IMMUTABLE_ENUM_SET =
-        (Collector)
-            Collector.<Enum, Accumulator, ImmutableSet<?>>of(
-                Accumulator::new,
-                Accumulator::add,
-                Accumulator::combine,
-                Accumulator::toImmutableSet,
-                Collector.Characteristics.UNORDERED);
-
-    private @Nullable EnumSet<E> set;
-
-    void add(E e) {
-      if (set == null) {
-        set = EnumSet.of(e);
-      } else {
-        set.add(e);
-      }
-    }
-
-    Accumulator<E> combine(Accumulator<E> other) {
-      if (this.set == null) {
-        return other;
-      } else if (other.set == null) {
-        return this;
-      } else {
-        this.set.addAll(other.set);
-        return this;
-      }
-    }
-
-    ImmutableSet<E> toImmutableSet() {
-      return (set == null) ? ImmutableSet.<E>of() : ImmutableEnumSet.asImmutable(set);
-    }
-  }
-
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new {@code ImmutableSet}
    * with an implementation specialized for enums. Unlike {@link ImmutableSet#toImmutableSet}, the
@@ -181,7 +145,7 @@ public final class Sets {
    * @since 21.0
    */
   public static <E extends Enum<E>> Collector<E, ?, ImmutableSet<E>> toImmutableEnumSet() {
-    return (Collector) Accumulator.TO_IMMUTABLE_ENUM_SET;
+    return CollectCollectors.toImmutableEnumSet();
   }
 
   /**


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make toImmutableEnum[Set|Map] to AndroidAccessToCollectors

I think that’s the last of them.

The implementations I moved verbatim, and there was no change of code there.

660f036a37966bbee88b3b002d1ad9d1afa8e50e