### PR TITLE
Upgrade maven-gpg-plugin to 3.0.1

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -373,7 +373,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.6</version>
+              <version>3.0.1</version>
               <executions>
                 <execution>
                   <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>1.6</version>
+              <version>3.0.1</version>
               <executions>
                 <execution>
                   <id>sign-artifacts</id>


### PR DESCRIPTION
Upgrades maven-gpg-plugin to [3.0.1](https://www.mail-archive.com/users@maven.apache.org/msg143178.html). 

This is the first release for this plugin in over 6 years, and moves the plugin to the 3.x versioning format all other Maven plugins are using. 

<img width="731" alt="Screen Shot 2022-05-26 at 4 48 54 PM" src="https://user-images.githubusercontent.com/16943514/170592927-8352766d-fe26-4de3-a202-c63b63f999a4.png">
