### PR TITLE
Refine examples for mapWithIndex

### DIFF
--- a/guava/src/com/google/common/collect/Streams.java
+++ b/guava/src/com/google/common/collect/Streams.java
@@ -410,10 +410,10 @@ public final class Streams {
    * <pre>{@code
    * mapWithIndex(
    *     Stream.of("a", "b", "c"),
-   *     (str, index) -> str + ":" + index)
+   *     (str, index) -> index + ":" + str)
    * }</pre>
    *
-   * <p>would return {@code Stream.of("a:0", "b:1", "c:2")}.
+   * <p>would return {@code Stream.of("0:a", "1:b", "2:c")}.
    *
    * <p>The resulting stream is <a
    * href="http://gee.cs.oswego.edu/dl/html/StreamParallelGuidance.html">efficiently splittable</a>
@@ -493,11 +493,11 @@ public final class Streams {
    *
    * <pre>{@code
    * mapWithIndex(
-   *     IntStream.of(0, 1, 2),
-   *     (i, index) -> i + ":" + index)
+   *     IntStream.of(2, 1, 0),
+   *     (elem, index) -> index + ":" + elem)
    * }</pre>
    *
-   * <p>...would return {@code Stream.of("0:0", "1:1", "2:2")}.
+   * <p>...would return {@code Stream.of("0:2", "1:1", "2:0")}.
    *
    * <p>The resulting stream is <a
    * href="http://gee.cs.oswego.edu/dl/html/StreamParallelGuidance.html">efficiently splittable</a>
@@ -573,11 +573,11 @@ public final class Streams {
    *
    * <pre>{@code
    * mapWithIndex(
-   *     LongStream.of(0, 1, 2),
-   *     (i, index) -> i + ":" + index)
+   *     LongStream.of(2, 1, 0),
+   *     (elem, index) -> index + ":" + elem)
    * }</pre>
    *
-   * <p>...would return {@code Stream.of("0:0", "1:1", "2:2")}.
+   * <p>...would return {@code Stream.of("0:2", "1:1", "2:0")}.
    *
    * <p>The resulting stream is <a
    * href="http://gee.cs.oswego.edu/dl/html/StreamParallelGuidance.html">efficiently splittable</a>
@@ -653,11 +653,11 @@ public final class Streams {
    *
    * <pre>{@code
    * mapWithIndex(
-   *     DoubleStream.of(0, 1, 2),
-   *     (x, index) -> x + ":" + index)
+   *     DoubleStream.of(2, 1, 0),
+   *     (x, index) -> index + ":" + x)
    * }</pre>
    *
-   * <p>...would return {@code Stream.of("0.0:0", "1.0:1", "2.0:2")}.
+   * <p>...would return {@code Stream.of("0:2.0", "1:1.0", "2:0.0")}.
    *
    * <p>The resulting stream is <a
    * href="http://gee.cs.oswego.edu/dl/html/StreamParallelGuidance.html">efficiently splittable</a>


### PR DESCRIPTION
The examples for `mapWithIndex` are really confusing, due to the following reasons:

1. `i` is always used as an index, which is confused with `index`.
2. `a:b` always represents mapping from a to b, but the examples use it differently.
3. The element `0,1,2` is exactly the same as indices.

We cannot know which argument is index and which one is element from the examples.