### PR TITLE
Improve efficiency of bulk removals in transformed lists.

### DIFF
--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -551,6 +551,11 @@ public final class Lists {
       this.function = checkNotNull(function);
     }
 
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+      fromList.subList(fromIndex, toIndex).clear();
+    }
+
     /**
      * The default implementation inherited is based on iteration and removal of each element which
      * can be overkill. That's why we forward this call directly to the backing list.
@@ -601,6 +606,11 @@ public final class Lists {
     TransformingRandomAccessList(List<F> fromList, Function<? super F, ? extends T> function) {
       this.fromList = checkNotNull(fromList);
       this.function = checkNotNull(function);
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+      fromList.subList(fromIndex, toIndex).clear();
     }
 
     @Override


### PR DESCRIPTION
Override removeRange(int,int) for Lists.TransformingSequentialList and Lists.TransformingRandomAccessList so that source list has opportunity to do more efficient deletions. Call fromList.subList(from, to).clear() instead of removing with iterator. Re-request of ignored #3372.