### PR TITLE
Add preconditions overloads for double

### DIFF
--- a/guava/src/com/google/common/base/Preconditions.java
+++ b/guava/src/com/google/common/base/Preconditions.java
@@ -211,6 +211,17 @@ public final class Preconditions {
    * Ensures the truth of an expression involving one or more parameters to the calling method.
    *
    * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, double p1) {
+    if (!b) {
+      throw new IllegalArgumentException(lenientFormat(errorMessageTemplate, p1));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
    *
    * @since 20.0 (varargs overload since 2.0)
    */
@@ -572,6 +583,18 @@ public final class Preconditions {
    * @since 20.0 (varargs overload since 2.0)
    */
   public static void checkState(boolean b, String errorMessageTemplate, long p1) {
+    if (!b) {
+      throw new IllegalStateException(lenientFormat(errorMessageTemplate, p1));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, double p1) {
     if (!b) {
       throw new IllegalStateException(lenientFormat(errorMessageTemplate, p1));
     }

--- a/guava/src/com/google/common/base/Verify.java
+++ b/guava/src/com/google/common/base/Verify.java
@@ -174,6 +174,18 @@ public final class Verify {
    * custom message otherwise.
    *
    * <p>See {@link #verify(boolean, String, Object...)} for details.
+   */
+  public static void verify(boolean expression, String errorMessageTemplate, double p1) {
+    if (!expression) {
+      throw new VerifyException(lenientFormat(errorMessageTemplate, p1));
+    }
+  }
+
+  /**
+   * Ensures that {@code expression} is {@code true}, throwing a {@code VerifyException} with a
+   * custom message otherwise.
+   *
+   * <p>See {@link #verify(boolean, String, Object...)} for details.
    *
    * @since 23.1 (varargs overload since 17.0)
    */


### PR DESCRIPTION
Add overloads for `checkArgument`, `checkState` and `verify` to avoid
boxing of sole `double` format parameter.