### PR TITLE
MOE Sync 2020-12-02

### DIFF
--- a/android/guava/src/com/google/common/collect/AbstractMultimap.java
+++ b/android/guava/src/com/google/common/collect/AbstractMultimap.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.WeakOuter;
 import java.util.AbstractCollection;
 import java.util.Collection;
@@ -105,7 +106,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
     return result;
   }
 
-  @NullableDecl private transient Collection<Entry<K, V>> entries;
+  @LazyInit @NullableDecl private transient Collection<Entry<K, V>> entries;
 
   @Override
   public Collection<Entry<K, V>> entries() {
@@ -143,7 +144,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
 
   abstract Iterator<Entry<K, V>> entryIterator();
 
-  @NullableDecl private transient Set<K> keySet;
+  @LazyInit @NullableDecl private transient Set<K> keySet;
 
   @Override
   public Set<K> keySet() {
@@ -153,7 +154,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
 
   abstract Set<K> createKeySet();
 
-  @NullableDecl private transient Multiset<K> keys;
+  @LazyInit @NullableDecl private transient Multiset<K> keys;
 
   @Override
   public Multiset<K> keys() {
@@ -163,7 +164,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
 
   abstract Multiset<K> createKeys();
 
-  @NullableDecl private transient Collection<V> values;
+  @LazyInit @NullableDecl private transient Collection<V> values;
 
   @Override
   public Collection<V> values() {
@@ -200,7 +201,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
     return Maps.valueIterator(entries().iterator());
   }
 
-  @NullableDecl private transient Map<K, Collection<V>> asMap;
+  @LazyInit @NullableDecl private transient Map<K, Collection<V>> asMap;
 
   @Override
   public Map<K, Collection<V>> asMap() {

--- a/android/guava/src/com/google/common/collect/Multimaps.java
+++ b/android/guava/src/com/google/common/collect/Multimaps.java
@@ -29,6 +29,7 @@ import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.Weak;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.IOException;
@@ -539,11 +540,11 @@ public final class Multimaps {
   private static class UnmodifiableMultimap<K, V> extends ForwardingMultimap<K, V>
       implements Serializable {
     final Multimap<K, V> delegate;
-    @NullableDecl transient Collection<Entry<K, V>> entries;
-    @NullableDecl transient Multiset<K> keys;
-    @NullableDecl transient Set<K> keySet;
-    @NullableDecl transient Collection<V> values;
-    @NullableDecl transient Map<K, Collection<V>> map;
+    @LazyInit @NullableDecl transient Collection<Entry<K, V>> entries;
+    @LazyInit @NullableDecl transient Multiset<K> keys;
+    @LazyInit @NullableDecl transient Set<K> keySet;
+    @LazyInit @NullableDecl transient Collection<V> values;
+    @LazyInit @NullableDecl transient Map<K, Collection<V>> map;
 
     UnmodifiableMultimap(final Multimap<K, V> delegate) {
       this.delegate = checkNotNull(delegate);

--- a/guava/src/com/google/common/collect/AbstractMultimap.java
+++ b/guava/src/com/google/common/collect/AbstractMultimap.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.WeakOuter;
 import java.util.AbstractCollection;
 import java.util.Collection;
@@ -107,7 +108,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
     return result;
   }
 
-  private transient @Nullable Collection<Entry<K, V>> entries;
+  @LazyInit private transient @Nullable Collection<Entry<K, V>> entries;
 
   @Override
   public Collection<Entry<K, V>> entries() {
@@ -155,7 +156,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
         entryIterator(), size(), (this instanceof SetMultimap) ? Spliterator.DISTINCT : 0);
   }
 
-  private transient @Nullable Set<K> keySet;
+  @LazyInit private transient @Nullable Set<K> keySet;
 
   @Override
   public Set<K> keySet() {
@@ -165,7 +166,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
 
   abstract Set<K> createKeySet();
 
-  private transient @Nullable Multiset<K> keys;
+  @LazyInit private transient @Nullable Multiset<K> keys;
 
   @Override
   public Multiset<K> keys() {
@@ -175,7 +176,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
 
   abstract Multiset<K> createKeys();
 
-  private transient @Nullable Collection<V> values;
+  @LazyInit private transient @Nullable Collection<V> values;
 
   @Override
   public Collection<V> values() {
@@ -221,7 +222,7 @@ abstract class AbstractMultimap<K, V> implements Multimap<K, V> {
     return Spliterators.spliterator(valueIterator(), size(), 0);
   }
 
-  private transient @Nullable Map<K, Collection<V>> asMap;
+  @LazyInit private transient @Nullable Map<K, Collection<V>> asMap;
 
   @Override
   public Map<K, Collection<V>> asMap() {

--- a/guava/src/com/google/common/collect/Multimaps.java
+++ b/guava/src/com/google/common/collect/Multimaps.java
@@ -29,6 +29,7 @@ import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.Weak;
 import com.google.j2objc.annotations.WeakOuter;
 import java.io.IOException;
@@ -626,11 +627,11 @@ public final class Multimaps {
   private static class UnmodifiableMultimap<K, V> extends ForwardingMultimap<K, V>
       implements Serializable {
     final Multimap<K, V> delegate;
-    transient @Nullable Collection<Entry<K, V>> entries;
-    transient @Nullable Multiset<K> keys;
-    transient @Nullable Set<K> keySet;
-    transient @Nullable Collection<V> values;
-    transient @Nullable Map<K, Collection<V>> map;
+    @LazyInit transient @Nullable Collection<Entry<K, V>> entries;
+    @LazyInit transient @Nullable Multiset<K> keys;
+    @LazyInit transient @Nullable Set<K> keySet;
+    @LazyInit transient @Nullable Collection<V> values;
+    @LazyInit transient @Nullable Map<K, Collection<V>> map;
 
     UnmodifiableMultimap(final Multimap<K, V> delegate) {
       this.delegate = checkNotNull(delegate);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Suppress TSAN errors for benign races.

Compare other usages of `@LazyInit` on collection views, such as `HashBiMap.inverse` and `AbstractTable.cellSet`.

2dd065fb4e67aa61c0db2e8851ae002e3b8959a2