### PR TITLE
Init lockFreeBitArray with length to reduce memory

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -877,12 +877,15 @@ public class ImmutableMapTest extends TestCase {
   }
 
   private static <K, V> void assertMapEquals(Map<K, V> map, Object... alternatingKeysAndValues) {
-    assertEquals(map.size(), alternatingKeysAndValues.length / 2);
-    int i = 0;
-    for (Entry<K, V> entry : map.entrySet()) {
-      assertEquals(alternatingKeysAndValues[i++], entry.getKey());
-      assertEquals(alternatingKeysAndValues[i++], entry.getValue());
+    Map<K, V> expected = new LinkedHashMap<>();
+    for (int i = 0; i < alternatingKeysAndValues.length; i += 2) {
+      @SuppressWarnings("unchecked")
+      K key = (K) alternatingKeysAndValues[i];
+      @SuppressWarnings("unchecked")
+      V value = (V) alternatingKeysAndValues[i + 1];
+      expected.put(key, value);
     }
+    assertThat(map).containsExactlyEntriesIn(expected).inOrder();
   }
 
   private static class IntHolder implements Serializable {

--- a/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -178,7 +178,7 @@ public class ImmutableMapTest extends TestCase {
       throw new UnsupportedOperationException();
     }
 
-    private static final Joiner joiner = Joiner.on(", ");
+    private static final Joiner JOINER = Joiner.on(", ");
 
     @Override
     protected void assertMoreInvariants(Map<K, V> map) {
@@ -187,10 +187,10 @@ public class ImmutableMapTest extends TestCase {
         assertEquals(entry.getKey() + "=" + entry.getValue(), entry.toString());
       }
 
-      assertEquals("{" + joiner.join(map.entrySet()) + "}", map.toString());
-      assertEquals("[" + joiner.join(map.entrySet()) + "]", map.entrySet().toString());
-      assertEquals("[" + joiner.join(map.keySet()) + "]", map.keySet().toString());
-      assertEquals("[" + joiner.join(map.values()) + "]", map.values().toString());
+      assertEquals("{" + JOINER.join(map.entrySet()) + "}", map.toString());
+      assertEquals("[" + JOINER.join(map.entrySet()) + "]", map.entrySet().toString());
+      assertEquals("[" + JOINER.join(map.keySet()) + "]", map.keySet().toString());
+      assertEquals("[" + JOINER.join(map.values()) + "]", map.values().toString());
 
       assertEquals(MinimalSet.from(map.entrySet()), map.entrySet());
       assertEquals(Sets.newHashSet(map.keySet()), map.keySet());
@@ -318,12 +318,13 @@ public class ImmutableMapTest extends TestCase {
 
   public static class CreationTests extends TestCase {
     public void testEmptyBuilder() {
-      ImmutableMap<String, Integer> map = new Builder<String, Integer>().build();
+      ImmutableMap<String, Integer> map = new Builder<String, Integer>().buildOrThrow();
       assertEquals(Collections.<String, Integer>emptyMap(), map);
     }
 
     public void testSingletonBuilder() {
-      ImmutableMap<String, Integer> map = new Builder<String, Integer>().put("one", 1).build();
+      ImmutableMap<String, Integer> map =
+          new Builder<String, Integer>().put("one", 1).buildOrThrow();
       assertMapEquals(map, "one", 1);
     }
 
@@ -335,7 +336,7 @@ public class ImmutableMapTest extends TestCase {
               .put("three", 3)
               .put("four", 4)
               .put("five", 5)
-              .build();
+              .buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
@@ -348,7 +349,7 @@ public class ImmutableMapTest extends TestCase {
       }
       Object[] builderArrayAfterPuts = builder.alternatingKeysAndValues;
       RegularImmutableMap<Integer, Integer> map =
-          (RegularImmutableMap<Integer, Integer>) builder.build();
+          (RegularImmutableMap<Integer, Integer>) builder.buildOrThrow();
       Object[] mapInternalArray = map.alternatingKeysAndValues;
       assertSame(builderArray, builderArrayAfterPuts);
       assertSame(builderArray, mapInternalArray);
@@ -363,16 +364,16 @@ public class ImmutableMapTest extends TestCase {
               .put("five", 5)
               .put("four", 4)
               .put("two", 2)
-              .build();
+              .buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
     public void testBuilder_orderEntriesByValueAfterExactSizeBuild() {
       Builder<String, Integer> builder =
           new Builder<String, Integer>(2).put("four", 4).put("one", 1);
-      ImmutableMap<String, Integer> keyOrdered = builder.build();
+      ImmutableMap<String, Integer> keyOrdered = builder.buildOrThrow();
       ImmutableMap<String, Integer> valueOrdered =
-          builder.orderEntriesByValue(Ordering.natural()).build();
+          builder.orderEntriesByValue(Ordering.natural()).buildOrThrow();
       assertMapEquals(keyOrdered, "four", 4, "one", 1);
       assertMapEquals(valueOrdered, "one", 1, "four", 4);
     }
@@ -389,7 +390,7 @@ public class ImmutableMapTest extends TestCase {
 
     public void testBuilder_withImmutableEntry() {
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().put(Maps.immutableEntry("one", 1)).build();
+          new Builder<String, Integer>().put(Maps.immutableEntry("one", 1)).buildOrThrow();
       assertMapEquals(map, "one", 1);
     }
 
@@ -430,12 +431,14 @@ public class ImmutableMapTest extends TestCase {
 
       builder.put(entry);
       holder.string = "two";
-      assertMapEquals(builder.build(), "one", 1);
+      assertMapEquals(builder.buildOrThrow(), "one", 1);
     }
 
     public void testBuilderPutAllWithEmptyMap() {
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().putAll(Collections.<String, Integer>emptyMap()).build();
+          new Builder<String, Integer>()
+              .putAll(Collections.<String, Integer>emptyMap())
+              .buildOrThrow();
       assertEquals(Collections.<String, Integer>emptyMap(), map);
     }
 
@@ -449,14 +452,14 @@ public class ImmutableMapTest extends TestCase {
       moreToPut.put("five", 5);
 
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().putAll(toPut).putAll(moreToPut).build();
+          new Builder<String, Integer>().putAll(toPut).putAll(moreToPut).buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
     public void testBuilderReuse() {
       Builder<String, Integer> builder = new Builder<>();
-      ImmutableMap<String, Integer> mapOne = builder.put("one", 1).put("two", 2).build();
-      ImmutableMap<String, Integer> mapTwo = builder.put("three", 3).put("four", 4).build();
+      ImmutableMap<String, Integer> mapOne = builder.put("one", 1).put("two", 2).buildOrThrow();
+      ImmutableMap<String, Integer> mapTwo = builder.put("three", 3).put("four", 4).buildOrThrow();
 
       assertMapEquals(mapOne, "one", 1, "two", 2);
       assertMapEquals(mapTwo, "one", 1, "two", 2, "three", 3, "four", 4);
@@ -470,7 +473,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     public void testBuilderPutImmutableEntryWithNullKeyFailsAtomically() {
@@ -481,7 +484,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     // for GWT compatibility
@@ -513,7 +516,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     public void testBuilderPutNullKey() {
@@ -559,7 +562,7 @@ public class ImmutableMapTest extends TestCase {
               .put("one", 1); // throwing on this line would be even better
 
       try {
-        builder.build();
+        builder.buildOrThrow();
         fail();
       } catch (IllegalArgumentException expected) {
       }
@@ -985,50 +988,53 @@ public class ImmutableMapTest extends TestCase {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            ImmutableMap.of(), ImmutableMap.builder().build(), ImmutableMap.ofEntries(), map())
+            ImmutableMap.of(),
+            ImmutableMap.builder().buildOrThrow(),
+            ImmutableMap.ofEntries(),
+            map())
         .addEqualityGroup(
             ImmutableMap.of(1, 1),
-            ImmutableMap.builder().put(1, 1).build(),
+            ImmutableMap.builder().put(1, 1).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1)),
             map(1, 1))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2),
-            ImmutableMap.builder().put(1, 1).put(2, 2).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2)),
             map(1, 1, 2, 2))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3)),
             map(1, 1, 2, 2, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 4, 2, 2, 3, 3),
-            ImmutableMap.builder().put(1, 4).put(2, 2).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 4).put(2, 2).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 4), entry(2, 2), entry(3, 3)),
             map(1, 4, 2, 2, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 4, 3, 3),
-            ImmutableMap.builder().put(1, 1).put(2, 4).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 4).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 4), entry(3, 3)),
             map(1, 1, 2, 4, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 4),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 4).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 4).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 4)),
             map(1, 1, 2, 2, 3, 4))
         .addEqualityGroup(
             ImmutableMap.of(1, 2, 2, 3, 3, 1),
-            ImmutableMap.builder().put(1, 2).put(2, 3).put(3, 1).build(),
+            ImmutableMap.builder().put(1, 2).put(2, 3).put(3, 1).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 2), entry(2, 3), entry(3, 1)),
             map(1, 2, 2, 3, 3, 1))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3, 4, 4),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3), entry(4, 4)),
             map(1, 1, 2, 2, 3, 3, 4, 4))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3, 4, 4, 5, 5),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).put(5, 5).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).put(5, 5).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3), entry(4, 4), entry(5, 5)),
             map(1, 1, 2, 2, 3, 3, 4, 4, 5, 5))
         .testEquals();

--- a/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -208,7 +208,7 @@ public class ImmutableMapTest extends TestCase {
       throw new UnsupportedOperationException();
     }
 
-    private static final Joiner joiner = Joiner.on(", ");
+    private static final Joiner JOINER = Joiner.on(", ");
 
     @Override
     protected void assertMoreInvariants(Map<K, V> map) {
@@ -217,10 +217,10 @@ public class ImmutableMapTest extends TestCase {
         assertEquals(entry.getKey() + "=" + entry.getValue(), entry.toString());
       }
 
-      assertEquals("{" + joiner.join(map.entrySet()) + "}", map.toString());
-      assertEquals("[" + joiner.join(map.entrySet()) + "]", map.entrySet().toString());
-      assertEquals("[" + joiner.join(map.keySet()) + "]", map.keySet().toString());
-      assertEquals("[" + joiner.join(map.values()) + "]", map.values().toString());
+      assertEquals("{" + JOINER.join(map.entrySet()) + "}", map.toString());
+      assertEquals("[" + JOINER.join(map.entrySet()) + "]", map.entrySet().toString());
+      assertEquals("[" + JOINER.join(map.keySet()) + "]", map.keySet().toString());
+      assertEquals("[" + JOINER.join(map.values()) + "]", map.values().toString());
 
       assertEquals(MinimalSet.from(map.entrySet()), map.entrySet());
       assertEquals(Sets.newHashSet(map.keySet()), map.keySet());
@@ -348,12 +348,13 @@ public class ImmutableMapTest extends TestCase {
 
   public static class CreationTests extends TestCase {
     public void testEmptyBuilder() {
-      ImmutableMap<String, Integer> map = new Builder<String, Integer>().build();
+      ImmutableMap<String, Integer> map = new Builder<String, Integer>().buildOrThrow();
       assertEquals(Collections.<String, Integer>emptyMap(), map);
     }
 
     public void testSingletonBuilder() {
-      ImmutableMap<String, Integer> map = new Builder<String, Integer>().put("one", 1).build();
+      ImmutableMap<String, Integer> map =
+          new Builder<String, Integer>().put("one", 1).buildOrThrow();
       assertMapEquals(map, "one", 1);
     }
 
@@ -365,7 +366,7 @@ public class ImmutableMapTest extends TestCase {
               .put("three", 3)
               .put("four", 4)
               .put("five", 5)
-              .build();
+              .buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
@@ -378,7 +379,7 @@ public class ImmutableMapTest extends TestCase {
       }
       Entry<Integer, Integer>[] builderArrayAfterPuts = builder.entries;
       RegularImmutableMap<Integer, Integer> map =
-          (RegularImmutableMap<Integer, Integer>) builder.build();
+          (RegularImmutableMap<Integer, Integer>) builder.buildOrThrow();
       Entry<Integer, Integer>[] mapInternalArray = map.entries;
       assertSame(builderArray, builderArrayAfterPuts);
       assertSame(builderArray, mapInternalArray);
@@ -393,16 +394,16 @@ public class ImmutableMapTest extends TestCase {
               .put("five", 5)
               .put("four", 4)
               .put("two", 2)
-              .build();
+              .buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
     public void testBuilder_orderEntriesByValueAfterExactSizeBuild() {
       Builder<String, Integer> builder =
           new Builder<String, Integer>(2).put("four", 4).put("one", 1);
-      ImmutableMap<String, Integer> keyOrdered = builder.build();
+      ImmutableMap<String, Integer> keyOrdered = builder.buildOrThrow();
       ImmutableMap<String, Integer> valueOrdered =
-          builder.orderEntriesByValue(Ordering.natural()).build();
+          builder.orderEntriesByValue(Ordering.natural()).buildOrThrow();
       assertMapEquals(keyOrdered, "four", 4, "one", 1);
       assertMapEquals(valueOrdered, "one", 1, "four", 4);
     }
@@ -419,7 +420,7 @@ public class ImmutableMapTest extends TestCase {
 
     public void testBuilder_withImmutableEntry() {
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().put(Maps.immutableEntry("one", 1)).build();
+          new Builder<String, Integer>().put(Maps.immutableEntry("one", 1)).buildOrThrow();
       assertMapEquals(map, "one", 1);
     }
 
@@ -460,12 +461,14 @@ public class ImmutableMapTest extends TestCase {
 
       builder.put(entry);
       holder.string = "two";
-      assertMapEquals(builder.build(), "one", 1);
+      assertMapEquals(builder.buildOrThrow(), "one", 1);
     }
 
     public void testBuilderPutAllWithEmptyMap() {
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().putAll(Collections.<String, Integer>emptyMap()).build();
+          new Builder<String, Integer>()
+              .putAll(Collections.<String, Integer>emptyMap())
+              .buildOrThrow();
       assertEquals(Collections.<String, Integer>emptyMap(), map);
     }
 
@@ -479,14 +482,14 @@ public class ImmutableMapTest extends TestCase {
       moreToPut.put("five", 5);
 
       ImmutableMap<String, Integer> map =
-          new Builder<String, Integer>().putAll(toPut).putAll(moreToPut).build();
+          new Builder<String, Integer>().putAll(toPut).putAll(moreToPut).buildOrThrow();
       assertMapEquals(map, "one", 1, "two", 2, "three", 3, "four", 4, "five", 5);
     }
 
     public void testBuilderReuse() {
       Builder<String, Integer> builder = new Builder<>();
-      ImmutableMap<String, Integer> mapOne = builder.put("one", 1).put("two", 2).build();
-      ImmutableMap<String, Integer> mapTwo = builder.put("three", 3).put("four", 4).build();
+      ImmutableMap<String, Integer> mapOne = builder.put("one", 1).put("two", 2).buildOrThrow();
+      ImmutableMap<String, Integer> mapTwo = builder.put("three", 3).put("four", 4).buildOrThrow();
 
       assertMapEquals(mapOne, "one", 1, "two", 2);
       assertMapEquals(mapTwo, "one", 1, "two", 2, "three", 3, "four", 4);
@@ -500,7 +503,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     public void testBuilderPutImmutableEntryWithNullKeyFailsAtomically() {
@@ -511,7 +514,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     // for GWT compatibility
@@ -543,7 +546,7 @@ public class ImmutableMapTest extends TestCase {
       } catch (NullPointerException expected) {
       }
       builder.put("foo", 2);
-      assertMapEquals(builder.build(), "foo", 2);
+      assertMapEquals(builder.buildOrThrow(), "foo", 2);
     }
 
     public void testBuilderPutNullKey() {
@@ -589,7 +592,7 @@ public class ImmutableMapTest extends TestCase {
               .put("one", 1); // throwing on this line would be even better
 
       try {
-        builder.build();
+        builder.buildOrThrow();
         fail();
       } catch (IllegalArgumentException expected) {
       }
@@ -1077,57 +1080,60 @@ public class ImmutableMapTest extends TestCase {
             .put(4, 4)
             .put(5, 5)
             .put(6, 6)
-            .build();
+            .buildOrThrow();
     assertNotNull(map.keySet().spliterator().trySplit());
   }
 
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            ImmutableMap.of(), ImmutableMap.builder().build(), ImmutableMap.ofEntries(), map())
+            ImmutableMap.of(),
+            ImmutableMap.builder().buildOrThrow(),
+            ImmutableMap.ofEntries(),
+            map())
         .addEqualityGroup(
             ImmutableMap.of(1, 1),
-            ImmutableMap.builder().put(1, 1).build(),
+            ImmutableMap.builder().put(1, 1).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1)),
             map(1, 1))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2),
-            ImmutableMap.builder().put(1, 1).put(2, 2).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2)),
             map(1, 1, 2, 2))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3)),
             map(1, 1, 2, 2, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 4, 2, 2, 3, 3),
-            ImmutableMap.builder().put(1, 4).put(2, 2).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 4).put(2, 2).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 4), entry(2, 2), entry(3, 3)),
             map(1, 4, 2, 2, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 4, 3, 3),
-            ImmutableMap.builder().put(1, 1).put(2, 4).put(3, 3).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 4).put(3, 3).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 4), entry(3, 3)),
             map(1, 1, 2, 4, 3, 3))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 4),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 4).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 4).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 4)),
             map(1, 1, 2, 2, 3, 4))
         .addEqualityGroup(
             ImmutableMap.of(1, 2, 2, 3, 3, 1),
-            ImmutableMap.builder().put(1, 2).put(2, 3).put(3, 1).build(),
+            ImmutableMap.builder().put(1, 2).put(2, 3).put(3, 1).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 2), entry(2, 3), entry(3, 1)),
             map(1, 2, 2, 3, 3, 1))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3, 4, 4),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3), entry(4, 4)),
             map(1, 1, 2, 2, 3, 3, 4, 4))
         .addEqualityGroup(
             ImmutableMap.of(1, 1, 2, 2, 3, 3, 4, 4, 5, 5),
-            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).put(5, 5).build(),
+            ImmutableMap.builder().put(1, 1).put(2, 2).put(3, 3).put(4, 4).put(5, 5).buildOrThrow(),
             ImmutableMap.ofEntries(entry(1, 1), entry(2, 2), entry(3, 3), entry(4, 4), entry(5, 5)),
             map(1, 1, 2, 2, 3, 3, 4, 4, 5, 5))
         .testEquals();
@@ -1179,7 +1185,7 @@ public class ImmutableMapTest extends TestCase {
         Arrays.asList(
             new AbstractMap.SimpleEntry<>("a", "1"), new AbstractMap.SimpleEntry<>("b", "2"));
     ImmutableMap<String, String> map =
-        ImmutableMap.<String, String>builder().putAll(entryList).build();
+        ImmutableMap.<String, String>builder().putAll(entryList).buildOrThrow();
     assertThat(map).containsExactly("a", "1", "b", "2").inOrder();
     entryList.get(0).setValue("3");
     assertThat(map).containsExactly("a", "1", "b", "2").inOrder();
@@ -1232,7 +1238,7 @@ public class ImmutableMapTest extends TestCase {
           for (Object k : keys) {
             builder.put(k, "dummy value");
           }
-          return builder.build();
+          return builder.buildOrThrow();
         }
       },
       BUILDER_PUT_ENTRIES_ONE_BY_ONE {
@@ -1242,7 +1248,7 @@ public class ImmutableMapTest extends TestCase {
           for (Object k : keys) {
             builder.put(Maps.immutableEntry(k, "dummy value"));
           }
-          return builder.build();
+          return builder.buildOrThrow();
         }
       },
       BUILDER_PUT_ALL_MAP {
@@ -1254,7 +1260,7 @@ public class ImmutableMapTest extends TestCase {
               throw new UnsupportedOperationException("duplicate key");
             }
           }
-          return ImmutableMap.builder().putAll(sourceMap).build();
+          return ImmutableMap.builder().putAll(sourceMap).buildOrThrow();
         }
       },
       BUILDER_PUT_ALL_ENTRIES {
@@ -1262,7 +1268,7 @@ public class ImmutableMapTest extends TestCase {
         public Map<Object, Object> create(List<?> keys) {
           return ImmutableMap.builder()
               .putAll(Lists.transform(keys, k -> Maps.immutableEntry(k, "dummy value")))
-              .build();
+              .buildOrThrow();
         }
       },
       FORCE_JDK {

--- a/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -894,12 +894,15 @@ public class ImmutableMapTest extends TestCase {
   }
 
   private static <K, V> void assertMapEquals(Map<K, V> map, Object... alternatingKeysAndValues) {
-    assertEquals(map.size(), alternatingKeysAndValues.length / 2);
-    int i = 0;
-    for (Entry<K, V> entry : map.entrySet()) {
-      assertEquals(alternatingKeysAndValues[i++], entry.getKey());
-      assertEquals(alternatingKeysAndValues[i++], entry.getValue());
+    Map<K, V> expected = new LinkedHashMap<>();
+    for (int i = 0; i < alternatingKeysAndValues.length; i += 2) {
+      @SuppressWarnings("unchecked")
+      K key = (K) alternatingKeysAndValues[i];
+      @SuppressWarnings("unchecked")
+      V value = (V) alternatingKeysAndValues[i + 1];
+      expected.put(key, value);
     }
+    assertThat(map).containsExactlyEntriesIn(expected).inOrder();
   }
 
   private static class IntHolder implements Serializable {


### PR DESCRIPTION
Fixes: google#5770

Initializing LockFreeBitArray with bit array would clone (while creating AtomicLongarray) the array passed in the background doubling the memory consumed. Previous logic also used a local variable that was holding the data that would be cloned again later.

Fix - Initialize the LockFreeBitArray with length initially and populate the array with bits directly from the dataStream.