### PR TITLE
Replaces all deprecated junit.framework.Assert imports

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
@@ -16,8 +16,8 @@
 
 package com.google.common.collect.testing;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import java.util.ArrayList;

--- a/android/guava-testlib/src/com/google/common/collect/testing/Helpers.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/Helpers.java
@@ -17,9 +17,9 @@
 package com.google.common.collect.testing;
 
 import static java.util.Collections.sort;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -37,7 +37,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 @GwtCompatible(emulated = true)

--- a/android/guava-testlib/src/com/google/common/collect/testing/google/GoogleHelpers.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/google/GoogleHelpers.java
@@ -16,7 +16,7 @@
 
 package com.google.common.collect.testing.google;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.Multimap;

--- a/android/guava-testlib/src/com/google/common/collect/testing/google/SetGenerators.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/google/SetGenerators.java
@@ -23,7 +23,7 @@ import static com.google.common.collect.testing.SampleElements.Strings.AFTER_LAS
 import static com.google.common.collect.testing.SampleElements.Strings.AFTER_LAST_2;
 import static com.google.common.collect.testing.SampleElements.Strings.BEFORE_FIRST;
 import static com.google.common.collect.testing.SampleElements.Strings.BEFORE_FIRST_2;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;

--- a/android/guava-testlib/src/com/google/common/escape/testing/EscaperAsserts.java
+++ b/android/guava-testlib/src/com/google/common/escape/testing/EscaperAsserts.java
@@ -24,7 +24,7 @@ import com.google.common.escape.CharEscaper;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.UnicodeEscaper;
 import java.io.IOException;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * Extra assert methods for testing Escaper implementations.

--- a/android/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.CheckForNull;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 /**

--- a/android/guava-testlib/src/com/google/common/testing/EqualsTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/EqualsTester.java
@@ -17,8 +17,8 @@
 package com.google.common.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Equivalence;

--- a/android/guava-testlib/src/com/google/common/testing/EquivalenceTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/EquivalenceTester.java
@@ -17,8 +17,8 @@
 package com.google.common.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Equivalence;

--- a/android/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
@@ -19,8 +19,8 @@ package com.google.common.testing;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;

--- a/android/guava-testlib/src/com/google/common/testing/NullPointerTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/NullPointerTester.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.CheckForNull;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 /**

--- a/android/guava-testlib/src/com/google/common/testing/SerializableTester.java
+++ b/android/guava-testlib/src/com/google/common/testing/SerializableTester.java
@@ -17,7 +17,7 @@
 package com.google.common.testing;
 
 import com.google.common.annotations.GwtCompatible;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 /**

--- a/android/guava-testlib/src/com/google/common/util/concurrent/testing/MockFutureListener.java
+++ b/android/guava-testlib/src/com/google/common/util/concurrent/testing/MockFutureListener.java
@@ -24,7 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * A simple mock implementation of {@code Runnable} that can be used for testing ListenableFutures.

--- a/android/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/android/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -16,13 +16,13 @@ package com.google.common.cache;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.cache.LocalCache.LocalLoadingCache;

--- a/android/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
+++ b/android/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
@@ -17,8 +17,8 @@
 package com.google.common.collect;
 
 import static com.google.common.testing.SerializableTester.reserialize;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;

--- a/android/guava-tests/test/com/google/common/eventbus/StringCatcher.java
+++ b/android/guava-tests/test/com/google/common/eventbus/StringCatcher.java
@@ -19,7 +19,7 @@ package com.google.common.eventbus;
 import com.google.common.collect.Lists;
 import java.util.List;
 import javax.annotation.CheckForNull;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * A simple EventSubscriber mock that records Strings.

--- a/android/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
@@ -19,7 +19,7 @@ package com.google.common.util.concurrent;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import com.google.common.testing.TearDown;
 import com.google.common.testing.TearDownAccepter;

--- a/android/guava-tests/test/com/google/common/util/concurrent/ListenableFutureTester.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/ListenableFutureTester.java
@@ -18,10 +18,10 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;

--- a/android/guava-tests/test/com/google/common/util/concurrent/TestPlatform.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/TestPlatform.java
@@ -23,8 +23,8 @@ import static com.google.common.util.concurrent.FuturesTest.pseudoTimedGetUninte
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import java.util.concurrent.ExecutionException;

--- a/android/guava-tests/test/com/google/common/util/concurrent/TestThread.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/TestThread.java
@@ -17,10 +17,10 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import com.google.common.testing.TearDown;
 import java.lang.reflect.InvocationTargetException;

--- a/guava-gwt/test-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/TestPlatform.java
+++ b/guava-gwt/test-super/com/google/common/util/concurrent/super/com/google/common/util/concurrent/TestPlatform.java
@@ -19,7 +19,7 @@ package com.google.common.util.concurrent;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;

--- a/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
@@ -16,8 +16,8 @@
 
 package com.google.common.collect.testing;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import java.util.ArrayList;

--- a/guava-testlib/src/com/google/common/collect/testing/Helpers.java
+++ b/guava-testlib/src/com/google/common/collect/testing/Helpers.java
@@ -17,9 +17,9 @@
 package com.google.common.collect.testing;
 
 import static java.util.Collections.sort;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
@@ -37,7 +37,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 @GwtCompatible(emulated = true)

--- a/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/SpliteratorTester.java
@@ -20,10 +20,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.testing.Helpers.assertEqualIgnoringOrder;
 import static com.google.common.collect.testing.Helpers.assertEqualInOrder;
 import static com.google.common.collect.testing.Platform.format;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.ImmutableSet;

--- a/guava-testlib/src/com/google/common/collect/testing/google/GoogleHelpers.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/GoogleHelpers.java
@@ -16,7 +16,7 @@
 
 package com.google.common.collect.testing.google;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.Multimap;

--- a/guava-testlib/src/com/google/common/collect/testing/google/SetGenerators.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/SetGenerators.java
@@ -23,7 +23,7 @@ import static com.google.common.collect.testing.SampleElements.Strings.AFTER_LAS
 import static com.google.common.collect.testing.SampleElements.Strings.AFTER_LAST_2;
 import static com.google.common.collect.testing.SampleElements.Strings.BEFORE_FIRST;
 import static com.google.common.collect.testing.SampleElements.Strings.BEFORE_FIRST_2;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;

--- a/guava-testlib/src/com/google/common/escape/testing/EscaperAsserts.java
+++ b/guava-testlib/src/com/google/common/escape/testing/EscaperAsserts.java
@@ -24,7 +24,7 @@ import com.google.common.escape.CharEscaper;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.UnicodeEscaper;
 import java.io.IOException;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * Extra assert methods for testing Escaper implementations.

--- a/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
+++ b/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
@@ -50,7 +50,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/guava-testlib/src/com/google/common/testing/CollectorTester.java
+++ b/guava-testlib/src/com/google/common/testing/CollectorTester.java
@@ -17,7 +17,7 @@
 package com.google.common.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import java.util.ArrayList;

--- a/guava-testlib/src/com/google/common/testing/EqualsTester.java
+++ b/guava-testlib/src/com/google/common/testing/EqualsTester.java
@@ -17,8 +17,8 @@
 package com.google.common.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Equivalence;

--- a/guava-testlib/src/com/google/common/testing/EquivalenceTester.java
+++ b/guava-testlib/src/com/google/common/testing/EquivalenceTester.java
@@ -17,8 +17,8 @@
 package com.google.common.testing;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.base.Equivalence;

--- a/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
+++ b/guava-testlib/src/com/google/common/testing/ForwardingWrapperTester.java
@@ -19,8 +19,8 @@ package com.google.common.testing;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.base.Function;

--- a/guava-testlib/src/com/google/common/testing/NullPointerTester.java
+++ b/guava-testlib/src/com/google/common/testing/NullPointerTester.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/guava-testlib/src/com/google/common/testing/SerializableTester.java
+++ b/guava-testlib/src/com/google/common/testing/SerializableTester.java
@@ -17,7 +17,7 @@
 package com.google.common.testing;
 
 import com.google.common.annotations.GwtCompatible;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 /**

--- a/guava-testlib/src/com/google/common/util/concurrent/testing/MockFutureListener.java
+++ b/guava-testlib/src/com/google/common/util/concurrent/testing/MockFutureListener.java
@@ -24,7 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * A simple mock implementation of {@code Runnable} that can be used for testing ListenableFutures.

--- a/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -16,13 +16,13 @@ package com.google.common.cache;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.cache.LocalCache.LocalLoadingCache;

--- a/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
+++ b/guava-tests/test/com/google/common/collect/LenientSerializableTester.java
@@ -17,8 +17,8 @@
 package com.google.common.collect;
 
 import static com.google.common.testing.SerializableTester.reserialize;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;

--- a/guava-tests/test/com/google/common/eventbus/StringCatcher.java
+++ b/guava-tests/test/com/google/common/eventbus/StringCatcher.java
@@ -18,7 +18,7 @@ package com.google.common.eventbus;
 
 import com.google.common.collect.Lists;
 import java.util.List;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**

--- a/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
+++ b/guava-tests/test/com/google/common/util/concurrent/InterruptionUtil.java
@@ -19,7 +19,7 @@ package com.google.common.util.concurrent;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import com.google.common.testing.TearDown;
 import com.google.common.testing.TearDownAccepter;

--- a/guava-tests/test/com/google/common/util/concurrent/ListenableFutureTester.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ListenableFutureTester.java
@@ -18,10 +18,10 @@ package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;

--- a/guava-tests/test/com/google/common/util/concurrent/TestPlatform.java
+++ b/guava-tests/test/com/google/common/util/concurrent/TestPlatform.java
@@ -23,8 +23,8 @@ import static com.google.common.util.concurrent.FuturesTest.pseudoTimedGetUninte
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 import com.google.common.annotations.GwtCompatible;
 import java.util.concurrent.ExecutionException;

--- a/guava-tests/test/com/google/common/util/concurrent/TestThread.java
+++ b/guava-tests/test/com/google/common/util/concurrent/TestThread.java
@@ -17,10 +17,10 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import com.google.common.testing.TearDown;
 import java.lang.reflect.InvocationTargetException;


### PR DESCRIPTION
Replaces all deprecated junit.framework.Assert imports with org.junit.Assert
<img width="498" alt="Screen Shot 2021-12-22 at 9 41 13 PM" src="https://user-images.githubusercontent.com/16943514/147188987-4bddaf4e-0695-4a3e-a7ff-466a8a4cb66f.png">

