### PR TITLE
Re-enable use of Unsafe.getLong() on aarch64 devices other than Android

### DIFF
--- a/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/android/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -244,7 +244,9 @@ final class LittleEndianByteArray {
        *
        */
       String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch)) {
+      String vendor = System.getProperty("java.vm.vendor");
+      if ("amd64".equals(arch) ||
+          ("aarch64".equals(arch) && !"The Android Project".equals(vendor))) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN

--- a/guava/src/com/google/common/hash/LittleEndianByteArray.java
+++ b/guava/src/com/google/common/hash/LittleEndianByteArray.java
@@ -244,7 +244,9 @@ final class LittleEndianByteArray {
        *
        */
       String arch = System.getProperty("os.arch");
-      if ("amd64".equals(arch)) {
+      String vendor = System.getProperty("java.vm.vendor");
+      if ("amd64".equals(arch) ||
+          ("aarch64".equals(arch) && !"The Android Project".equals(vendor))) {
         theGetter =
             ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN)
                 ? UnsafeByteArray.UNSAFE_LITTLE_ENDIAN


### PR DESCRIPTION
This provides a 2.24x speedup on Graviton2 aarch64-linux.

Unsafe.getLong() was disabled on aarch64 following this commit:
https://github.com/google/guava/commit/acf29b389bc9ff8701f69d05b30e9d899bc10e35
"Android devices may report to run aarch64 while running in 32-bit mode, and then
crash when loading 64-bit values at unaligned addresses."

This patch re-enables Unsafe.getLong() on aarch64 devices other than Android.

Measuring performance of a micro-benchmark:

```
public Long MyBenchmark() {
      final String value = "Although this detail has no connection whatever with the real substance of what we are about to relate";
      return Hashing.farmHashFingerprint64().hashString(value, StandardCharsets.UTF_8).asLong();
}
```

with Guava top of the tree as of today:
```
Benchmark                 Mode  Cnt     Score   Error   Units
MyBenchmark.MyBenchmark  thrpt   25  1264.365 ± 3.533  ops/ms
```
and with the current patch, I see a 2.24x speedup:
```
Benchmark                 Mode  Cnt     Score   Error   Units
MyBenchmark.MyBenchmark  thrpt   25  2830.370 ± 9.508  ops/ms
```
Patch based on recommendations from Ali Saidi <alisaidi@amazon.com>.