### PR TITLE
Use constructors of HashSet/LinkedHashSet directly instead of factory methods from Sets class.

### DIFF
--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -35,13 +35,11 @@ import com.google.common.cache.CacheBuilder.NullListener;
 import com.google.common.cache.CacheBuilder.OneWeigher;
 import com.google.common.cache.CacheLoader.InvalidCacheLoadException;
 import com.google.common.cache.CacheLoader.UnsupportedLoadingOperationException;
-import com.google.common.cache.LocalCache.AbstractCacheSet;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.Futures;
@@ -66,8 +64,8 @@ import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
@@ -4016,7 +4014,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     int misses = 0;
 
     Map<K, V> result = Maps.newLinkedHashMap();
-    Set<K> keysToLoad = Sets.newLinkedHashSet();
+    Set<K> keysToLoad = new LinkedHashSet<>();
     for (K key : keys) {
       V value = get(key);
       if (!result.containsKey(key)) {

--- a/guava/src/com/google/common/collect/FilteredEntryMultimap.java
+++ b/guava/src/com/google/common/collect/FilteredEntryMultimap.java
@@ -29,6 +29,7 @@ import com.google.j2objc.annotations.WeakOuter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -212,7 +213,7 @@ class FilteredEntryMultimap<K extends @Nullable Object, V extends @Nullable Obje
       if (result.isEmpty()) {
         return null;
       } else if (unfiltered instanceof SetMultimap) {
-        return Collections.unmodifiableSet(Sets.newLinkedHashSet(result));
+        return Collections.unmodifiableSet(new LinkedHashSet<>(result));
       } else {
         return Collections.unmodifiableList(result);
       }

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -49,6 +49,7 @@ import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -4138,7 +4139,7 @@ public final class Maps {
       try {
         return super.removeAll(checkNotNull(c));
       } catch (UnsupportedOperationException e) {
-        Set<K> toRemove = Sets.newHashSet();
+        Set<K> toRemove = new HashSet<>();
         for (Entry<K, V> entry : map().entrySet()) {
           if (c.contains(entry.getValue())) {
             toRemove.add(entry.getKey());
@@ -4153,7 +4154,7 @@ public final class Maps {
       try {
         return super.retainAll(checkNotNull(c));
       } catch (UnsupportedOperationException e) {
-        Set<K> toRetain = Sets.newHashSet();
+        Set<K> toRetain = new HashSet<>();
         for (Entry<K, V> entry : map().entrySet()) {
           if (c.contains(entry.getValue())) {
             toRetain.add(entry.getKey());

--- a/guava/src/com/google/common/collect/Platform.java
+++ b/guava/src/com/google/common/collect/Platform.java
@@ -19,6 +19,7 @@ package com.google.common.collect;
 import com.google.common.annotations.GwtCompatible;
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,7 +83,7 @@ final class Platform {
    * for insertions.
    */
   static <E extends @Nullable Object> Set<E> preservesInsertionOrderOnAddsSet() {
-    return Sets.newLinkedHashSet();
+    return new LinkedHashSet<>();
   }
 
   /**

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -236,7 +236,7 @@ public final class Sets {
    * <p>Overall, this method is not very useful and will likely be deprecated in the future.
    */
   public static <E extends @Nullable Object> HashSet<E> newHashSet(Iterator<? extends E> elements) {
-    HashSet<E> set = newHashSet();
+    HashSet<E> set = new HashSet<>();
     Iterators.addAll(set, elements);
     return set;
   }
@@ -328,7 +328,7 @@ public final class Sets {
     if (elements instanceof Collection) {
       return new LinkedHashSet<E>((Collection<? extends E>) elements);
     }
-    LinkedHashSet<E> set = newLinkedHashSet();
+    LinkedHashSet<E> set = new LinkedHashSet<>();
     Iterables.addAll(set, elements);
     return set;
   }

--- a/guava/src/com/google/common/reflect/TypeVisitor.java
+++ b/guava/src/com/google/common/reflect/TypeVisitor.java
@@ -14,12 +14,12 @@
 
 package com.google.common.reflect;
 
-import com.google.common.collect.Sets;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.HashSet;
 import java.util.Set;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -57,7 +57,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @ElementTypesAreNonnullByDefault
 abstract class TypeVisitor {
 
-  private final Set<Type> visited = Sets.newHashSet();
+  private final Set<Type> visited = new HashSet<>();
 
   /**
    * Visits the given types. Null types are ignored. This allows subclasses to call {@code

--- a/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/SimpleTimeLimiter.java
@@ -20,12 +20,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.ObjectArrays;
-import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -252,7 +252,7 @@ public final class SimpleTimeLimiter implements TimeLimiter {
   }
 
   private static Set<Method> findInterruptibleMethods(Class<?> interfaceType) {
-    Set<Method> set = Sets.newHashSet();
+    Set<Method> set = new HashSet<>();
     for (Method m : interfaceType.getMethods()) {
       if (declaresInterruptedEx(m)) {
         set.add(m);


### PR DESCRIPTION
As stated in `Sets` javadoc, usages of such methods is not needed for Java 7. As Guava compiles for Java 7+ now, code can now take advantage of diamond syntax.