### PR TITLE
add one public interface canAcquire to test if it is possible to get …

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -328,6 +328,15 @@ public class RateLimiterTest extends TestCase {
     assertEvents("R0.00", "R1.00", "R1.00", "R0.50", "R1.00", "R2.00");
   }
 
+  public void testCanAcquire(){
+    RateLimiter limiter = RateLimiter.create(5, stopwatch);
+    assertTrue(limiter.canAcquire());
+    assertTrue(limiter.tryAcquire());
+    assertFalse(limiter.canAcquire());
+    stopwatch.sleepMillis(300); //make sure there is a permit generated
+    assertTrue(limiter.canAcquire());
+  }
+
   public void testTryAcquire_noWaitAllowed() {
     RateLimiter limiter = RateLimiter.create(5.0, stopwatch);
     assertTrue(limiter.tryAcquire(0, SECONDS));

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -427,6 +427,16 @@ public abstract class RateLimiter {
   }
 
   /**
+   * to test if client can get at least one permit or not. NOTE this interface would not reserve any permit.
+   *
+   * @return {@code true} if some permits can be acquired, {@code false} otherwise
+   */
+  public boolean canAcquire() {
+    long nowMicros = stopwatch.readMicros();
+    return canAcquire(nowMicros, 0);
+  }
+
+  /**
    * Reserves next ticket and returns the wait time that the caller must wait for.
    *
    * @return the required wait time, never negative


### PR DESCRIPTION
Not sure if there is any other idea to address my requirement, the following is why I want to add one public interface to test if it  is possible to get any permit.

We have a message store service, customer pull messages from our store service. Each time customer just send a pull request (this request ask to pull messages no more than 32), if there is any message in the store, then can return the existing messages even they are less than 32.

So for each pull request, we will search the store to get how many msg we have right now. if there is no msg, then return immediately. If there are msgs, then we response messages no more than 32 immediately.

we want to limit the pull msg TPS to 1K for example. With current RateLimiter interface, we cannot call tryAcquire when the system receive the pull request, since we don't know how many msg we can get from the store. we have to call tryAcquire when we finish the search from store (since we know the number of msg in the search result). So if client call pull very frequently, each time we have to search the store (it would be a heavy burden for store), then we call tryAcquire and refuse the pull request due to 1K limitation.

It's better to refuse the pull request if there is no hope to get any permit when the pull request just arrive (since the 1K limitation). So I think we need to canAcquire interface to test if it is possible to get any permit.
        customer                  msgService 
     pull request   -->        canAcquire (true: continue, false: refuse)
                                          search from the store
                                          tryAcquire (true: continue, false: refuse)
      pull response <--      send response   

