### PR TITLE
Enabling Tables.newCustomTable with ConcurrentMap

### DIFF
--- a/guava/src/com/google/common/collect/StandardTable.java
+++ b/guava/src/com/google/common/collect/StandardTable.java
@@ -130,12 +130,7 @@ class StandardTable<R, C, V> extends AbstractTable<R, C, V> implements Serializa
   }
 
   private Map<C, V> getOrCreate(R rowKey) {
-    Map<C, V> map = backingMap.get(rowKey);
-    if (map == null) {
-      map = factory.get();
-      backingMap.put(rowKey, map);
-    }
-    return map;
+    return backingMap.computeIfAbsent(rowKey, key -> factory.get());
   }
 
   @CanIgnoreReturnValue


### PR DESCRIPTION
If I want to use [Tables.newCustomTable](https://guava.dev/releases/22.0/api/docs/com/google/common/collect/Tables.html#newCustomTable-java.util.Map-com.google.common.base.Supplier-) with ConcurrentMaps, the current implementation is not thread safe when the row is not present. Because it's delegating to the backing map by calling computeIfAbsent.