### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -140,7 +140,7 @@ public final class HttpHeaders {
   public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
   /** The HTTP {@code Range} header field name. */
   public static final String RANGE = "Range";
-  /** The HTTP {@code Referer} header field name. */
+  /** The HTTP {@code Referrer} header field name. */
   public static final String REFERER = "Referer";
   /**
    * The HTTP <a href="https://www.w3.org/TR/referrer-policy/">{@code Referrer-Policy}</a> header

--- a/android/guava/src/com/google/common/net/HttpHeaders.java
+++ b/android/guava/src/com/google/common/net/HttpHeaders.java
@@ -140,7 +140,7 @@ public final class HttpHeaders {
   public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
   /** The HTTP {@code Range} header field name. */
   public static final String RANGE = "Range";
-  /** The HTTP {@code Referrer} header field name. */
+  /** The HTTP {@code Referer} header field name. */
   public static final String REFERER = "Referer";
   /**
    * The HTTP <a href="https://www.w3.org/TR/referrer-policy/">{@code Referrer-Policy}</a> header

--- a/android/guava/src/com/google/common/reflect/TypeResolver.java
+++ b/android/guava/src/com/google/common/reflect/TypeResolver.java
@@ -509,7 +509,7 @@ public final class TypeResolver {
         @Override
         TypeVariable<?> captureAsTypeVariable(Type[] upperBounds) {
           Set<Type> combined = new LinkedHashSet<>(asList(upperBounds));
-          // Since this is an artifically generated type variable, we don't bother checking
+          // Since this is an artificially generated type variable, we don't bother checking
           // subtyping between declared type bound and actual type bound. So it's possible that we
           // may generate something like <capture#1-of ? extends Foo&SubFoo>.
           // Checking subtype between declared and actual type bounds

--- a/guava/src/com/google/common/reflect/TypeResolver.java
+++ b/guava/src/com/google/common/reflect/TypeResolver.java
@@ -509,7 +509,7 @@ public final class TypeResolver {
         @Override
         TypeVariable<?> captureAsTypeVariable(Type[] upperBounds) {
           Set<Type> combined = new LinkedHashSet<>(asList(upperBounds));
-          // Since this is an artifically generated type variable, we don't bother checking
+          // Since this is an artificially generated type variable, we don't bother checking
           // subtyping between declared type bound and actual type bound. So it's possible that we
           // may generate something like <capture#1-of ? extends Foo&SubFoo>.
           // Checking subtype between declared and actual type bounds


### PR DESCRIPTION
fixing typo and replace to correct word with reference from [Merriam webster](https://www.merriam-webster.com/) and [wikitionary](https://www.wiktionary.org/)