### PR TITLE
change in peek() method of PeekingImpl class

### DIFF
--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -1147,8 +1147,8 @@ public final class Iterators {
     @Override
     public E peek() {
       if (!hasPeeked) {
+        if(iterator.hasNext()) hasPeeked = true;
         peekedElement = iterator.next();
-        hasPeeked = true;
       }
       return peekedElement;
     }


### PR DESCRIPTION
Added validation, if the iterator.hasNext() return true, then only we change the value of hasPeeked to true, because before what we are doing is without checking iterator contains some value or not, we mark hasPeeked to true in peek() method and, if the user call hasNext() method of PeekingImpl class immediately after calling peek() method, it will always return true.