### PR TITLE
FEATURE: Add BloomFilter support for conversion between BloomFilter.bits and Redis bitmap

### DIFF
--- a/guava-tests/test/com/google/common/hash/BloomFilterTest.java
+++ b/guava-tests/test/com/google/common/hash/BloomFilterTest.java
@@ -525,6 +525,19 @@ public class BloomFilterTest extends TestCase {
     assertEquals(bf, BloomFilter.readFrom(new ByteArrayInputStream(out.toByteArray()), funnel));
   }
 
+  public void testBitmapRedisSerialization(){
+    Funnel<byte[]> funnel = Funnels.byteArrayFunnel();
+    BloomFilter<byte[]> bf = BloomFilter.create(funnel, 100);
+    for (int i = 0; i < 100; i++) {
+      bf.put(Ints.toByteArray(i));
+    }
+
+    byte[] data = bf.serialToRedisBitmapBytes();
+
+    BloomFilter<byte[]> bf2 = BloomFilter.createFromRedisBitmapBytes(data, funnel, 100, 0.03);
+    assertEquals(bf,bf2);
+  }
+
   /**
    * This test will fail whenever someone updates/reorders the BloomFilterStrategies constants. Only
    * appending a new constant is allowed.


### PR DESCRIPTION
This PR adds the method to convert guava bitmap and redis bitmap to each other.

```java
BloomFilter<Person> bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charset.forName("utf-8")), 1000000, 0.01);

bloomFilter.put("foo");
bloomFilter.put("bar");

//Convert to  a byte array in Redis bitmap format
byte[] data = bf.serialToRedisBitmapBytes();

//Store in redis
redis.set(key.getBytes(), data)
```

Real life use-case:
In my project, I need to provide BloomFilter filtering service based on the distributed cache such as Redis. My implementation method is to base the basic logic on the existing code of BloomFilter of Guava, such as the hash method, but the bitmap is based on the bitmap of Redis. This works well so far, but there are situations where when building BloomFilter with a lot of data, such as building BloomFilter with a million data, the number of Redis operations becomes a performance bottleneck. My approach is to build BloomFilter in the local cache. Then convert Guava's bitmap to Redis's bitmap format and write it to Redis once.