### PR TITLE
Fix #4011: Files::createTempDir security vulnerability

### DIFF
--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -421,25 +421,14 @@ public final class Files {
   @Beta
   @Deprecated
   public static File createTempDir() {
-    File baseDir = new File(System.getProperty("java.io.tmpdir"));
-    @SuppressWarnings("GoodTime") // reading system time without TimeSource
-    String baseName = System.currentTimeMillis() + "-";
-
-    for (int counter = 0; counter < TEMP_DIR_ATTEMPTS; counter++) {
-      File tempDir = new File(baseDir, baseName + counter);
-      if (tempDir.mkdir()) {
-        return tempDir;
-      }
+    try {
+      @SuppressWarnings("GoodTime") // reading system time without TimeSource
+      String baseName = System.currentTimeMillis() + "-";
+      java.nio.file.Path temp = java.nio.file.Files.createTempDirectory(baseName);
+      return temp.toFile();
+    } catch (IOException ioex) {
+      throw new IllegalStateException("Failed to create temporary directory.", ioex);
     }
-    throw new IllegalStateException(
-        "Failed to create directory within "
-            + TEMP_DIR_ATTEMPTS
-            + " attempts (tried "
-            + baseName
-            + "0 to "
-            + baseName
-            + (TEMP_DIR_ATTEMPTS - 1)
-            + ')');
   }
 
   /**


### PR DESCRIPTION
I am submitting this PR because...

- this method is marked both `Beta` and `Deprecated`.
- This change still has the code work correctly it just uses NIO which does not have the vulnerability
- Allows security companies like Sonatype and Snyk to stop reporting this as vulnerable