### PR TITLE
checkNotNull's argument should not be marked as NonNull

### DIFF
--- a/guava/src/com/google/common/base/Preconditions.java
+++ b/guava/src/com/google/common/base/Preconditions.java
@@ -873,7 +873,7 @@ public final class Preconditions {
    * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(T reference) {
+  public static <T> T checkNotNull(T reference) {
     if (reference == null) {
       throw new NullPointerException();
     }
@@ -891,7 +891,7 @@ public final class Preconditions {
    * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T reference, @Nullable Object errorMessage) {
     if (reference == null) {
       throw new NullPointerException(String.valueOf(errorMessage));
@@ -915,7 +915,7 @@ public final class Preconditions {
    * @see Verify#verifyNotNull Verify.verifyNotNull()
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T reference,
       @Nullable String errorMessageTemplate,
       @Nullable Object @Nullable ... errorMessageArgs) {
@@ -933,7 +933,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, char p1) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1));
@@ -949,7 +949,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, int p1) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1));
@@ -965,7 +965,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, long p1) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1));
@@ -981,7 +981,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, @Nullable Object p1) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1));
@@ -997,7 +997,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, char p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1013,7 +1013,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, char p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1029,7 +1029,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, char p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1045,7 +1045,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, char p1, @Nullable Object p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1061,7 +1061,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, int p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1077,7 +1077,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, int p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1093,7 +1093,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, int p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1109,7 +1109,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, int p1, @Nullable Object p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1125,7 +1125,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, long p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1141,7 +1141,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, long p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1157,7 +1157,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, long p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1173,7 +1173,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, long p1, @Nullable Object p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1189,7 +1189,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, @Nullable Object p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1205,7 +1205,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, @Nullable Object p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1221,7 +1221,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, @Nullable Object p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1237,7 +1237,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj, @Nullable String errorMessageTemplate, @Nullable Object p1, @Nullable Object p2) {
     if (obj == null) {
       throw new NullPointerException(lenientFormat(errorMessageTemplate, p1, p2));
@@ -1253,7 +1253,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj,
       @Nullable String errorMessageTemplate,
       @Nullable Object p1,
@@ -1273,7 +1273,7 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   @CanIgnoreReturnValue
-  public static <T extends @NonNull Object> T checkNotNull(
+  public static <T> T checkNotNull(
       T obj,
       @Nullable String errorMessageTemplate,
       @Nullable Object p1,


### PR DESCRIPTION
checkNotNull ensures that output it's not null, it's this method responsibility to check non-nullability. NotNull on input parameter should be used if method assumes input is not null/requires it.

Adding NotNull broke IntelliJ's code analysis. IntelliJ assumed that NonNull argument must be null on method input, however in fact method's contract is to ensure that on output the value is not null.