### PR TITLE
Improve tests

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/MapInterfaceTest.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/MapInterfaceTest.java
@@ -844,8 +844,9 @@ public abstract class MapInterfaceTest<K, V> extends TestCase {
       return;
     }
 
-    assertEquals(map, map);
-    assertEquals(makePopulatedMap(), map);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(map.equals(map));
+    assertTrue(makePopulatedMap().equals(map));
     assertFalse(map.equals(Collections.emptyMap()));
     // no-inspection ObjectEqualsNull
     assertFalse(map.equals(null));
@@ -895,8 +896,9 @@ public abstract class MapInterfaceTest<K, V> extends TestCase {
       return;
     }
 
-    assertEquals(map, map);
-    assertEquals(makeEmptyMap(), map);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(map.equals(map));
+    assertTrue(makeEmptyMap().equals(map));
     assertEquals(Collections.emptyMap(), map);
     assertFalse(map.equals(Collections.emptySet()));
     // noinspection ObjectEqualsNull

--- a/android/guava-testlib/src/com/google/common/testing/EqualsTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/EqualsTester.java
@@ -122,7 +122,7 @@ public final class EqualsTester {
       assertTrue(
           item + " must not be Object#equals to an arbitrary object of another class",
           !item.equals(NotAnInstance.EQUAL_TO_NOTHING));
-      assertEquals(item + " must be Object#equals to itself", item, item);
+      assertTrue(item + " must be Object#equals to itself", item.equals(item));
       assertEquals(
           "the Object#hashCode of " + item + " must be consistent",
           item.hashCode(),

--- a/android/guava-tests/test/com/google/common/base/CharMatcherTest.java
+++ b/android/guava-tests/test/com/google/common/base/CharMatcherTest.java
@@ -386,7 +386,7 @@ public class CharMatcherTest extends TestCase {
     assertSame(s, matcher.replaceFrom(s, 'z'));
     assertSame(s, matcher.replaceFrom(s, "ZZ"));
     assertSame(s, matcher.trimFrom(s));
-    assertSame(0, matcher.countIn(s));
+    assertEquals(0, matcher.countIn(s));
   }
 
   private void reallyTestMatchThenNoMatch(CharMatcher matcher, String s) {

--- a/android/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/android/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -232,7 +232,7 @@ public class LocalCacheTest extends TestCase {
 
   private Throwable popLoggedThrowable() {
     List<LogRecord> logRecords = logHandler.getStoredLogRecords();
-    assertSame(1, logRecords.size());
+    assertEquals(1, logRecords.size());
     LogRecord logRecord = logRecords.get(0);
     logHandler.clear();
     return logRecord.getThrown();

--- a/android/guava-tests/test/com/google/common/collect/AbstractMapEntryTest.java
+++ b/android/guava-tests/test/com/google/common/collect/AbstractMapEntryTest.java
@@ -61,7 +61,8 @@ public class AbstractMapEntryTest extends TestCase {
 
   public void testEquals() {
     Entry<String, Integer> foo1 = entry("foo", 1);
-    assertEquals(foo1, foo1);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(foo1.equals(foo1));
     assertEquals(control("foo", 1), foo1);
     assertEquals(control("bar", 2), entry("bar", 2));
     assertFalse(control("foo", 1).equals(entry("foo", 2)));

--- a/android/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -619,14 +619,14 @@ public class ListsTest extends TestCase {
 
   public void testCartesianProduct_indexOf() {
     List<List<Integer>> actual = Lists.cartesianProduct(list(1, 2), list(3, 4));
-    assertEquals(actual.indexOf(list(1, 3)), 0);
-    assertEquals(actual.indexOf(list(1, 4)), 1);
-    assertEquals(actual.indexOf(list(2, 3)), 2);
-    assertEquals(actual.indexOf(list(2, 4)), 3);
-    assertEquals(actual.indexOf(list(3, 1)), -1);
+    assertEquals(0, actual.indexOf(list(1, 3)));
+    assertEquals(1, actual.indexOf(list(1, 4)));
+    assertEquals(2, actual.indexOf(list(2, 3)));
+    assertEquals(3, actual.indexOf(list(2, 4)));
+    assertEquals(-1, actual.indexOf(list(3, 1)));
 
-    assertEquals(actual.indexOf(list(1)), -1);
-    assertEquals(actual.indexOf(list(1, 1, 1)), -1);
+    assertEquals(-1, actual.indexOf(list(1)));
+    assertEquals(-1, actual.indexOf(list(1, 1, 1)));
   }
 
   public void testCartesianProduct_lastIndexOf() {

--- a/android/guava-tests/test/com/google/common/collect/MapsTest.java
+++ b/android/guava-tests/test/com/google/common/collect/MapsTest.java
@@ -1153,8 +1153,8 @@ public class MapsTest extends TestCase {
     biMap.put("two", 2);
     Converter<String, Integer> converter = Maps.asConverter(biMap);
 
-    assertSame(1, converter.convert("one"));
-    assertSame(2, converter.convert("two"));
+    assertEquals((Integer) 1, converter.convert("one"));
+    assertEquals((Integer) 2, converter.convert("two"));
     try {
       converter.convert("three");
       fail();
@@ -1163,9 +1163,9 @@ public class MapsTest extends TestCase {
 
     biMap.put("three", 3);
 
-    assertSame(1, converter.convert("one"));
-    assertSame(2, converter.convert("two"));
-    assertSame(3, converter.convert("three"));
+    assertEquals((Integer) 1, converter.convert("one"));
+    assertEquals((Integer) 2, converter.convert("two"));
+    assertEquals((Integer) 3, converter.convert("three"));
   }
 
   public void testAsConverter_withNullMapping() throws Exception {

--- a/android/guava-tests/test/com/google/common/collect/MultimapsTest.java
+++ b/android/guava-tests/test/com/google/common/collect/MultimapsTest.java
@@ -610,7 +610,8 @@ public class MultimapsTest extends TestCase {
     assertEquals("[3, 1, 4]", ummodifiable.get(Color.BLUE).toString());
 
     Collection<Integer> collection = multimap.get(Color.BLUE);
-    assertEquals(collection, collection);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(collection.equals(collection));
 
     assertFalse(multimap.keySet() instanceof SortedSet);
     assertFalse(multimap.asMap() instanceof SortedMap);

--- a/android/guava-tests/test/com/google/common/math/IntMathTest.java
+++ b/android/guava-tests/test/com/google/common/math/IntMathTest.java
@@ -137,10 +137,10 @@ public class IntMathTest extends TestCase {
   @GwtIncompatible // BigIntegerMath // TODO(cpovirk): GWT-enable BigIntegerMath
   public void testConstantsHalfPowersOf10() {
     for (int i = 0; i < IntMath.halfPowersOf10.length; i++) {
-      assert IntMath.halfPowersOf10[i]
-          == Math.min(
+      assertEquals(IntMath.halfPowersOf10[i],
+          Math.min(
               Integer.MAX_VALUE,
-              BigIntegerMath.sqrt(BigInteger.TEN.pow(2 * i + 1), FLOOR).longValue());
+              BigIntegerMath.sqrt(BigInteger.TEN.pow(2 * i + 1), FLOOR).longValue()));
     }
   }
 

--- a/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -299,7 +299,8 @@ public class BooleansTest extends TestCase {
     assertEquals(1, Booleans.asList(ARRAY_FALSE_TRUE).lastIndexOf(true));
     List<Boolean> reference = Booleans.asList(ARRAY_FALSE);
     assertEquals(Booleans.asList(ARRAY_FALSE), reference);
-    assertEquals(reference, reference);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(reference.equals(reference));
   }
 
   public void testAsListHashcode() {

--- a/android/guava-tests/test/com/google/common/util/concurrent/AtomicLongMapTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/AtomicLongMapTest.java
@@ -52,7 +52,7 @@ public class AtomicLongMapTest extends TestCase {
     Map<String, Long> in = ImmutableMap.of("1", 1L, "2", 2L, "3", 3L);
     AtomicLongMap<String> map = AtomicLongMap.create(in);
     assertFalse(map.isEmpty());
-    assertSame(3, map.size());
+    assertEquals(3, map.size());
     assertTrue(map.containsKey("1"));
     assertTrue(map.containsKey("2"));
     assertTrue(map.containsKey("3"));
@@ -302,7 +302,7 @@ public class AtomicLongMapTest extends TestCase {
     Map<String, Long> in = ImmutableMap.of("1", 1L, "2", 2L, "3", 3L);
     AtomicLongMap<String> map = AtomicLongMap.create();
     assertTrue(map.isEmpty());
-    assertSame(0, map.size());
+    assertEquals(0, map.size());
     assertFalse(map.containsKey("1"));
     assertFalse(map.containsKey("2"));
     assertFalse(map.containsKey("3"));
@@ -312,7 +312,7 @@ public class AtomicLongMapTest extends TestCase {
 
     map.putAll(in);
     assertFalse(map.isEmpty());
-    assertSame(3, map.size());
+    assertEquals(3, map.size());
     assertTrue(map.containsKey("1"));
     assertTrue(map.containsKey("2"));
     assertTrue(map.containsKey("3"));

--- a/guava-testlib/src/com/google/common/collect/testing/MapInterfaceTest.java
+++ b/guava-testlib/src/com/google/common/collect/testing/MapInterfaceTest.java
@@ -844,8 +844,9 @@ public abstract class MapInterfaceTest<K, V> extends TestCase {
       return;
     }
 
-    assertEquals(map, map);
-    assertEquals(makePopulatedMap(), map);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(map.equals(map));
+    assertTrue(makePopulatedMap().equals(map));
     assertFalse(map.equals(Collections.emptyMap()));
     // no-inspection ObjectEqualsNull
     assertFalse(map.equals(null));
@@ -895,8 +896,9 @@ public abstract class MapInterfaceTest<K, V> extends TestCase {
       return;
     }
 
-    assertEquals(map, map);
-    assertEquals(makeEmptyMap(), map);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(map.equals(map));
+    assertTrue(makeEmptyMap().equals(map));
     assertEquals(Collections.emptyMap(), map);
     assertFalse(map.equals(Collections.emptySet()));
     // noinspection ObjectEqualsNull

--- a/guava-testlib/src/com/google/common/testing/EqualsTester.java
+++ b/guava-testlib/src/com/google/common/testing/EqualsTester.java
@@ -122,7 +122,7 @@ public final class EqualsTester {
       assertTrue(
           item + " must not be Object#equals to an arbitrary object of another class",
           !item.equals(NotAnInstance.EQUAL_TO_NOTHING));
-      assertEquals(item + " must be Object#equals to itself", item, item);
+      assertTrue(item + " must be Object#equals to itself", item.equals(item));
       assertEquals(
           "the Object#hashCode of " + item + " must be consistent",
           item.hashCode(),

--- a/guava-tests/test/com/google/common/base/CharMatcherTest.java
+++ b/guava-tests/test/com/google/common/base/CharMatcherTest.java
@@ -386,7 +386,7 @@ public class CharMatcherTest extends TestCase {
     assertSame(s, matcher.replaceFrom(s, 'z'));
     assertSame(s, matcher.replaceFrom(s, "ZZ"));
     assertSame(s, matcher.trimFrom(s));
-    assertSame(0, matcher.countIn(s));
+    assertEquals(0, matcher.countIn(s));
   }
 
   private void reallyTestMatchThenNoMatch(CharMatcher matcher, String s) {

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -229,7 +229,7 @@ public class LocalCacheTest extends TestCase {
 
   private Throwable popLoggedThrowable() {
     List<LogRecord> logRecords = logHandler.getStoredLogRecords();
-    assertSame(1, logRecords.size());
+    assertEquals(1, logRecords.size());
     LogRecord logRecord = logRecords.get(0);
     logHandler.clear();
     return logRecord.getThrown();

--- a/guava-tests/test/com/google/common/collect/AbstractMapEntryTest.java
+++ b/guava-tests/test/com/google/common/collect/AbstractMapEntryTest.java
@@ -61,7 +61,8 @@ public class AbstractMapEntryTest extends TestCase {
 
   public void testEquals() {
     Entry<String, Integer> foo1 = entry("foo", 1);
-    assertEquals(foo1, foo1);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(foo1.equals(foo1));
     assertEquals(control("foo", 1), foo1);
     assertEquals(control("bar", 2), entry("bar", 2));
     assertFalse(control("foo", 1).equals(entry("foo", 2)));

--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -619,14 +619,14 @@ public class ListsTest extends TestCase {
 
   public void testCartesianProduct_indexOf() {
     List<List<Integer>> actual = Lists.cartesianProduct(list(1, 2), list(3, 4));
-    assertEquals(actual.indexOf(list(1, 3)), 0);
-    assertEquals(actual.indexOf(list(1, 4)), 1);
-    assertEquals(actual.indexOf(list(2, 3)), 2);
-    assertEquals(actual.indexOf(list(2, 4)), 3);
-    assertEquals(actual.indexOf(list(3, 1)), -1);
+    assertEquals(0, actual.indexOf(list(1, 3)));
+    assertEquals(1, actual.indexOf(list(1, 4)));
+    assertEquals(2, actual.indexOf(list(2, 3)));
+    assertEquals(3, actual.indexOf(list(2, 4)));
+    assertEquals(-1, actual.indexOf(list(3, 1)));
 
-    assertEquals(actual.indexOf(list(1)), -1);
-    assertEquals(actual.indexOf(list(1, 1, 1)), -1);
+    assertEquals(-1, actual.indexOf(list(1)));
+    assertEquals(-1, actual.indexOf(list(1, 1, 1)));
   }
 
   public void testCartesianProduct_lastIndexOf() {

--- a/guava-tests/test/com/google/common/collect/MapsTest.java
+++ b/guava-tests/test/com/google/common/collect/MapsTest.java
@@ -1153,8 +1153,8 @@ public class MapsTest extends TestCase {
     biMap.put("two", 2);
     Converter<String, Integer> converter = Maps.asConverter(biMap);
 
-    assertSame(1, converter.convert("one"));
-    assertSame(2, converter.convert("two"));
+    assertEquals((Integer) 1, converter.convert("one"));
+    assertEquals((Integer) 2, converter.convert("two"));
     try {
       converter.convert("three");
       fail();
@@ -1163,9 +1163,9 @@ public class MapsTest extends TestCase {
 
     biMap.put("three", 3);
 
-    assertSame(1, converter.convert("one"));
-    assertSame(2, converter.convert("two"));
-    assertSame(3, converter.convert("three"));
+    assertEquals((Integer) 1, converter.convert("one"));
+    assertEquals((Integer) 2, converter.convert("two"));
+    assertEquals((Integer) 3, converter.convert("three"));
   }
 
   public void testAsConverter_withNullMapping() throws Exception {

--- a/guava-tests/test/com/google/common/collect/MultimapsTest.java
+++ b/guava-tests/test/com/google/common/collect/MultimapsTest.java
@@ -667,7 +667,8 @@ public class MultimapsTest extends TestCase {
     assertEquals("[3, 1, 4]", ummodifiable.get(Color.BLUE).toString());
 
     Collection<Integer> collection = multimap.get(Color.BLUE);
-    assertEquals(collection, collection);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(collection.equals(collection));
 
     assertFalse(multimap.keySet() instanceof SortedSet);
     assertFalse(multimap.asMap() instanceof SortedMap);

--- a/guava-tests/test/com/google/common/math/IntMathTest.java
+++ b/guava-tests/test/com/google/common/math/IntMathTest.java
@@ -137,10 +137,10 @@ public class IntMathTest extends TestCase {
   @GwtIncompatible // BigIntegerMath // TODO(cpovirk): GWT-enable BigIntegerMath
   public void testConstantsHalfPowersOf10() {
     for (int i = 0; i < IntMath.halfPowersOf10.length; i++) {
-      assert IntMath.halfPowersOf10[i]
-          == Math.min(
+      assertEquals(IntMath.halfPowersOf10[i],
+          Math.min(
               Integer.MAX_VALUE,
-              BigIntegerMath.sqrt(BigInteger.TEN.pow(2 * i + 1), FLOOR).longValue());
+              BigIntegerMath.sqrt(BigInteger.TEN.pow(2 * i + 1), FLOOR).longValue()));
     }
   }
 

--- a/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -299,7 +299,8 @@ public class BooleansTest extends TestCase {
     assertEquals(1, Booleans.asList(ARRAY_FALSE_TRUE).lastIndexOf(true));
     List<Boolean> reference = Booleans.asList(ARRAY_FALSE);
     assertEquals(Booleans.asList(ARRAY_FALSE), reference);
-    assertEquals(reference, reference);
+    // Explicitly call `equals`; `assertEquals` might return fast
+    assertTrue(reference.equals(reference));
   }
 
   public void testAsListHashcode() {

--- a/guava-tests/test/com/google/common/util/concurrent/AtomicLongMapTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AtomicLongMapTest.java
@@ -52,7 +52,7 @@ public class AtomicLongMapTest extends TestCase {
     Map<String, Long> in = ImmutableMap.of("1", 1L, "2", 2L, "3", 3L);
     AtomicLongMap<String> map = AtomicLongMap.create(in);
     assertFalse(map.isEmpty());
-    assertSame(3, map.size());
+    assertEquals(3, map.size());
     assertTrue(map.containsKey("1"));
     assertTrue(map.containsKey("2"));
     assertTrue(map.containsKey("3"));
@@ -302,7 +302,7 @@ public class AtomicLongMapTest extends TestCase {
     Map<String, Long> in = ImmutableMap.of("1", 1L, "2", 2L, "3", 3L);
     AtomicLongMap<String> map = AtomicLongMap.create();
     assertTrue(map.isEmpty());
-    assertSame(0, map.size());
+    assertEquals(0, map.size());
     assertFalse(map.containsKey("1"));
     assertFalse(map.containsKey("2"));
     assertFalse(map.containsKey("3"));
@@ -312,7 +312,7 @@ public class AtomicLongMapTest extends TestCase {
 
     map.putAll(in);
     assertFalse(map.isEmpty());
-    assertSame(3, map.size());
+    assertEquals(3, map.size());
     assertTrue(map.containsKey("1"));
     assertTrue(map.containsKey("2"));
     assertTrue(map.containsKey("3"));


### PR DESCRIPTION
- Fix usage of `assertSame` for primitive values
This just happened to work previously because for small `int` values the boxed `Integer` instances are cached and therefore are the same references.
- Fix switched expected and actual arguments for assertion calls
This would have caused confusing messages in case the test failed.
- Replace usage of `assertEquals` for `equals` implementation tests
_see commit message_