### PR TITLE
Simplify some test method code

### DIFF
--- a/guava-tests/test/com/google/common/base/AbstractIteratorTest.java
+++ b/guava-tests/test/com/google/common/base/AbstractIteratorTest.java
@@ -77,7 +77,7 @@ public class AbstractIteratorTest extends TestCase {
     }
   }
 
-  public void testSneakyThrow() throws Exception {
+  public void testSneakyThrow() {
     Iterator<Integer> iter =
         new AbstractIterator<Integer>() {
           boolean haveBeenCalled;
@@ -190,7 +190,7 @@ public class AbstractIteratorTest extends TestCase {
         new AbstractIterator<Integer>() {
           @Override
           protected Integer computeNext() {
-            boolean unused = hasNext();
+            hasNext();
             return null;
           }
         };
@@ -205,7 +205,7 @@ public class AbstractIteratorTest extends TestCase {
   // hasNext/next), but we'll cop out for now, knowing that
   // next() both start by invoking hasNext() anyway.
 
-  /** Throws a undeclared checked exception. */
+  /** Throws an undeclared checked exception. */
   private static void sneakyThrow(Throwable t) {
     class SneakyThrower<T extends Throwable> {
       @SuppressWarnings("unchecked") // intentionally unsafe for test

--- a/guava-tests/test/com/google/common/base/AsciiTest.java
+++ b/guava-tests/test/com/google/common/base/AsciiTest.java
@@ -54,8 +54,8 @@ public class AsciiTest extends TestCase {
   public void testCharsIgnored() {
     for (char c : IGNORED.toCharArray()) {
       String str = String.valueOf(c);
-      assertTrue(str, c == Ascii.toLowerCase(c));
-      assertTrue(str, c == Ascii.toUpperCase(c));
+      assertEquals(str, c, Ascii.toLowerCase(c));
+      assertEquals(str, c, Ascii.toUpperCase(c));
       assertFalse(str, Ascii.isLowerCase(c));
       assertFalse(str, Ascii.isUpperCase(c));
     }
@@ -64,7 +64,7 @@ public class AsciiTest extends TestCase {
   public void testCharsLower() {
     for (char c : LOWER.toCharArray()) {
       String str = String.valueOf(c);
-      assertTrue(str, c == Ascii.toLowerCase(c));
+      assertEquals(str, c, Ascii.toLowerCase(c));
       assertFalse(str, c == Ascii.toUpperCase(c));
       assertTrue(str, Ascii.isLowerCase(c));
       assertFalse(str, Ascii.isUpperCase(c));
@@ -75,7 +75,7 @@ public class AsciiTest extends TestCase {
     for (char c : UPPER.toCharArray()) {
       String str = String.valueOf(c);
       assertFalse(str, c == Ascii.toLowerCase(c));
-      assertTrue(str, c == Ascii.toUpperCase(c));
+      assertEquals(str, c, Ascii.toUpperCase(c));
       assertFalse(str, Ascii.isLowerCase(c));
       assertTrue(str, Ascii.isUpperCase(c));
     }
@@ -98,27 +98,26 @@ public class AsciiTest extends TestCase {
   }
 
   public void testTruncateIllegalArguments() {
-    String truncated = null;
     try {
-      truncated = Ascii.truncate("foobar", 2, "...");
+      Ascii.truncate("foobar", 2, "...");
       fail();
     } catch (IllegalArgumentException expected) {
     }
 
     try {
-      truncated = Ascii.truncate("foobar", 8, "1234567890");
+      Ascii.truncate("foobar", 8, "1234567890");
       fail();
     } catch (IllegalArgumentException expected) {
     }
 
     try {
-      truncated = Ascii.truncate("foobar", -1, "...");
+      Ascii.truncate("foobar", -1, "...");
       fail();
     } catch (IllegalArgumentException expected) {
     }
 
     try {
-      truncated = Ascii.truncate("foobar", -1, "");
+      Ascii.truncate("foobar", -1, "");
       fail();
     } catch (IllegalArgumentException expected) {
     }


### PR DESCRIPTION
1. Remove unused variable 'unused' declare
2. Remove unused variable 'truncated' declare
3. Remove unused 'throw Exception' declare
4. Fix typo 'a' to 'an'
5. Simplify assertTrue(string, boolean) to assertEquals(string, char, char)