### PR TITLE
MOE Sync 2020-12-04

### DIFF
--- a/android/guava-tests/test/com/google/common/math/BigIntegerMathTest.java
+++ b/android/guava-tests/test/com/google/common/math/BigIntegerMathTest.java
@@ -441,7 +441,7 @@ public class BigIntegerMathTest extends TestCase {
   @GwtIncompatible // TODO
   @AndroidIncompatible // slow
   public void testDivNonZeroExact() {
-    boolean isAndroid = System.getProperties().getProperty("java.runtime.name").contains("Android");
+    boolean isAndroid = System.getProperty("java.runtime.name").contains("Android");
     for (BigInteger p : NONZERO_BIGINTEGER_CANDIDATES) {
       for (BigInteger q : NONZERO_BIGINTEGER_CANDIDATES) {
         if (isAndroid && p.equals(BAD_FOR_ANDROID_P) && q.equals(BAD_FOR_ANDROID_Q)) {

--- a/android/guava-tests/test/com/google/common/math/TestPlatform.java
+++ b/android/guava-tests/test/com/google/common/math/TestPlatform.java
@@ -26,6 +26,6 @@ class TestPlatform {
   }
 
   static boolean isAndroid() {
-    return System.getProperties().getProperty("java.runtime.name").contains("Android");
+    return System.getProperty("java.runtime.name").contains("Android");
   }
 }

--- a/guava-tests/test/com/google/common/math/BigIntegerMathTest.java
+++ b/guava-tests/test/com/google/common/math/BigIntegerMathTest.java
@@ -441,7 +441,7 @@ public class BigIntegerMathTest extends TestCase {
   @GwtIncompatible // TODO
   @AndroidIncompatible // slow
   public void testDivNonZeroExact() {
-    boolean isAndroid = System.getProperties().getProperty("java.runtime.name").contains("Android");
+    boolean isAndroid = System.getProperty("java.runtime.name").contains("Android");
     for (BigInteger p : NONZERO_BIGINTEGER_CANDIDATES) {
       for (BigInteger q : NONZERO_BIGINTEGER_CANDIDATES) {
         if (isAndroid && p.equals(BAD_FOR_ANDROID_P) && q.equals(BAD_FOR_ANDROID_Q)) {

--- a/guava-tests/test/com/google/common/math/TestPlatform.java
+++ b/guava-tests/test/com/google/common/math/TestPlatform.java
@@ -26,6 +26,6 @@ class TestPlatform {
   }
 
   static boolean isAndroid() {
-    return System.getProperties().getProperty("java.runtime.name").contains("Android");
+    return System.getProperty("java.runtime.name").contains("Android");
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> System.getProperties().getProperty => System.getProperty.

My motivation was that it's slightly easier for a nullness checker to determine that System.getProperty(standardProperty) is (generally speaking) non-null. But it turns out that java.runtime.name is not a standard property!

Still, this is a slight simplification, so I guess I'm submitting.

96203a3d7a76dda7190e30d58431515fd9ad4ea3

-------

<p> Fix a bug in HashBiMap which was causing crashes in Sheets on iOS.

The crash was caused by the fact, that linked-list of BiEntry instances inside a bucket were using @Weak references, and only the first entry in the list was strongly referenced. The remaining ones were deallocated.

With this change, Sheets iOS is not crashing anymore.

847c0235ef0a768a4d19274a1fe8264bcbfc190a