### PR TITLE
Fix confusing Javadoc of memoizeWithExpiration

### DIFF
--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -203,10 +203,9 @@ public final class Suppliers {
   }
 
   /**
-   * Returns a supplier that caches the instance supplied by the delegate and removes the cached
-   * value after the specified time has passed. Subsequent calls to {@code get()} return the cached
-   * value if the expiration time has not passed. After the expiration time, a new value is
-   * retrieved, cached, and returned. See: <a
+   * Returns a supplier that caches the instance supplied by the delegate. Subsequent calls to
+   * {@code get()} return the cached value if the expiration time has not passed. When called
+   * after the expiration time, a new value is retrieved, cached, and returned. See: <a
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the


### PR DESCRIPTION
The previous wording could be read such that the cache is cleared in
the background once the expiration time is reached. However this is
not the case, so we simply remove the following part of the Javadoc:
"and removes the cached value after the specified time has passed"
The rest of the Javadoc already accurately describes the behavior,
though the part with "After the expiration time" could again be
misinterpreted, so we rewrite this to clarify that things only
happen once the "get" method is called.