### PR TITLE
Halve the memory used by BloomFilter.readFrom()

### DIFF
--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -607,11 +607,11 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
       dataLength = din.readInt();
 
       Strategy strategy = BloomFilterStrategies.values()[strategyOrdinal];
-      long[] data = new long[dataLength];
-      for (int i = 0; i < data.length; i++) {
-        data[i] = din.readLong();
+      LockFreeBitArray bits = new LockFreeBitArray((long)dataLength * 64);
+      for (int i = 0; i < dataLength; i++) {
+        bits.data.lazySet(i, din.readLong());
       }
-      return new BloomFilter<T>(new LockFreeBitArray(data), numHashFunctions, funnel, strategy);
+      return new BloomFilter<T>(bits, numHashFunctions, funnel, strategy);
     } catch (RuntimeException e) {
       String message =
           "Unable to deserialize BloomFilter from InputStream."


### PR DESCRIPTION
The BloomFilters  readFrom method reads into a separately allocated array, then converts (clones) the array into the expected object.
The code has been modified to directly read into the final array, not requiring two instances of the array (for a short duration) and the time/cpu used for the copy.