### PR TITLE
Fix erroneous -0 literals in tests

### DIFF
--- a/android/guava-tests/test/com/google/common/primitives/DoublesTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/DoublesTest.java
@@ -469,8 +469,8 @@ public class DoublesTest extends TestCase {
     testSortDescending(new double[] {1, 3, 1}, new double[] {3, 1, 1});
     testSortDescending(new double[] {-1, 1, -2, 2}, new double[] {2, 1, -1, -2});
     testSortDescending(
-        new double[] {-1, 1, Double.NaN, -2, -0, 0, 2},
-        new double[] {Double.NaN, 2, 1, 0, -0, -1, -2});
+        new double[] {-1, 1, Double.NaN, -2, -0.0, 0, 2},
+        new double[] {Double.NaN, 2, 1, 0, -0.0, -1, -2});
   }
 
   private static void testSortDescending(double[] input, double[] expectedOutput) {

--- a/android/guava-tests/test/com/google/common/primitives/FloatsTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/FloatsTest.java
@@ -454,7 +454,7 @@ public class FloatsTest extends TestCase {
     testSortDescending(new float[] {1, 3, 1}, new float[] {3, 1, 1});
     testSortDescending(new float[] {-1, 1, -2, 2}, new float[] {2, 1, -1, -2});
     testSortDescending(
-        new float[] {-1, 1, Float.NaN, -2, -0, 0, 2}, new float[] {Float.NaN, 2, 1, 0, -0, -1, -2});
+        new float[] {-1, 1, Float.NaN, -2, -0f, 0, 2}, new float[] {Float.NaN, 2, 1, 0, -0f, -1, -2});
   }
 
   private static void testSortDescending(float[] input, float[] expectedOutput) {

--- a/guava-tests/test/com/google/common/primitives/DoublesTest.java
+++ b/guava-tests/test/com/google/common/primitives/DoublesTest.java
@@ -469,8 +469,8 @@ public class DoublesTest extends TestCase {
     testSortDescending(new double[] {1, 3, 1}, new double[] {3, 1, 1});
     testSortDescending(new double[] {-1, 1, -2, 2}, new double[] {2, 1, -1, -2});
     testSortDescending(
-        new double[] {-1, 1, Double.NaN, -2, -0, 0, 2},
-        new double[] {Double.NaN, 2, 1, 0, -0, -1, -2});
+        new double[] {-1, 1, Double.NaN, -2, -0.0, 0, 2},
+        new double[] {Double.NaN, 2, 1, 0, -0.0, -1, -2});
   }
 
   private static void testSortDescending(double[] input, double[] expectedOutput) {

--- a/guava-tests/test/com/google/common/primitives/FloatsTest.java
+++ b/guava-tests/test/com/google/common/primitives/FloatsTest.java
@@ -454,7 +454,7 @@ public class FloatsTest extends TestCase {
     testSortDescending(new float[] {1, 3, 1}, new float[] {3, 1, 1});
     testSortDescending(new float[] {-1, 1, -2, 2}, new float[] {2, 1, -1, -2});
     testSortDescending(
-        new float[] {-1, 1, Float.NaN, -2, -0, 0, 2}, new float[] {Float.NaN, 2, 1, 0, -0, -1, -2});
+        new float[] {-1, 1, Float.NaN, -2, -0f, 0, 2}, new float[] {Float.NaN, 2, 1, 0, -0f, -1, -2});
   }
 
   private static void testSortDescending(float[] input, float[] expectedOutput) {


### PR DESCRIPTION
-0 is evaluated to 0, even if the result is afterwards converted to float or double, for example: `Double.toString(-0)`