### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     name: "${{ matrix.root-pom }} on JDK ${{ matrix.java }}"
     strategy:
       matrix:
@@ -21,20 +24,20 @@ jobs:
     steps:
       # Cancel any previous runs for the same branch that are still running.
       - name: 'Cancel previous runs'
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
         with:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@f08d6490899c79192a5e35ab386509ac8f2411d4 # v3
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -57,16 +60,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@f08d6490899c79192a5e35ab386509ac8f2411d4 # v3
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # v2
         with:
           java-version: 11
           distribution: 'zulu'
@@ -86,16 +89,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v3
+        uses: actions/cache@f08d6490899c79192a5e35ab386509ac8f2411d4 # v3
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - name: 'Set up JDK 11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # v2
         with:
           java-version: 11
           distribution: 'zulu'


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

GitHub's own repository pin's their checkout actions by SHA and doesn't use the version tag https://github.com/github/docs/blob/ea7f218c91ecbae9a700a8702b51a7d2736e0d2c/.github/workflows/docs-review-collect.yml#L23

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>