### PR TITLE
Remove ambiguous return statement

### DIFF
--- a/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -131,15 +131,13 @@ abstract class AbstractCatchingFuture<
     T fallbackResult;
     try {
       fallbackResult = doFallback(localFallback, castThrowable);
+      setResult(fallbackResult);
     } catch (Throwable t) {
       setException(t);
-      return;
     } finally {
       exceptionType = null;
       fallback = null;
     }
-
-    setResult(fallbackResult);
   }
 
   @Override

--- a/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java
@@ -131,15 +131,13 @@ abstract class AbstractCatchingFuture<
     T fallbackResult;
     try {
       fallbackResult = doFallback(localFallback, castThrowable);
+      setResult(fallbackResult);
     } catch (Throwable t) {
       setException(t);
-      return;
     } finally {
       exceptionType = null;
       fallback = null;
     }
-
-    setResult(fallbackResult);
   }
 
   @Override


### PR DESCRIPTION
https://github.com/google/guava/blob/f9b25b423ac6c7201d77387efe079ff540954de2/guava/src/com/google/common/util/concurrent/AbstractCatchingFuture.java#L132-L142

The return statement in the catch seems to be less meaningful since return only happens after finally is executed. Modified the code for better clarity 