### PR TITLE
Issue #2394 - Replace LinkedList with ArrayDeque

### DIFF
--- a/android/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
+++ b/android/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
@@ -18,10 +18,10 @@ package com.google.common.cache;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -36,7 +36,7 @@ import junit.framework.TestCase;
 public class CacheLoaderTest extends TestCase {
 
   private static class QueuingExecutor implements Executor {
-    private LinkedList<Runnable> tasks = Lists.newLinkedList();
+    private ArrayDeque<Runnable> tasks = Queues.newArrayDeque();
 
     @Override
     public void execute(Runnable task) {

--- a/android/guava/src/com/google/common/io/LineReader.java
+++ b/android/guava/src/com/google/common/io/LineReader.java
@@ -23,7 +23,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.CharBuffer;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Queue;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
@@ -43,7 +43,7 @@ public final class LineReader {
   private final CharBuffer cbuf = createBuffer();
   private final char[] buf = cbuf.array();
 
-  private final Queue<String> lines = new LinkedList<>();
+  private final Queue<String> lines = new ArrayDeque<>();
   private final LineBuffer lineBuf =
       new LineBuffer() {
         @Override

--- a/android/guava/src/com/google/thirdparty/publicsuffix/TrieParser.java
+++ b/android/guava/src/com/google/thirdparty/publicsuffix/TrieParser.java
@@ -17,8 +17,8 @@ package com.google.thirdparty.publicsuffix;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import java.util.List;
+import com.google.common.collect.Queues;
+import java.util.ArrayDeque;
 
 /** Parser for a map of reversed domain names stored as a serialized radix tree. */
 @GwtCompatible
@@ -34,7 +34,7 @@ final class TrieParser {
     int encodedLen = encoded.length();
     int idx = 0;
     while (idx < encodedLen) {
-      idx += doParseTrieToBuilder(Lists.<CharSequence>newLinkedList(), encoded, idx, builder);
+      idx += doParseTrieToBuilder(Queues.<CharSequence>newArrayDeque(), encoded, idx, builder);
     }
     return builder.build();
   }
@@ -50,7 +50,7 @@ final class TrieParser {
    * @return The number of characters consumed from {@code encoded}.
    */
   private static int doParseTrieToBuilder(
-      List<CharSequence> stack,
+      ArrayDeque<CharSequence> stack,
       CharSequence encoded,
       int start,
       ImmutableMap.Builder<String, PublicSuffixType> builder) {
@@ -67,7 +67,7 @@ final class TrieParser {
       }
     }
 
-    stack.add(0, reverse(encoded.subSequence(start, idx)));
+    stack.push(reverse(encoded.subSequence(start, idx)));
 
     if (c == '!' || c == '?' || c == ':' || c == ',') {
       // '!' represents an interior node that represents a REGISTRY entry in the map.
@@ -92,7 +92,7 @@ final class TrieParser {
         }
       }
     }
-    stack.remove(0);
+    stack.pop();
     return idx - start;
   }
 

--- a/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
+++ b/guava-tests/test/com/google/common/cache/CacheLoaderTest.java
@@ -18,10 +18,10 @@ package com.google.common.cache;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -36,7 +36,7 @@ import junit.framework.TestCase;
 public class CacheLoaderTest extends TestCase {
 
   private static class QueuingExecutor implements Executor {
-    private LinkedList<Runnable> tasks = Lists.newLinkedList();
+    private ArrayDeque<Runnable> tasks = Queues.newArrayDeque();
 
     @Override
     public void execute(Runnable task) {

--- a/guava/src/com/google/common/io/LineReader.java
+++ b/guava/src/com/google/common/io/LineReader.java
@@ -23,7 +23,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.CharBuffer;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Queue;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,7 +43,7 @@ public final class LineReader {
   private final CharBuffer cbuf = createBuffer();
   private final char[] buf = cbuf.array();
 
-  private final Queue<String> lines = new LinkedList<>();
+  private final Queue<String> lines = new ArrayDeque<>();
   private final LineBuffer lineBuf =
       new LineBuffer() {
         @Override

--- a/guava/src/com/google/thirdparty/publicsuffix/TrieParser.java
+++ b/guava/src/com/google/thirdparty/publicsuffix/TrieParser.java
@@ -17,8 +17,8 @@ package com.google.thirdparty.publicsuffix;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import java.util.List;
+import com.google.common.collect.Queues;
+import java.util.ArrayDeque;
 
 /** Parser for a map of reversed domain names stored as a serialized radix tree. */
 @GwtCompatible
@@ -34,7 +34,7 @@ final class TrieParser {
     int encodedLen = encoded.length();
     int idx = 0;
     while (idx < encodedLen) {
-      idx += doParseTrieToBuilder(Lists.<CharSequence>newLinkedList(), encoded, idx, builder);
+      idx += doParseTrieToBuilder(Queues.<CharSequence>newArrayDeque(), encoded, idx, builder);
     }
     return builder.build();
   }
@@ -50,7 +50,7 @@ final class TrieParser {
    * @return The number of characters consumed from {@code encoded}.
    */
   private static int doParseTrieToBuilder(
-      List<CharSequence> stack,
+      ArrayDeque<CharSequence> stack,
       CharSequence encoded,
       int start,
       ImmutableMap.Builder<String, PublicSuffixType> builder) {
@@ -67,7 +67,7 @@ final class TrieParser {
       }
     }
 
-    stack.add(0, reverse(encoded.subSequence(start, idx)));
+    stack.push(reverse(encoded.subSequence(start, idx)));
 
     if (c == '!' || c == '?' || c == ':' || c == ',') {
       // '!' represents an interior node that represents a REGISTRY entry in the map.
@@ -92,7 +92,7 @@ final class TrieParser {
         }
       }
     }
-    stack.remove(0);
+    stack.pop();
     return idx - start;
   }
 


### PR DESCRIPTION
#2394

Refactor TrieParser, LineReader, and CacheLoaderTest by replacing LinkedList with ArrayDeque. LinkedList still occur at a few places where it does not make sense to replace it.