### PR TITLE
remove @Beta annotations from tryParse methods

### DIFF
--- a/guava/src/com/google/common/primitives/Ints.java
+++ b/guava/src/com/google/common/primitives/Ints.java
@@ -713,7 +713,6 @@ public final class Ints extends IntsMethodsForWeb {
    * @throws NullPointerException if {@code string} is {@code null}
    * @since 11.0
    */
-  @Beta
   @CheckForNull
   public static Integer tryParse(String string) {
     return tryParse(string, 10);
@@ -739,7 +738,6 @@ public final class Ints extends IntsMethodsForWeb {
    * @throws NullPointerException if {@code string} is {@code null}
    * @since 19.0
    */
-  @Beta
   @CheckForNull
   public static Integer tryParse(String string, int radix) {
     Long result = Longs.tryParse(string, radix);

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -363,7 +363,6 @@ public final class Longs {
    * @throws NullPointerException if {@code string} is {@code null}
    * @since 14.0
    */
-  @Beta
   @CheckForNull
   public static Long tryParse(String string) {
     return tryParse(string, 10);
@@ -389,7 +388,6 @@ public final class Longs {
    * @throws NullPointerException if {@code string} is {@code null}
    * @since 19.0
    */
-  @Beta
   @CheckForNull
   public static Long tryParse(String string, int radix) {
     if (checkNotNull(string).isEmpty()) {


### PR DESCRIPTION
Removed the Beta annotations from Longs#tryParse and Ints#tryParse. These methods have been in beta since versions 14.0 and 19.0 respectively, while their code hasn't changed in over 7 years. It's safe to say that these methods are stable.