### PR TITLE
Override MapMakerInternalMap#compute

### DIFF
--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -1696,14 +1696,11 @@ class MapMakerInternalMap<
         if (newValue != null) {
           // Update entry
           put(key, hash, newValue, false);
-          return newValue;
-        } else {
+        } else if (oldValue != null) {
           // Remove entry
-          if (oldValue != null || containsKey(key, hash)) {
-            remove(key, hash);
-          }
-          return null;
+          remove(key, hash);
         }
+        return newValue;
       } finally {
         unlock();
       }

--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -1693,10 +1693,12 @@ class MapMakerInternalMap<
       try {
         V oldValue = get(key, hash);
         V newValue = remappingFunction.apply(key, oldValue);
-        if (newValue != null) {
+        if (newValue != null
+            && !map.valueEquivalence().equivalent(oldValue, newValue)) {
           // Update entry
           put(key, hash, newValue, false);
-        } else if (oldValue != null) {
+        } else if (newValue == null
+                   && oldValue != null) {
           // Remove entry
           remove(key, hash);
         }


### PR DESCRIPTION
Ensure that `remappingFunction` is executed atomically (and only once). Prevent excessive lookups in the case of contention.
This is the behavior of `ConcurrentHashMap`

Fixes #5766 