### PR TITLE
MOE Sync 2020-12-11

### DIFF
--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -90,6 +90,42 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <!--
+                 The execution named default-compile happens first, regardless
+                 of the order of the executions in the source file. So, because
+                 Java8Usage is a dependency of the main sources, we need to call
+                 its compilation "default-compile," even though it's the special
+                 case.
+            -->
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/Java8Usage.java</include>
+              </includes>
+              <!-- -source 8 -target 8 is a no-op in the mainline but matters in the backport. -->
+              <source>8</source>
+              <target>8</target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>main-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/Java8Usage.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/android/guava/src/com/google/common/base/Java8Usage.java
+++ b/android/guava/src/com/google/common/base/Java8Usage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.base;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+/**
+ * A class that uses a couple Java 8 features but doesn't really do anything. This lets us attempt
+ * to load it and log a warning if that fails, giving users advance notice of our dropping Java 8
+ * support.
+ */
+/*
+ * This class should be annotated @GwtCompatible. But if we annotate it @GwtCompatible, then we need
+ * to build GwtCompatible.java (-source 7 -target 7 in the Android flavor) before we build
+ * Java8Usage.java (-source 8 target 8, which we already need to build before the rest of
+ * common.base). We could configure Maven to do that, but it's easier to just skip the annotation.
+ */
+final class Java8Usage {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  private @interface SomeTypeAnnotation {}
+
+  @CanIgnoreReturnValue
+  static @SomeTypeAnnotation String performCheck() {
+    Runnable r = () -> {};
+    r.run();
+    return "";
+  }
+
+  private Java8Usage() {}
+}

--- a/android/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -26,10 +26,10 @@ abstract class SmoothRateLimiter extends RateLimiter {
   /*
    * How is the RateLimiter designed, and why?
    *
-   * The primary feature of a RateLimiter is its "stable rate", the maximum rate that is should
-   * allow at normal conditions. This is enforced by "throttling" incoming requests as needed, i.e.
-   * compute, for an incoming request, the appropriate throttle time, and make the calling thread
-   * wait as much.
+   * The primary feature of a RateLimiter is its "stable rate", the maximum rate that it should
+   * allow in normal conditions. This is enforced by "throttling" incoming requests as needed. For
+   * example, we could compute the appropriate throttle time for an incoming request, and make the
+   * calling thread wait for that time.
    *
    * The simplest way to maintain a rate of QPS is to keep the timestamp of the last granted
    * request, and ensure that (1/QPS) seconds have elapsed since then. For example, for a rate of

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -118,6 +118,16 @@
           <configuration>
             <source>1.7</source>
             <target>1.7</target>
+            <compilerArgs>
+              <!--
+                   Make includes/excludes fully work:
+                   https://issues.apache.org/jira/browse/MCOMPILER-174
+
+                   (Compare what guava-gwt has to do for maven-javadoc-plugin.)
+              -->
+              <arg>-sourcepath</arg>
+              <arg>doesnotexist</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -90,6 +90,42 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <!--
+                 The execution named default-compile happens first, regardless
+                 of the order of the executions in the source file. So, because
+                 Java8Usage is a dependency of the main sources, we need to call
+                 its compilation "default-compile," even though it's the special
+                 case.
+            -->
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/Java8Usage.java</include>
+              </includes>
+              <!-- -source 8 -target 8 is a no-op in the mainline but matters in the backport. -->
+              <source>8</source>
+              <target>8</target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>main-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/Java8Usage.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/guava/src/com/google/common/base/Java8Usage.java
+++ b/guava/src/com/google/common/base/Java8Usage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.base;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+/**
+ * A class that uses a couple Java 8 features but doesn't really do anything. This lets us attempt
+ * to load it and log a warning if that fails, giving users advance notice of our dropping Java 8
+ * support.
+ */
+/*
+ * This class should be annotated @GwtCompatible. But if we annotate it @GwtCompatible, then we need
+ * to build GwtCompatible.java (-source 7 -target 7 in the Android flavor) before we build
+ * Java8Usage.java (-source 8 target 8, which we already need to build before the rest of
+ * common.base). We could configure Maven to do that, but it's easier to just skip the annotation.
+ */
+final class Java8Usage {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  private @interface SomeTypeAnnotation {}
+
+  @CanIgnoreReturnValue
+  static @SomeTypeAnnotation String performCheck() {
+    Runnable r = () -> {};
+    r.run();
+    return "";
+  }
+
+  private Java8Usage() {}
+}

--- a/guava/src/com/google/common/base/MoreObjects.java
+++ b/guava/src/com/google/common/base/MoreObjects.java
@@ -15,10 +15,13 @@
 package com.google.common.base;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.logging.Level.WARNING;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.Arrays;
+import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -141,6 +144,38 @@ public final class MoreObjects {
    * @since 18.0 (since 2.0 as {@code Objects.ToStringHelper}).
    */
   public static final class ToStringHelper {
+    @GuardedBy("ToStringHelper.class")
+    private static boolean performedJava8CompatibilityCheck;
+
+    private static void java8CompatibilityCheck() {
+      @SuppressWarnings("GuardedBy")
+      boolean racyReadForDoubleCheckedLock = performedJava8CompatibilityCheck;
+      if (racyReadForDoubleCheckedLock) {
+        return;
+      }
+      synchronized (ToStringHelper.class) {
+        if (performedJava8CompatibilityCheck) {
+          return;
+        }
+        performedJava8CompatibilityCheck = true;
+      }
+
+      try {
+        Java8Usage.performCheck();
+      } catch (Throwable underlying) {
+        Exception toLog =
+            new Exception(
+                "Guava will drop support for Java 7 in 2021. Please let us know if this will cause"
+                    + " you problems: https://github.com/google/guava/issues/5269",
+                underlying);
+        Logger.getLogger(ToStringHelper.class.getName())
+            .log(
+                WARNING,
+                "Java 7 compatibility warning: See https://github.com/google/guava/issues/5269",
+                toLog);
+      }
+    }
+
     private final String className;
     private final ValueHolder holderHead = new ValueHolder();
     private ValueHolder holderTail = holderHead;
@@ -148,6 +183,7 @@ public final class MoreObjects {
 
     /** Use {@link MoreObjects#toStringHelper(Object)} to create an instance. */
     private ToStringHelper(String className) {
+      java8CompatibilityCheck();
       this.className = checkNotNull(className);
     }
 

--- a/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -26,10 +26,10 @@ abstract class SmoothRateLimiter extends RateLimiter {
   /*
    * How is the RateLimiter designed, and why?
    *
-   * The primary feature of a RateLimiter is its "stable rate", the maximum rate that is should
-   * allow at normal conditions. This is enforced by "throttling" incoming requests as needed, i.e.
-   * compute, for an incoming request, the appropriate throttle time, and make the calling thread
-   * wait as much.
+   * The primary feature of a RateLimiter is its "stable rate", the maximum rate that it should
+   * allow in normal conditions. This is enforced by "throttling" incoming requests as needed. For
+   * example, we could compute the appropriate throttle time for an incoming request, and make the
+   * calling thread wait for that time.
    *
    * The simplest way to maintain a rate of QPS is to keep the timestamp of the last granted
    * request, and ensure that (1/QPS) seconds have elapsed since then. For example, for a rate of

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,16 @@
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
+            <compilerArgs>
+              <!--
+                   Make includes/excludes fully work:
+                   https://issues.apache.org/jira/browse/MCOMPILER-174
+
+                   (Compare what guava-gwt has to do for maven-javadoc-plugin.)
+              -->
+              <arg>-sourcepath</arg>
+              <arg>doesnotexist</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Correct a typo and some odd phrasing in the first paragraph of the javadoc for SmoothRateLimiter.

8d571ca36055d207635d84db4159607c511de649

-------

<p> Log a warning if running under a Java 7 VM.

More precisely, log a warning if lambda expressions or type annotations in our classes would produce an exception. If someone wants to use Retrolambda or a similar tool to rewrite our classes, that's fine with us if it works. And our support for Android is unchanged: The Android toolchain rewrites lambdas and removes type annotations.

This is a step toward removing Java 7 support entirely: https://github.com/google/guava/issues/5269

RELNOTES=Introduced a warning log message when running under Java 7. This warning is not _guaranteed_ to be logged when running under Java 7, so please don't rely on it as your only warning about future problems. If the warning _itself_ causes you trouble, you can eliminate it by silencing the logger for `com.google.common.base.MoreObjects$ToStringHelper` (which is used _only_ for this warning). This warning prepares for [removing support for Java 7 in 2021](https://github.com/google/guava/issues/5269). Please report any problems.

0357006a920c9cf84d47901471a525da85deba34