### PR TITLE
MOE Sync 2020-12-03

### DIFF
--- a/android/guava/src/com/google/common/base/StandardSystemProperty.java
+++ b/android/guava/src/com/google/common/base/StandardSystemProperty.java
@@ -80,7 +80,15 @@ public enum StandardSystemProperty {
   /** Name of JIT compiler to use. */
   JAVA_COMPILER("java.compiler"),
 
-  /** Path of extension directory or directories. */
+  /**
+   * Path of extension directory or directories.
+   *
+   * @deprecated This property was <a
+   *     href="https://openjdk.java.net/jeps/220#Removed:-The-extension-mechanism">deprecated</a> in
+   *     Java 8 and removed in Java 9. We do not plan to remove this API from Guava, but if you are
+   *     using it, it is probably not doing what you want.
+   */
+  @Deprecated
   JAVA_EXT_DIRS("java.ext.dirs"),
 
   /** Operating system name. */
@@ -124,6 +132,25 @@ public enum StandardSystemProperty {
   /**
    * Returns the current value for this system property by delegating to {@link
    * System#getProperty(String)}.
+   *
+   * <p>The value returned by this method is non-null except in rare circumstances:
+   *
+   * <ul>
+   *   <li>{@link #JAVA_EXT_DIRS} was deprecated in Java 8 and removed in Java 9. We have not
+   *       confirmed whether it is available under older versions.
+   *   <li>{@link #JAVA_COMPILER}, while still listed as required as of Java 15, is typically not
+   *       available even under older version.
+   *   <li>Any property may be cleared through APIs like {@link System#clearProperty}.
+   *   <li>Unusual environments like GWT may have their own special handling of system properties.
+   * </ul>
+   *
+   * <p>Note that {@code StandardSystemProperty} does not provide constants for more recently added
+   * properties, including:
+   *
+   * <ul>
+   *   <li>{@code java.vendor.version} (added in Java 11, listed as optional as of Java 13)
+   *   <li>{@code jdk.module.*} (added in Java 9, optional)
+   * </ul>
    */
   @NullableDecl
   public String value() {

--- a/guava/src/com/google/common/base/StandardSystemProperty.java
+++ b/guava/src/com/google/common/base/StandardSystemProperty.java
@@ -80,7 +80,15 @@ public enum StandardSystemProperty {
   /** Name of JIT compiler to use. */
   JAVA_COMPILER("java.compiler"),
 
-  /** Path of extension directory or directories. */
+  /**
+   * Path of extension directory or directories.
+   *
+   * @deprecated This property was <a
+   *     href="https://openjdk.java.net/jeps/220#Removed:-The-extension-mechanism">deprecated</a> in
+   *     Java 8 and removed in Java 9. We do not plan to remove this API from Guava, but if you are
+   *     using it, it is probably not doing what you want.
+   */
+  @Deprecated
   JAVA_EXT_DIRS("java.ext.dirs"),
 
   /** Operating system name. */
@@ -124,6 +132,25 @@ public enum StandardSystemProperty {
   /**
    * Returns the current value for this system property by delegating to {@link
    * System#getProperty(String)}.
+   *
+   * <p>The value returned by this method is non-null except in rare circumstances:
+   *
+   * <ul>
+   *   <li>{@link #JAVA_EXT_DIRS} was deprecated in Java 8 and removed in Java 9. We have not
+   *       confirmed whether it is available under older versions.
+   *   <li>{@link #JAVA_COMPILER}, while still listed as required as of Java 15, is typically not
+   *       available even under older version.
+   *   <li>Any property may be cleared through APIs like {@link System#clearProperty}.
+   *   <li>Unusual environments like GWT may have their own special handling of system properties.
+   * </ul>
+   *
+   * <p>Note that {@code StandardSystemProperty} does not provide constants for more recently added
+   * properties, including:
+   *
+   * <ul>
+   *   <li>{@code java.vendor.version} (added in Java 11, listed as optional as of Java 13)
+   *   <li>{@code jdk.module.*} (added in Java 9, optional)
+   * </ul>
    */
   public @Nullable String value() {
     return System.getProperty(key);

--- a/guava/src/com/google/common/collect/HashBiMap.java
+++ b/guava/src/com/google/common/collect/HashBiMap.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Maps.IteratorBasedAbstractMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.j2objc.annotations.RetainedWith;
-import com.google.j2objc.annotations.Weak;
+import com.google.j2objc.annotations.WeakOuter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -88,11 +88,11 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     final int keyHash;
     final int valueHash;
 
-    @Weak @Nullable BiEntry<K, V> nextInKToVBucket;
-    @Weak @Nullable BiEntry<K, V> nextInVToKBucket;
+    @Nullable BiEntry<K, V> nextInKToVBucket;
+    @Nullable BiEntry<K, V> nextInVToKBucket;
 
-    @Weak @Nullable BiEntry<K, V> nextInKeyInsertionOrder;
-    @Weak @Nullable BiEntry<K, V> prevInKeyInsertionOrder;
+    @Nullable BiEntry<K, V> nextInKeyInsertionOrder;
+    @Nullable BiEntry<K, V> prevInKeyInsertionOrder;
 
     BiEntry(K key, int keyHash, V value, int valueHash) {
       super(key, value);
@@ -105,8 +105,8 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
 
   private transient BiEntry<K, V>[] hashTableKToV;
   private transient BiEntry<K, V>[] hashTableVToK;
-  @Weak private transient @Nullable BiEntry<K, V> firstInKeyInsertionOrder;
-  @Weak private transient @Nullable BiEntry<K, V> lastInKeyInsertionOrder;
+  private transient @Nullable BiEntry<K, V> firstInKeyInsertionOrder;
+  private transient @Nullable BiEntry<K, V> lastInKeyInsertionOrder;
   private transient int size;
   private transient int mask;
   private transient int modCount;
@@ -453,6 +453,7 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
     return new KeySet();
   }
 
+  @WeakOuter
   private final class KeySet extends Maps.KeySet<K, V> {
     KeySet() {
       super(HashBiMap.this);
@@ -624,6 +625,7 @@ public final class HashBiMap<K, V> extends IteratorBasedAbstractMap<K, V>
       return new InverseKeySet();
     }
 
+    @WeakOuter
     private final class InverseKeySet extends Maps.KeySet<V, K> {
       InverseKeySet() {
         super(Inverse.this);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Explain when StandardSystemProperty.value() can return a null value, and deprecate JAVA_EXT_DIRS.

value()'s return type has been @Nullable since 4232450e7bb7c46c08868f699323db3e787507c8, but I had forgotten the details about why, despite past CLs to update the test for specific missing keys.

I assume that we'll never actually *remove* JAVA_EXT_DIRS.

(Just slightly relevant to https://github.com/google/guava/issues/2571)

RELNOTES=`base`: Deprecated `StandardSystemProperty.JAVA_EXT_DIRS`. We do not plan to remove the API, but in recent versions of Java, that property always has a value of `null`.

5cdf73749704cdb752b922ec8c66dff2d36b22de

-------

<p> Automated rollback of 67517b5a5b7627eee39a47917197998b9f974751.

*** Reason for rollback ***

Causing Sheets iOS crash

*** Original change description ***

Fix memory leaks and potential crashes in HashBiMap, which occur in transpiled ObjC code.
Add iOS specific unit tests in XPlat, because Guava is missing infrastructure for iOS tests.

***

d2568df195c16cdbc62c6ab93ce489f9a4a81dc3