### PR TITLE
Issue5387 - Added logical operators to UnsignedInteger class

### DIFF
--- a/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
+++ b/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
@@ -151,6 +151,20 @@ public class UnsignedIntegerTest extends TestCase {
       }
     }
   }
+  
+  
+  public void testOr() {
+    for (int a : TEST_INTS) {
+      for (int b : TEST_INTS) {
+        UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
+        UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
+        int expected =
+                aUnsigned.bigIntegerValue().or(bUnsigned.bigIntegerValue()).intValue();
+        UnsignedInteger unsignedSub = aUnsigned.or(bUnsigned);
+        assertEquals(expected, unsignedSub.intValue());
+      }
+    }
+  }
 
   public void testXor() {
     for (int a : TEST_INTS) {
@@ -158,7 +172,7 @@ public class UnsignedIntegerTest extends TestCase {
         UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
         UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
         int expected =
-                force32(aUnsigned.bigIntegerValue().xor(bUnsigned.bigIntegerValue()).intValue());
+                aUnsigned.bigIntegerValue().xor(bUnsigned.bigIntegerValue()).intValue();
         UnsignedInteger unsignedSub = aUnsigned.xor(bUnsigned);
         assertEquals(expected, unsignedSub.intValue());
       }
@@ -185,19 +199,6 @@ public class UnsignedIntegerTest extends TestCase {
         int expected =
             force32(aUnsigned.bigIntegerValue().subtract(bUnsigned.bigIntegerValue()).intValue());
         UnsignedInteger unsignedSub = aUnsigned.minus(bUnsigned);
-        assertEquals(expected, unsignedSub.intValue());
-      }
-    }
-  }
-
-  public void testOr() {
-    for (int a : TEST_INTS) {
-      for (int b : TEST_INTS) {
-        UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
-        UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
-        int expected =
-                force32(aUnsigned.bigIntegerValue().or(bUnsigned.bigIntegerValue()).intValue());
-        UnsignedInteger unsignedSub = aUnsigned.or(bUnsigned);
         assertEquals(expected, unsignedSub.intValue());
       }
     }

--- a/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
+++ b/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
@@ -165,6 +165,19 @@ public class UnsignedIntegerTest extends TestCase {
     }
   }
 
+  public void testOr() {
+    for (int a : TEST_INTS) {
+      for (int b : TEST_INTS) {
+        UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
+        UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
+        int expected =
+                force32(aUnsigned.bigIntegerValue().or(bUnsigned.bigIntegerValue()).intValue());
+        UnsignedInteger unsignedSub = aUnsigned.or(bUnsigned);
+        assertEquals(expected, unsignedSub.intValue());
+      }
+    }
+  }
+
   @GwtIncompatible // multiply
   public void testTimes() {
     for (int a : TEST_INTS) {

--- a/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
+++ b/guava-tests/test/com/google/common/primitives/UnsignedIntegerTest.java
@@ -140,6 +140,31 @@ public class UnsignedIntegerTest extends TestCase {
     }
   }
 
+  public void testLogicalAnd() {
+    for (int a: TEST_INTS) {
+      for (int b: TEST_INTS) {
+        UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
+        UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
+        int expected = aUnsigned.bigIntegerValue().and(bUnsigned.bigIntegerValue()).intValue();
+        UnsignedInteger unsignedAnd = aUnsigned.and(bUnsigned);
+        assertEquals(expected, unsignedAnd.intValue());
+      }
+    }
+  }
+
+  public void testXor() {
+    for (int a : TEST_INTS) {
+      for (int b : TEST_INTS) {
+        UnsignedInteger aUnsigned = UnsignedInteger.fromIntBits(a);
+        UnsignedInteger bUnsigned = UnsignedInteger.fromIntBits(b);
+        int expected =
+                force32(aUnsigned.bigIntegerValue().xor(bUnsigned.bigIntegerValue()).intValue());
+        UnsignedInteger unsignedSub = aUnsigned.xor(bUnsigned);
+        assertEquals(expected, unsignedSub.intValue());
+      }
+    }
+  }
+
   public void testPlus() {
     for (int a : TEST_INTS) {
       for (int b : TEST_INTS) {

--- a/guava/src/com/google/common/primitives/UnsignedInteger.java
+++ b/guava/src/com/google/common/primitives/UnsignedInteger.java
@@ -117,6 +117,23 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
   }
 
   /**
+   * Returns the result of the bitwise logical <i>and</i> operation with {@code val}.
+   */
+  public UnsignedInteger and(UnsignedInteger val) { return fromIntBits(this.value & checkNotNull(val).value); }
+
+  /**
+   * Returns the result of bitwise logical <i>or</i> operation with{@code val}.
+   */
+  public UnsignedInteger or(UnsignedInteger val) {
+    return fromIntBits(this.value | checkNotNull(val).value);
+  }
+
+  /**
+   * Returns the result of the bitwise logical <i>xor</i> operation with {@code val}.
+   */
+  public UnsignedInteger xor(UnsignedInteger val) { return fromIntBits(this.value ^ checkNotNull(val).value); }
+
+  /**
    * Returns the result of adding this and {@code val}. If the result would have more than 32 bits,
    * returns the low 32 bits of the result.
    *
@@ -166,13 +183,6 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
    */
   public UnsignedInteger mod(UnsignedInteger val) {
     return fromIntBits(UnsignedInts.remainder(value, checkNotNull(val).value));
-  }
-
-  /**
-   * Returns the result of bitwise logical or operation with{@code val}.
-   */
-  public UnsignedInteger or(UnsignedInteger val) {
-    return fromIntBits(this.value | checkNotNull(val).value);
   }
 
   /**

--- a/guava/src/com/google/common/primitives/UnsignedInteger.java
+++ b/guava/src/com/google/common/primitives/UnsignedInteger.java
@@ -169,6 +169,13 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
   }
 
   /**
+   * Returns the result of bitwise logical or operation with{@code val}.
+   */
+  public UnsignedInteger or(UnsignedInteger val) {
+    return fromIntBits(this.value | checkNotNull(val).value);
+  }
+
+  /**
    * Returns the value of this {@code UnsignedInteger} as an {@code int}. This is an inverse
    * operation to {@link #fromIntBits}.
    *


### PR DESCRIPTION
Added `and, or` and `xor` operations for the `UnsignedInteger` class according to the issue #5387.

We thought about also implementing left shift and right shift.
Since the `UnsignedLong` has a similar behaviour, it would make sense to add them there as well.