### PR TITLE
Fix typos in Javadocs, comments and code

### DIFF
--- a/android/guava-tests/test/com/google/common/base/PredicatesTest.java
+++ b/android/guava-tests/test/com/google/common/base/PredicatesTest.java
@@ -764,7 +764,7 @@ public class PredicatesTest extends TestCase {
   }
 
   @SuppressWarnings("unchecked") // varargs
-  @GwtIncompatible // SerializbleTester
+  @GwtIncompatible // SerializableTester
   public void testCascadingSerialization() throws Exception {
     // Eclipse says Predicate<Integer>; javac says Predicate<Object>.
     Predicate<? super Integer> nasty =

--- a/android/guava/src/com/google/common/collect/Ordering.java
+++ b/android/guava/src/com/google/common/collect/Ordering.java
@@ -839,11 +839,10 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * duplicates according to the comparator. The sort performed is <i>stable</i>, meaning that such
    * elements will appear in the returned list in the same order they appeared in {@code elements}.
    *
-   * <p><b>Performance note:</b> According to our
-   * benchmarking
-   * on Open JDK 7, {@link #immutableSortedCopy} generally performs better (in both time and space)
-   * than this method, and this method in turn generally performs better than copying the list and
-   * calling {@link Collections#sort(List)}.
+   * <p><b>Performance note:</b> According to our benchmarking on OpenJDK 7, {@link
+   * #immutableSortedCopy} generally performs better (in both time and space) than this method, and
+   * this method in turn generally performs better than copying the list and calling {@link
+   * Collections#sort(List)}.
    */
   // TODO(kevinb): rerun benchmarks including new options
   public <E extends T> List<E> sortedCopy(Iterable<E> elements) {
@@ -861,9 +860,8 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * duplicates according to the comparator. The sort performed is <i>stable</i>, meaning that such
    * elements will appear in the returned list in the same order they appeared in {@code elements}.
    *
-   * <p><b>Performance note:</b> According to our
-   * benchmarking
-   * on Open JDK 7, this method is the most efficient way to make a sorted copy of a collection.
+   * <p><b>Performance note:</b> According to our benchmarking on OpenJDK 7, this method is the most
+   * efficient way to make a sorted copy of a collection.
    *
    * @throws NullPointerException if any element of {@code elements} is {@code null}
    * @since 3.0
@@ -931,8 +929,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * @deprecated Use {@link Collections#binarySearch(List, Object, Comparator)} directly.
    */
   @Deprecated
-  public int binarySearch(
-      List<? extends T> sortedList, @ParametricNullness T key) {
+  public int binarySearch(List<? extends T> sortedList, @ParametricNullness T key) {
     return Collections.binarySearch(sortedList, key, this);
   }
 

--- a/guava-testlib/src/com/google/common/collect/testing/AbstractContainerTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/AbstractContainerTester.java
@@ -210,7 +210,7 @@ public abstract class AbstractContainerTester<C, E>
 
   /**
    * Returns the {@linkplain #getSampleElements() sample elements} as ordered by {@link
-   * TestContainerGenerator#order(List)}. Tests should used this method only if they declare
+   * TestContainerGenerator#order(List)}. Tests should use this method only if they declare
    * requirement {@link com.google.common.collect.testing.features.CollectionFeature#KNOWN_ORDER}.
    */
   protected List<E> getOrderedElements() {

--- a/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
@@ -146,7 +146,7 @@ abstract class AbstractIteratorTester<E, I extends Iterator<E>> {
      * {@link #previousElements} if the reverse is true, or -- overriding both of these -- {@code
      * null} if {@code remove()} or {@code add()} has been called more recently than either. We use
      * this to determine which stack to pop from on a call to {@code remove()} (or to pop from and
-     * push to on a call to {@code set()}.
+     * push to on a call to {@code set()}).
      */
     Stack<E> stackWithLastReturnedElementAtTop = null;
 

--- a/guava-testlib/src/com/google/common/collect/testing/DerivedGenerator.java
+++ b/guava-testlib/src/com/google/common/collect/testing/DerivedGenerator.java
@@ -24,7 +24,7 @@ import com.google.common.annotations.GwtCompatible;
  * collection generator.
  *
  * <p>{@code GwtTestSuiteGenerator} expects every {@code DerivedIterator} implementation to provide
- * a one-arg constructor accepting its inner generator as an argument). This requirement enables it
+ * a one-arg constructor accepting its inner generator as an argument. This requirement enables it
  * to generate source code (since GWT cannot use reflection to generate the suites).
  *
  * @author Chris Povirk

--- a/guava-testlib/src/com/google/common/collect/testing/testers/ListSubListTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/ListSubListTester.java
@@ -326,7 +326,7 @@ public class ListSubListTester<E> extends AbstractListTester<E> {
 
   /**
    * Returns the {@link Method} instance for {@link
-   * #testSubList_originalListSetAffectsSubListLargeList()} ()} so that tests of {@link
+   * #testSubList_originalListSetAffectsSubListLargeList()} so that tests of {@link
    * CopyOnWriteArrayList} can suppress them with {@code
    * FeatureSpecificTestSuiteBuilder.suppressing()} until <a
    * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6570631">Sun bug 6570631</a> is fixed.

--- a/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
+++ b/guava-testlib/src/com/google/common/testing/ClassSanityTester.java
@@ -713,9 +713,9 @@ public final class ClassSanityTester {
     for (Invokable<?, ?> factory : factories) {
       factory.setAccessible(true);
     }
-    // Sorts methods/constructors with least number of parameters first since it's likely easier to
-    // fill dummy parameter values for them. Ties are broken by name then by the string form of the
-    // parameter list.
+    // Sorts methods/constructors with the least number of parameters first since it's likely easier
+    // to fill dummy parameter values for them. Ties are broken by name then by the string form of
+    // the parameter list.
     return BY_NUMBER_OF_PARAMETERS
         .compound(BY_METHOD_NAME)
         .compound(BY_PARAMETERS)

--- a/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/ClassSanityTesterTest.java
@@ -212,11 +212,11 @@ public class ClassSanityTesterTest extends TestCase {
   @AndroidIncompatible // TODO(cpovirk): ClassNotFoundException... ClassSanityTesterTest$AnInterface
   public void testEqualsAndSerializableOnReturnValues_good() throws Exception {
     tester
-        .forAllPublicStaticMethods(GoodEqualsAndSerialiableFactory.class)
+        .forAllPublicStaticMethods(GoodEqualsAndSerializableFactory.class)
         .testEqualsAndSerializable();
   }
 
-  public static class GoodEqualsAndSerialiableFactory {
+  public static class GoodEqualsAndSerializableFactory {
     public static Object good(AnInterface s) {
       return Functions.constant(s);
     }
@@ -432,8 +432,8 @@ public class ClassSanityTesterTest extends TestCase {
     tester.testNulls(GoodNulls.class);
   }
 
-  public void testNoNullCheckNeededDespitNotInstantiable() throws Exception {
-    tester.doTestNulls(NoNullCheckNeededDespitNotInstantiable.class, Visibility.PACKAGE);
+  public void testNoNullCheckNeededDespiteNotInstantiable() throws Exception {
+    tester.doTestNulls(NoNullCheckNeededDespiteNotInstantiable.class, Visibility.PACKAGE);
   }
 
   public void testNulls_interface() {
@@ -1163,9 +1163,9 @@ public class ClassSanityTesterTest extends TestCase {
     public void failsToRejectNull(@SuppressWarnings("unused") String s) {}
   }
 
-  public static class NoNullCheckNeededDespitNotInstantiable {
+  public static class NoNullCheckNeededDespiteNotInstantiable {
 
-    public NoNullCheckNeededDespitNotInstantiable(NotInstantiable x) {
+    public NoNullCheckNeededDespiteNotInstantiable(NotInstantiable x) {
       checkNotNull(x);
     }
 

--- a/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/EqualsTesterTest.java
@@ -114,7 +114,7 @@ public class EqualsTesterTest extends TestCase {
   }
 
   /** Test proper handling of case where an object is not equal to itself */
-  public void testNonreflexiveEquals() {
+  public void testNonReflexiveEquals() {
     Object obj = new NonReflexiveObject();
     equalsTester.addEqualityGroup(obj);
     try {

--- a/guava-testlib/test/com/google/common/testing/EquivalenceTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/EquivalenceTesterTest.java
@@ -113,7 +113,7 @@ public class EquivalenceTesterTest extends TestCase {
     fail();
   }
 
-  public void testTest_trasitive() {
+  public void testTest_transitive() {
     Object group1Item1 = new TestObject(1, 1);
     Object group1Item2 = new TestObject(1, 2);
     Object group1Item3 = new TestObject(1, 3);

--- a/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
+++ b/guava-testlib/test/com/google/common/testing/anotherpackage/ForwardingWrapperTesterTest.java
@@ -256,7 +256,7 @@ public class ForwardingWrapperTesterTest extends TestCase {
         new Function<Adder, Adder>() {
           @Override
           public Adder apply(Adder adder) {
-            return new FailsToPropagageException(adder);
+            return new FailsToPropagateException(adder);
           }
         },
         "add(",
@@ -374,10 +374,10 @@ public class ForwardingWrapperTesterTest extends TestCase {
     }
   }
 
-  private static class FailsToPropagageException implements Adder {
+  private static class FailsToPropagateException implements Adder {
     private final Adder adder;
 
-    FailsToPropagageException(Adder adder) {
+    FailsToPropagateException(Adder adder) {
       this.adder = adder;
     }
 

--- a/guava-tests/benchmark/com/google/common/base/CharMatcherBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/base/CharMatcherBenchmark.java
@@ -130,9 +130,9 @@ public class CharMatcherBenchmark {
       list.set(list.indexOf(0), list.get(0));
       list.set(0, 0);
     }
-    // Get threshold in the range [0, length], rounding up to ensure that non
-    // zero percent values result in a non-zero threshold (so we always have at
-    // least one matching character).
+    // Get threshold in the range [0, length], rounding up to ensure that
+    // non-zero percent values result in a non-zero threshold (so we always
+    // have at least one matching character).
     int threshold = ((percent * length) + 99) / 100;
     StringBuilder builder = new StringBuilder(length);
     for (int n = 0; n < length; n++) {

--- a/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/io/ByteSourceAsCharSourceReadBenchmark.java
@@ -78,7 +78,7 @@ public class ByteSourceAsCharSourceReadBenchmark {
               return new String(buffer, 0, bufIndex);
             }
             // otherwise we got the size wrong.  This can happen if the size changes between when
-            // we called sizeIfKnown and when we started reading the file (or i guess if
+            // we called sizeIfKnown and when we started reading the file (or I guess if
             // maxCharsPerByte is wrong)
             // Fallback to an incremental approach
             StringBuilder builder = new StringBuilder(bufIndex + 32);

--- a/guava-tests/benchmark/com/google/common/math/QuantilesBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/math/QuantilesBenchmark.java
@@ -50,7 +50,7 @@ public class QuantilesBenchmark {
   }
 
   private double[] dataset(int i) {
-    // We must test on a fresh clone of the dataset each time. Doing sorts and quickselects on an
+    // We must test on a fresh clone of the dataset each time. Doing sorts and quickselects on a
     // dataset which is already sorted or partially sorted is cheating.
     return datasets[i & 0xFF].clone();
   }

--- a/guava-tests/test/com/google/common/base/PredicatesTest.java
+++ b/guava-tests/test/com/google/common/base/PredicatesTest.java
@@ -764,7 +764,7 @@ public class PredicatesTest extends TestCase {
   }
 
   @SuppressWarnings("unchecked") // varargs
-  @GwtIncompatible // SerializbleTester
+  @GwtIncompatible // SerializableTester
   public void testCascadingSerialization() throws Exception {
     // Eclipse says Predicate<Integer>; javac says Predicate<Object>.
     Predicate<? super Integer> nasty =

--- a/guava-tests/test/com/google/common/cache/CacheTesting.java
+++ b/guava-tests/test/com/google/common/cache/CacheTesting.java
@@ -98,7 +98,7 @@ class CacheTesting {
   }
 
   /**
-   * Forces the segment containing the given {@code key} to expand (see {@link Segment#expand()}.
+   * Forces the segment containing the given {@code key} to expand (see {@link Segment#expand()}).
    */
   static <K, V> void forceExpandSegment(Cache<K, V> cache, K key) {
     checkNotNull(cache);

--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -326,7 +326,7 @@ public class LocalCacheTest extends TestCase {
   }
 
   public void testSetConcurrencyLevel() {
-    // round up to nearest power of two
+    // round up to the nearest power of two
 
     checkConcurrencyLevel(1, 1);
     checkConcurrencyLevel(2, 2);
@@ -345,7 +345,7 @@ public class LocalCacheTest extends TestCase {
   }
 
   public void testSetInitialCapacity() {
-    // share capacity over each segment, then round up to nearest power of two
+    // share capacity over each segment, then round up to the nearest power of two
 
     checkInitialCapacity(1, 0, 1);
     checkInitialCapacity(1, 1, 1);

--- a/guava-tests/test/com/google/common/cache/LocalLoadingCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalLoadingCacheTest.java
@@ -323,7 +323,7 @@ public class LocalLoadingCacheTest extends TestCase {
     recursiveCache = CacheBuilder.newBuilder().weakKeys().weakValues().build(recursiveLoader);
     cacheRef.set(recursiveCache);
 
-    // tells the test when the compution has completed
+    // tells the test when the computation has completed
     final CountDownLatch doneSignal = new CountDownLatch(1);
 
     Thread thread =

--- a/guava-tests/test/com/google/common/collect/AbstractIteratorTest.java
+++ b/guava-tests/test/com/google/common/collect/AbstractIteratorTest.java
@@ -137,7 +137,6 @@ public class AbstractIteratorTest extends TestCase {
     }
   }
 
-
   @GwtIncompatible // weak references
   public void testFreesNextReference() {
     Iterator<Object> itr =
@@ -295,7 +294,7 @@ public class AbstractIteratorTest extends TestCase {
   // hasNext/next/peek), but we'll cop out for now, knowing that peek() and
   // next() both start by invoking hasNext() anyway.
 
-  /** Throws a undeclared checked exception. */
+  /** Throws an undeclared checked exception. */
   private static void sneakyThrow(Throwable t) {
     class SneakyThrower<T extends Throwable> {
       @SuppressWarnings("unchecked") // not really safe, but that's the point

--- a/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableMapTest.java
@@ -1023,7 +1023,7 @@ public class ImmutableMapTest extends TestCase {
   @GwtIncompatible // SerializableTester
   @SuppressWarnings("unchecked")
   public void ignore_testSerializationNoDuplication_regularImmutableMap() throws Exception {
-    // Tests that searializing a map, its keySet, and values only writes the underlying data once.
+    // Tests that serializing a map, its keySet, and values only writes the underlying data once.
 
     Entry<Integer, Integer>[] entries = (Entry<Integer, Integer>[]) new Entry<?, ?>[1000];
     for (int i = 0; i < 1000; i++) {
@@ -1053,7 +1053,7 @@ public class ImmutableMapTest extends TestCase {
   @GwtIncompatible // SerializableTester
   @SuppressWarnings("unchecked")
   public void ignore_testSerializationNoDuplication_jdkBackedImmutableMap() throws Exception {
-    // Tests that searializing a map, its keySet, and values only writes
+    // Tests that serializing a map, its keySet, and values only writes
     // the underlying data once.
 
     Entry<Integer, Integer>[] entries = (Entry<Integer, Integer>[]) new Entry<?, ?>[1000];

--- a/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -1006,7 +1006,7 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     assertTrue(copy instanceof ImmutableSortedAsList);
   }
 
-  public void testAsListInconsistentComprator() {
+  public void testAsListInconsistentComparator() {
     ImmutableSet<String> set =
         ImmutableSortedSet.orderedBy(STRING_LENGTH)
             .add("in", "the", "quick", "jumped", "over", "a")

--- a/guava-tests/test/com/google/common/collect/ListsImplTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsImplTest.java
@@ -64,7 +64,7 @@ public class ListsImplTest extends TestCase {
     /** Creates a new list with the given contents. */
     public abstract <T> List<T> createList(Class<T> listType, Collection<? extends T> contents);
 
-    /** The modifiablity of this list example. */
+    /** The modifiability of this list example. */
     public Modifiability modifiability() {
       return modifiability;
     }

--- a/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
+++ b/guava-tests/test/com/google/common/collect/MapMakerInternalMapTest.java
@@ -90,7 +90,7 @@ public class MapMakerInternalMapTest extends TestCase {
   }
 
   public void testSetConcurrencyLevel() {
-    // round up to nearest power of two
+    // round up to the nearest power of two
 
     checkConcurrencyLevel(1, 1);
     checkConcurrencyLevel(2, 2);
@@ -109,7 +109,7 @@ public class MapMakerInternalMapTest extends TestCase {
   }
 
   public void testSetInitialCapacity() {
-    // share capacity over each segment, then round up to nearest power of two
+    // share capacity over each segment, then round up to the nearest power of two
 
     checkInitialCapacity(1, 0, 1);
     checkInitialCapacity(1, 1, 1);
@@ -185,7 +185,7 @@ public class MapMakerInternalMapTest extends TestCase {
     for (int i = 0; i < map.segments.length; i++) {
       totalCapacity += map.segments[i].maxSegmentSize;
     }
-    assertTrue("totalCapcity=" + totalCapacity + ", maxSize=" + maxSize, totalCapacity <= maxSize);
+    assertTrue("totalCapacity=" + totalCapacity + ", maxSize=" + maxSize, totalCapacity <= maxSize);
   }
 
   public void testSetWeakKeys() {

--- a/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
+++ b/guava-tests/test/com/google/common/collect/MinMaxPriorityQueueTest.java
@@ -276,7 +276,7 @@ public class MinMaxPriorityQueueTest extends TestCase {
   public void testRemove() {
     MinMaxPriorityQueue<Integer> mmHeap = MinMaxPriorityQueue.create();
     mmHeap.addAll(Lists.newArrayList(1, 2, 3, 4, 47, 1, 5, 3, 0));
-    assertTrue("Heap is not intact initally", mmHeap.isIntact());
+    assertTrue("Heap is not intact initially", mmHeap.isIntact());
     assertEquals(9, mmHeap.size());
     mmHeap.remove(5);
     assertEquals(8, mmHeap.size());

--- a/guava-tests/test/com/google/common/escape/ArrayBasedEscaperMapTest.java
+++ b/guava-tests/test/com/google/common/escape/ArrayBasedEscaperMapTest.java
@@ -62,7 +62,7 @@ public class ArrayBasedEscaperMapTest extends TestCase {
     char[][] replacementArray = fem.getReplacementArray();
     // Array length is highest character value + 1
     assertEquals(65536, replacementArray.length);
-    // The final element should always be non null.
+    // The final element should always be non-null.
     assertNotNull(replacementArray[replacementArray.length - 1]);
     // Exhaustively check all mappings (an int index avoids wrapping).
     for (int n = 0; n < replacementArray.length; ++n) {

--- a/guava-tests/test/com/google/common/escape/EscapersTest.java
+++ b/guava-tests/test/com/google/common/escape/EscapersTest.java
@@ -60,7 +60,7 @@ public class EscapersTest extends TestCase {
   }
 
   public void testBuilderCreatesIndependentEscapers() {
-    // Setup a simple builder and create the first escaper.
+    // Set up a simple builder and create the first escaper.
     Escapers.Builder builder = Escapers.builder();
     builder.setSafeRange('a', 'z');
     builder.setUnsafeReplacement("X");
@@ -108,7 +108,7 @@ public class EscapersTest extends TestCase {
     }
   }
 
-  // A trival non-optimized escaper for testing.
+  // A trivial non-optimized escaper for testing.
   static CharEscaper createSimpleCharEscaper(final ImmutableMap<Character, char[]> replacementMap) {
     return new CharEscaper() {
       @Override
@@ -118,7 +118,7 @@ public class EscapersTest extends TestCase {
     };
   }
 
-  // A trival non-optimized escaper for testing.
+  // A trivial non-optimized escaper for testing.
   static UnicodeEscaper createSimpleUnicodeEscaper(
       final ImmutableMap<Integer, char[]> replacementMap) {
     return new UnicodeEscaper() {

--- a/guava-tests/test/com/google/common/eventbus/EventBusTest.java
+++ b/guava-tests/test/com/google/common/eventbus/EventBusTest.java
@@ -168,7 +168,7 @@ public class EventBusTest extends TestCase {
     GhostCatcher catcher = new GhostCatcher();
     bus.register(catcher);
 
-    // A String -- an event for which noone has registered.
+    // A String -- an event for which none has registered.
     bus.post(EVENT);
 
     List<DeadEvent> events = catcher.getEvents();

--- a/guava-tests/test/com/google/common/graph/ElementOrderTest.java
+++ b/guava-tests/test/com/google/common/graph/ElementOrderTest.java
@@ -150,7 +150,7 @@ public final class ElementOrderTest {
   // Combined node and edge order tests
 
   @Test
-  public void nodeOrderUnorderedandEdgesSorted() {
+  public void nodeOrderUnorderedAndEdgesSorted() {
     MutableNetwork<Integer, String> network =
         NetworkBuilder.directed()
             .nodeOrder(unordered())

--- a/guava-tests/test/com/google/common/hash/HashTestUtils.java
+++ b/guava-tests/test/com/google/common/hash/HashTestUtils.java
@@ -376,7 +376,7 @@ final class HashTestUtils {
       for (int j = 0; j < keyBits; j++) {
         if (j <= i) continue;
         int count = 0;
-        int maxCount = 20; // the probability of error here is miniscule
+        int maxCount = 20; // the probability of error here is minuscule
         boolean diff = false;
 
         while (!diff) {

--- a/guava-tests/test/com/google/common/io/BaseEncodingTest.java
+++ b/guava-tests/test/com/google/common/io/BaseEncodingTest.java
@@ -465,7 +465,7 @@ public class BaseEncodingTest extends TestCase {
       BaseEncoding encoding, String cannotDecode, @Nullable String expectedMessage) {
     // We use this somewhat weird pattern with an enum for each assertion we want to make as a way
     // of dealing with the fact that one of the assertions is @GwtIncompatible but we don't want to
-    // have to have duplicate @GwtIncompatible test methods just to make that assertion.
+    // have duplicate @GwtIncompatible test methods just to make that assertion.
     for (AssertFailsToDecodeStrategy strategy : AssertFailsToDecodeStrategy.values()) {
       strategy.assertFailsToDecode(encoding, cannotDecode, expectedMessage);
     }

--- a/guava-tests/test/com/google/common/io/ByteSinkTester.java
+++ b/guava-tests/test/com/google/common/io/ByteSinkTester.java
@@ -31,7 +31,7 @@ import junit.framework.TestSuite;
 
 /**
  * A generator of {@code TestSuite} instances for testing {@code ByteSink} implementations.
- * Generates tests of a all methods on a {@code ByteSink} given various inputs written to it as well
+ * Generates tests of all methods on a {@code ByteSink} given various inputs written to it as well
  * as sub-suites for testing the {@code CharSink} view in the same way.
  *
  * @author Colin Decker

--- a/guava-tests/test/com/google/common/io/ByteSourceTester.java
+++ b/guava-tests/test/com/google/common/io/ByteSourceTester.java
@@ -37,7 +37,7 @@ import junit.framework.TestSuite;
 
 /**
  * A generator of {@code TestSuite} instances for testing {@code ByteSource} implementations.
- * Generates tests of a all methods on a {@code ByteSource} given various inputs the source is
+ * Generates tests of all methods on a {@code ByteSource} given various inputs the source is
  * expected to contain as well as sub-suites for testing the {@code CharSource} view and {@code
  * slice()} views in the same way.
  *

--- a/guava-tests/test/com/google/common/io/CharSinkTester.java
+++ b/guava-tests/test/com/google/common/io/CharSinkTester.java
@@ -27,7 +27,7 @@ import junit.framework.TestSuite;
 
 /**
  * A generator of {@code TestSuite} instances for testing {@code CharSink} implementations.
- * Generates tests of a all methods on a {@code CharSink} given various inputs written to it.
+ * Generates tests of all methods on a {@code CharSink} given various inputs written to it.
  *
  * @author Colin Decker
  */

--- a/guava-tests/test/com/google/common/io/CharSourceTester.java
+++ b/guava-tests/test/com/google/common/io/CharSourceTester.java
@@ -36,7 +36,7 @@ import junit.framework.TestSuite;
 
 /**
  * A generator of {@code TestSuite} instances for testing {@code CharSource} implementations.
- * Generates tests of a all methods on a {@code CharSource} given various inputs the source is
+ * Generates tests of all methods on a {@code CharSource} given various inputs the source is
  * expected to contain.
  *
  * @author Colin Decker

--- a/guava-tests/test/com/google/common/math/IntMathTest.java
+++ b/guava-tests/test/com/google/common/math/IntMathTest.java
@@ -212,7 +212,7 @@ public class IntMathTest extends TestCase {
     }
   }
 
-  // Relies on the correctness of BigIntegrerMath.log2 for all modes except UNNECESSARY.
+  // Relies on the correctness of BigIntegerMath.log2 for all modes except UNNECESSARY.
   public void testLog2MatchesBigInteger() {
     for (int x : POSITIVE_INTEGER_CANDIDATES) {
       for (RoundingMode mode : ALL_SAFE_ROUNDING_MODES) {

--- a/guava-tests/test/com/google/common/math/MathPreconditionsTest.java
+++ b/guava-tests/test/com/google/common/math/MathPreconditionsTest.java
@@ -103,7 +103,7 @@ public class MathPreconditionsTest extends TestCase {
     }
   }
 
-  public void testCheckPositive_postiveBigInteger() {
+  public void testCheckPositive_positiveBigInteger() {
     MathPreconditions.checkPositive("BigInteger", BigInteger.ONE);
   }
 
@@ -251,7 +251,7 @@ public class MathPreconditionsTest extends TestCase {
     }
   }
 
-  public void testCheckRoundingUnnnecessary_success() {
+  public void testCheckRoundingUnnecessary_success() {
     MathPreconditions.checkRoundingUnnecessary(true);
   }
 

--- a/guava-tests/test/com/google/common/math/MathTesting.java
+++ b/guava-tests/test/com/google/common/math/MathTesting.java
@@ -150,7 +150,7 @@ public class MathTesting {
 
   static {
     ImmutableSet.Builder<Long> longValues = ImmutableSet.builder();
-    // First of all add all the integer candidate values.
+    // First add all the integer candidate values.
     longValues.addAll(Iterables.transform(POSITIVE_INTEGER_CANDIDATES, TO_LONG));
     // Add boundary values manually to avoid over/under flow (this covers 2^N for 31 and 63).
     longValues.add(Integer.MAX_VALUE + 1L, Long.MAX_VALUE - 1L, Long.MAX_VALUE);
@@ -185,7 +185,7 @@ public class MathTesting {
 
   static {
     ImmutableSet.Builder<BigInteger> bigValues = ImmutableSet.builder();
-    // First of all add all the long candidate values.
+    // First add all the long candidate values.
     bigValues.addAll(Iterables.transform(POSITIVE_LONG_CANDIDATES, TO_BIGINTEGER));
     // Add boundary values manually to avoid over/under flow.
     bigValues.add(BigInteger.valueOf(Long.MAX_VALUE).add(ONE));

--- a/guava-tests/test/com/google/common/math/QuantilesTest.java
+++ b/guava-tests/test/com/google/common/math/QuantilesTest.java
@@ -424,12 +424,12 @@ public class QuantilesTest extends TestCase {
             1, 1.5,
             2, 2.0,
             8, 5.0,
-            9, POSITIVE_INFINITY, // interpolating between 5.0 and POSITIVE_INFNINITY
+            9, POSITIVE_INFINITY, // interpolating between 5.0 and POSITIVE_INFINITY
             10, POSITIVE_INFINITY);
   }
 
   public void testScale_index_compute_doubleCollection_positiveInfinity() {
-    // interpolating between 5.0 and POSITIVE_INFNINITY
+    // interpolating between 5.0 and POSITIVE_INFINITY
     assertThat(Quantiles.scale(10).index(9).compute(ONE_TO_FIVE_AND_POSITIVE_INFINITY))
         .isPositiveInfinity();
   }
@@ -442,7 +442,7 @@ public class QuantilesTest extends TestCase {
         .comparingValuesUsing(QUANTILE_CORRESPONDENCE)
         .containsExactly(
             0, NEGATIVE_INFINITY,
-            1, NEGATIVE_INFINITY, // interpolating between NEGATIVE_INFNINITY and 1.0
+            1, NEGATIVE_INFINITY, // interpolating between NEGATIVE_INFINITY and 1.0
             2, 1.0,
             8, 4.0,
             9, 4.5,
@@ -450,7 +450,7 @@ public class QuantilesTest extends TestCase {
   }
 
   public void testScale_index_compute_doubleCollection_negativeInfinity() {
-    // interpolating between NEGATIVE_INFNINITY and 1.0
+    // interpolating between NEGATIVE_INFINITY and 1.0
     assertThat(Quantiles.scale(10).index(1).compute(ONE_TO_FIVE_AND_NEGATIVE_INFINITY))
         .isNegativeInfinity();
   }
@@ -540,7 +540,7 @@ public class QuantilesTest extends TestCase {
 
     // Assert that the dataset contains the same elements after the in-place computation (although
     // they may be reordered). We only do this for one index rather than for all indexes, as it is
-    // quite expensives (quadratic in the size of PSEUDORANDOM_DATASET).
+    // quite expensive (quadratic in the size of PSEUDORANDOM_DATASET).
     double[] dataset = Doubles.toArray(PSEUDORANDOM_DATASET);
     @SuppressWarnings("unused")
     double actual = percentiles().index(33).computeInPlace(dataset);

--- a/guava-tests/test/com/google/common/math/StatsTesting.java
+++ b/guava-tests/test/com/google/common/math/StatsTesting.java
@@ -64,7 +64,7 @@ class StatsTesting {
           + (-56.78 - TWO_VALUES_MEAN) * (-789.012 - OTHER_TWO_VALUES_MEAN);
 
   /**
-   * Helper class for testing with non-finite values. {@link #ALL_MANY_VALUES} gives a number
+   * Helper class for testing with non-finite values. {@link #ALL_MANY_VALUES} gives a number of
    * instances with many combinations of finite and non-finite values. All have {@link
    * #MANY_VALUES_COUNT} values. If all the values are finite then the mean is {@link
    * #MANY_VALUES_MEAN} and the sum-of-squares-of-deltas is {@link
@@ -214,7 +214,7 @@ class StatsTesting {
 
   /**
    * Returns a stream of a million primitive doubles. The stream is parallel, which should cause
-   * {@code collect} calls to run in multi-threaded mode, so testing the combiner as well as the
+   * {@code collect} calls to run in multithreaded mode, so testing the combiner as well as the
    * supplier and accumulator.
    */
   static DoubleStream megaPrimitiveDoubleStream() {
@@ -396,7 +396,7 @@ class StatsTesting {
   }
 
   /**
-   * Asserts that {@code transformation} is diagonal (i.e. neither horizontal or vertical) and
+   * Asserts that {@code transformation} is diagonal (i.e. neither horizontal nor vertical) and
    * passes through both {@code (x1, y1)} and {@code (x1 + xDelta, y1 + yDelta)}. Includes
    * assertions about all the public instance methods of {@link LinearTransformation} (on both
    * {@code transformation} and its inverse). Since the transformation is expected to be diagonal,

--- a/guava-tests/test/com/google/common/net/InetAddressesTest.java
+++ b/guava-tests/test/com/google/common/net/InetAddressesTest.java
@@ -645,7 +645,7 @@ public class InetAddressesTest extends TestCase {
             InetAddresses.getCoercedIPv4Address(
                 InetAddresses.forString("2001:0000:4136:e378:8000:63bf:3fff:fdd3")));
 
-    // 2 Teredo addresses NOT differing in the their embedded IPv4 addresses should hash to the same
+    // 2 Teredo addresses NOT differing in their embedded IPv4 addresses should hash to the same
     // value.
     assertThat(
             InetAddresses.getCoercedIPv4Address(

--- a/guava-tests/test/com/google/common/net/PercentEscaperTest.java
+++ b/guava-tests/test/com/google/common/net/PercentEscaperTest.java
@@ -45,7 +45,7 @@ public class PercentEscaperTest extends TestCase {
       }
     }
 
-    // Testing mutlibyte escape sequences
+    // Testing multibyte escape sequences
     assertEscaping(e, "%00", '\u0000'); // nul
     assertEscaping(e, "%7F", '\u007f'); // del
     assertEscaping(e, "%C2%80", '\u0080'); // xx-00010,x-000000

--- a/guava-tests/test/com/google/common/primitives/DoubleArrayAsListTest.java
+++ b/guava-tests/test/com/google/common/primitives/DoubleArrayAsListTest.java
@@ -53,7 +53,7 @@ public class DoubleArrayAsListTest extends TestCase {
     List<ListTestSuiteBuilder<Double>> builders =
         ImmutableList.of(
             ListTestSuiteBuilder.using(new DoublesAsListGenerator()).named("Doubles.asList"),
-            ListTestSuiteBuilder.using(new DoublsAsListHeadSubListGenerator())
+            ListTestSuiteBuilder.using(new DoublesAsListHeadSubListGenerator())
                 .named("Doubles.asList, head subList"),
             ListTestSuiteBuilder.using(new DoublesAsListTailSubListGenerator())
                 .named("Doubles.asList, tail subList"),
@@ -84,7 +84,7 @@ public class DoubleArrayAsListTest extends TestCase {
     }
   }
 
-  public static final class DoublsAsListHeadSubListGenerator extends TestDoubleListGenerator {
+  public static final class DoublesAsListHeadSubListGenerator extends TestDoubleListGenerator {
     @Override
     protected List<Double> create(Double[] elements) {
       Double[] suffix = {Double.MIN_VALUE, Double.MAX_VALUE};

--- a/guava-tests/test/com/google/common/primitives/IntsTest.java
+++ b/guava-tests/test/com/google/common/primitives/IntsTest.java
@@ -670,8 +670,8 @@ public class IntsTest extends TestCase {
   }
 
   /**
-   * Encodes the an integer as a string with given radix, then uses {@link Ints#tryParse(String,
-   * int)} to parse the result. Asserts the result is the same as what we started with.
+   * Encodes an integer as a string with given radix, then uses {@link Ints#tryParse(String, int)}
+   * to parse the result. Asserts the result is the same as what we started with.
    */
   private static void radixEncodeParseAndAssertEquals(Integer value, int radix) {
     assertWithMessage("Radix: " + radix)

--- a/guava-tests/test/com/google/common/primitives/UnsignedIntsTest.java
+++ b/guava-tests/test/com/google/common/primitives/UnsignedIntsTest.java
@@ -292,7 +292,7 @@ public class UnsignedIntsTest extends TestCase {
       assertThat(UnsignedInts.parseUnsignedInt(maxAsString, radix)).isEqualTo(-1);
 
       try {
-        // tests that we get exception whre an overflow would occur.
+        // tests that we get exception where an overflow would occur.
         long overflow = 1L << 32;
         String overflowAsString = Long.toString(overflow, radix);
         UnsignedInts.parseUnsignedInt(overflowAsString, radix);

--- a/guava-tests/test/com/google/common/primitives/UnsignedLongsTest.java
+++ b/guava-tests/test/com/google/common/primitives/UnsignedLongsTest.java
@@ -293,7 +293,7 @@ public class UnsignedLongsTest extends TestCase {
       assertThat(UnsignedLongs.parseUnsignedLong(maxAsString, radix)).isEqualTo(max.longValue());
 
       try {
-        // tests that we get exception whre an overflow would occur.
+        // tests that we get exception where an overflow would occur.
         BigInteger overflow = max.add(ONE);
         String overflowAsString = overflow.toString(radix);
         UnsignedLongs.parseUnsignedLong(overflowAsString, radix);

--- a/guava-tests/test/com/google/common/reflect/InvokableTest.java
+++ b/guava-tests/test/com/google/common/reflect/InvokableTest.java
@@ -49,9 +49,9 @@ public class InvokableTest extends TestCase {
   public void testApiCompatibleWithAccessibleObject() {
     ImmutableSet<String> invokableMethods =
         publicMethodSignatures(Invokable.class, ImmutableSet.<String>of());
-    ImmutableSet<String> accesibleObjectMethods =
+    ImmutableSet<String> accessibleObjectMethods =
         publicMethodSignatures(AccessibleObject.class, ImmutableSet.of("canAccess"));
-    assertThat(invokableMethods).containsAtLeastElementsIn(accesibleObjectMethods);
+    assertThat(invokableMethods).containsAtLeastElementsIn(accessibleObjectMethods);
     Class<?> genericDeclaration;
     try {
       genericDeclaration = Class.forName("java.lang.reflect.GenericDeclaration");
@@ -453,7 +453,7 @@ public class InvokableTest extends TestCase {
 
   static class Foo {}
 
-  public void testConstructor_isOverridablel() throws Exception {
+  public void testConstructor_isOverridable() throws Exception {
     Invokable<?, ?> delegate = Invokable.from(Foo.class.getDeclaredConstructor());
     assertFalse(delegate.isOverridable());
     assertFalse(delegate.isVarArgs());

--- a/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenResolutionTest.java
@@ -255,7 +255,7 @@ public class TypeTokenResolutionTest extends TestCase {
     }
   }
 
-  public void testConextIsParameterizedType() throws Exception {
+  public void testContextIsParameterizedType() throws Exception {
     class Context {
       @SuppressWarnings("unused") // used by reflection
       Map<String, Integer> returningMap() {

--- a/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenSubtypeTest.java
@@ -237,7 +237,7 @@ public class TypeTokenSubtypeTest extends TestCase {
     @TestSubtype(suppressGetSupertype = true, suppressGetSubtype = true)
     public List<RecursiveTypeBoundBugExample<?>> ifYouUseTheTypeVariableOnTheClassAndItIsRecursive(
         List<RecursiveTypeBoundBugExample<? extends RecursiveTypeBoundBugExample<T>>> arg) {
-      return notSubtype(arg); // isSubtype() currently incorectly considers it a subtype.
+      return notSubtype(arg); // isSubtype() currently incorrectly considers it a subtype.
     }
   }
 

--- a/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
+++ b/guava-tests/test/com/google/common/reflect/TypeTokenTest.java
@@ -1101,7 +1101,7 @@ public class TypeTokenTest extends TestCase {
   }
 
   public void testGetSupertype_chained() {
-    @SuppressWarnings("unchecked") // StringListIterable extensd ListIterable<String>
+    @SuppressWarnings("unchecked") // StringListIterable extends ListIterable<String>
     TypeToken<ListIterable<String>> listIterableType =
         (TypeToken<ListIterable<String>>)
             TypeToken.of(StringListIterable.class).getSupertype(ListIterable.class);
@@ -1794,7 +1794,7 @@ public class TypeTokenTest extends TestCase {
 
     abstract <T2 extends CharSequence & Iterable<T2>> void acceptT2(T2 t2);
 
-    static void verifyConsitentRawType() {
+    static void verifyConsistentRawType() {
       for (Method method : RawTypeConsistencyTester.class.getDeclaredMethods()) {
         assertEquals(
             method.getReturnType(), TypeToken.of(method.getGenericReturnType()).getRawType());
@@ -1808,7 +1808,7 @@ public class TypeTokenTest extends TestCase {
   }
 
   public void testRawTypes() {
-    RawTypeConsistencyTester.verifyConsitentRawType();
+    RawTypeConsistencyTester.verifyConsistentRawType();
     assertEquals(Object.class, TypeToken.of(Types.subtypeOf(Object.class)).getRawType());
     assertEquals(
         CharSequence.class, TypeToken.of(Types.subtypeOf(CharSequence.class)).getRawType());

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -424,7 +424,6 @@ public class AbstractFutureTest extends TestCase {
    * He did the bash, he did the future bash The future bash, it was a concurrency smash He did the
    * bash, it caught on in a flash He did the bash, he did the future bash
    */
-
   public void testFutureBash() {
     final CyclicBarrier barrier =
         new CyclicBarrier(
@@ -559,7 +558,7 @@ public class AbstractFutureTest extends TestCase {
     allTasks.add(setFutureCancelRunnable);
     for (int k = 0; k < 50; k++) {
       // For each listener we add a task that submits it to the executor directly for the blocking
-      // get usecase and another task that adds it as a listener to the future to exercise both
+      // get use case and another task that adds it as a listener to the future to exercise both
       // racing addListener calls and addListener calls completing after the future completes.
       final Runnable listener =
           k % 2 == 0 ? collectResultsRunnable : collectResultsTimedGetRunnable;
@@ -683,7 +682,7 @@ public class AbstractFutureTest extends TestCase {
     allTasks.add(setFutureCompleteSuccessfullyRunnable);
     for (int k = 0; k < size; k++) {
       // For each listener we add a task that submits it to the executor directly for the blocking
-      // get usecase and another task that adds it as a listener to the future to exercise both
+      // get use case and another task that adds it as a listener to the future to exercise both
       // racing addListener calls and addListener calls completing after the future completes.
       final Runnable listener =
           k % 2 == 0 ? collectResultsRunnable : collectResultsTimedGetRunnable;

--- a/guava-tests/test/com/google/common/util/concurrent/AggregateFutureStateFallbackAtomicHelperTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AggregateFutureStateFallbackAtomicHelperTest.java
@@ -40,11 +40,10 @@ import junit.framework.TestSuite;
  * </ul>
  *
  * To force selection of our fallback strategies we load {@link AggregateFutureState} (and all of
- * {@code com.google.common.util.concurrent} in degenerate class loaders which make certain platform
- * classes unavailable. Then we construct a test suite so we can run the normal FuturesTest test
- * methods in these degenerate classloaders.
+ * {@code com.google.common.util.concurrent}) in degenerate class loaders which make certain
+ * platform classes unavailable. Then we construct a test suite so we can run the normal FuturesTest
+ * test methods in these degenerate classloaders.
  */
-
 public class AggregateFutureStateFallbackAtomicHelperTest extends TestCase {
 
   /**

--- a/guava-tests/test/com/google/common/util/concurrent/FutureCallbackTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FutureCallbackTest.java
@@ -89,7 +89,7 @@ public class FutureCallbackTest extends TestCase {
     addCallback(f, callback, directExecutor());
   }
 
-  public void testRuntimeExeceptionFromGet() {
+  public void testRuntimeExceptionFromGet() {
     RuntimeException e = new IllegalArgumentException("foo not found");
     ListenableFuture<String> f = UncheckedThrowingFuture.throwingRuntimeException(e);
     MockCallback callback = new MockCallback(e);

--- a/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/FuturesTest.java
@@ -388,7 +388,7 @@ public class FuturesTest extends TestCase {
         new AsyncFunction<Foo, Bar>() {
           @Override
           public ListenableFuture<Bar> apply(Foo unused) {
-            throw new AssertionFailedError("Unexpeted call to apply.");
+            throw new AssertionFailedError("Unexpected call to apply.");
           }
         };
     assertTrue(transformAsync(input, function, directExecutor()).cancel(false));
@@ -402,7 +402,7 @@ public class FuturesTest extends TestCase {
         new AsyncFunction<Foo, Bar>() {
           @Override
           public ListenableFuture<Bar> apply(Foo unused) {
-            throw new AssertionFailedError("Unexpeted call to apply.");
+            throw new AssertionFailedError("Unexpected call to apply.");
           }
         };
     assertTrue(transformAsync(input, function, directExecutor()).cancel(true));

--- a/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/SequentialExecutorTest.java
@@ -310,7 +310,7 @@ public class SequentialExecutorTest extends TestCase {
       executor.execute(errorTask);
       service.execute(barrierTask); // submit directly to the service
       // the barrier task runs after the error task so we know that the error has been observed by
-      // SequentialExecutor by the time the barrier is satified
+      // SequentialExecutor by the time the barrier is satisfied
       barrier.await(1, TimeUnit.SECONDS);
       executor.execute(barrierTask);
       // timeout means the second task wasn't even tried

--- a/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/ServiceManagerTest.java
@@ -504,7 +504,7 @@ public class ServiceManagerTest extends TestCase {
           }
         };
     stoppingThread.start();
-    // this should be super fast since the only non stopped service is a NoOpService
+    // this should be super fast since the only non-stopped service is a NoOpService
     stoppingThread.join(1000);
     assertFalse("stopAsync has deadlocked!.", stoppingThread.isAlive());
     failLeave.countDown(); // release the background thread
@@ -623,7 +623,7 @@ public class ServiceManagerTest extends TestCase {
   }
 
   /**
-   * This service will shutdown very quickly after stopAsync is called and uses a background thread
+   * This service will shut down very quickly after stopAsync is called and uses a background thread
    * so that we know that the stopping() listeners will execute on a different thread than the
    * terminated() listeners.
    */

--- a/guava-tests/test/com/google/common/util/concurrent/TrustedListenableFutureTaskTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/TrustedListenableFutureTaskTest.java
@@ -205,7 +205,7 @@ public class TrustedListenableFutureTaskTest extends TestCase {
     exitLatch.await();
   }
 
-  @GwtIncompatible // used only in GwtIncomaptible tests
+  @GwtIncompatible // used only in GwtIncompatible tests
   private void awaitUnchecked(CyclicBarrier barrier) {
     try {
       barrier.await();

--- a/guava/src/com/google/common/base/MoreObjects.java
+++ b/guava/src/com/google/common/base/MoreObjects.java
@@ -349,7 +349,7 @@ public final class MoreObjects {
     }
 
     private static boolean isEmpty(Object value) {
-      // Put types estimated to be most frequent first.
+      // Put types estimated to be the most frequent first.
       if (value instanceof CharSequence) {
         return ((CharSequence) value).length() == 0;
       } else if (value instanceof Collection) {

--- a/guava/src/com/google/common/base/StandardSystemProperty.java
+++ b/guava/src/com/google/common/base/StandardSystemProperty.java
@@ -125,7 +125,7 @@ public enum StandardSystemProperty {
     this.key = key;
   }
 
-  /** Returns the key used to lookup this system property. */
+  /** Returns the key used to look up this system property. */
   public String key() {
     return key;
   }

--- a/guava/src/com/google/common/base/Throwables.java
+++ b/guava/src/com/google/common/base/Throwables.java
@@ -516,7 +516,7 @@ public final class Throwables {
   /**
    * Returns the Method that can be used to return the size of a stack, or null if that method
    * cannot be found (it is only to be found in fairly recent JDKs). Tries to test method {@link
-   * sun.misc.JavaLangAccess#getStackTraceDepth(Throwable)} getStackTraceDepth} prior to return it
+   * sun.misc.JavaLangAccess#getStackTraceDepth(Throwable) getStackTraceDepth} prior to return it
    * (might fail some JDKs).
    *
    * <p>See <a href="https://github.com/google/guava/issues/2887">Throwables#lazyStackTrace throws

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -1768,7 +1768,8 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
    * up stale entries. As such it should only be called outside a segment context, such as during
    * iteration.
    */
-  @Nullable V getLiveValue(ReferenceEntry<K, V> entry, long now) {
+  @Nullable
+  V getLiveValue(ReferenceEntry<K, V> entry, long now) {
     if (entry.getKey() == null) {
       return null;
     }
@@ -2231,7 +2232,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
             valueReference = e.getValueReference();
             if (map.isExpired(e, now)) {
               // This is a duplicate check, as preWriteCleanup already purged expired
-              // entries, but let's accomodate an incorrect expiration queue.
+              // entries, but let's accommodate an incorrect expiration queue.
               enqueueNotification(
                   entryKey,
                   hash,

--- a/guava/src/com/google/common/collect/ClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/ClassToInstanceMap.java
@@ -39,7 +39,7 @@ import javax.annotation.CheckForNull;
  * implementation and this interface specify otherwise. Thus, if you use a nullness checker, you can
  * safely suppress any warnings it produces when you write null values into a {@code
  * MutableClassToInstanceMap}. Just be sure to be prepared for null values when reading from it,
- * since nullness checkers will assume that vaules are non-null then, too.
+ * since nullness checkers will assume that values are non-null then, too.
  *
  * <p>See the Guava User Guide article on <a href=
  * "https://github.com/google/guava/wiki/NewCollectionTypesExplained#classtoinstancemap">{@code
@@ -55,7 +55,7 @@ import javax.annotation.CheckForNull;
 @DoNotMock("Use ImmutableClassToInstanceMap or MutableClassToInstanceMap")
 @GwtCompatible
 @ElementTypesAreNonnullByDefault
-// If we ever support non-null projections (https://github.com/jspecify/jspecify/issues/86), we
+// If we ever support non-null projections (https://github.com/jspecify/jspecify/issues/86),
 // we might annotate this as...
 // ClassToInstanceMap<B extends @Nullable Object> extends Map<Class<? extends @Nonnull B>, B>
 // ...and change its methods similarly (<T extends @Nonnull B> or Class<@Nonnull T>).

--- a/guava/src/com/google/common/collect/CompactHashMap.java
+++ b/guava/src/com/google/common/collect/CompactHashMap.java
@@ -117,9 +117,7 @@ class CompactHashMap<K extends @Nullable Object, V extends @Nullable Object>
    * Maximum allowed false positive probability of detecting a hash flooding attack given random
    * input.
    */
-  @VisibleForTesting(
-      )
-  static final double HASH_FLOODING_FPP = 0.001;
+  @VisibleForTesting() static final double HASH_FLOODING_FPP = 0.001;
 
   /**
    * Maximum allowed length of a hash table bucket before falling back to a j.u.LinkedHashMap-based
@@ -413,7 +411,7 @@ class CompactHashMap<K extends @Nullable Object, V extends @Nullable Object>
   private void resizeMeMaybe(int newSize) {
     int entriesSize = requireEntries().length;
     if (newSize > entriesSize) {
-      // 1.5x but round up to nearest odd (this is optimal for memory consumption on Android)
+      // 1.5x but round up to the nearest odd (this is optimal for memory consumption on Android)
       int newCapacity =
           Math.min(CompactHashing.MAX_SIZE, (entriesSize + Math.max(1, entriesSize >>> 1)) | 1);
       if (newCapacity != entriesSize) {

--- a/guava/src/com/google/common/collect/CompactHashSet.java
+++ b/guava/src/com/google/common/collect/CompactHashSet.java
@@ -131,9 +131,7 @@ class CompactHashSet<E extends @Nullable Object> extends AbstractSet<E> implemen
    * Maximum allowed false positive probability of detecting a hash flooding attack given random
    * input.
    */
-  @VisibleForTesting(
-      )
-  static final double HASH_FLOODING_FPP = 0.001;
+  @VisibleForTesting() static final double HASH_FLOODING_FPP = 0.001;
 
   /**
    * Maximum allowed length of a hash table bucket before falling back to a j.u.LinkedHashSet based
@@ -365,7 +363,7 @@ class CompactHashSet<E extends @Nullable Object> extends AbstractSet<E> implemen
   private void resizeMeMaybe(int newSize) {
     int entriesSize = requireEntries().length;
     if (newSize > entriesSize) {
-      // 1.5x but round up to nearest odd (this is optimal for memory consumption on Android)
+      // 1.5x but round up to the nearest odd (this is optimal for memory consumption on Android)
       int newCapacity =
           Math.min(CompactHashing.MAX_SIZE, (entriesSize + Math.max(1, entriesSize >>> 1)) | 1);
       if (newCapacity != entriesSize) {

--- a/guava/src/com/google/common/collect/ContiguousSet.java
+++ b/guava/src/com/google/common/collect/ContiguousSet.java
@@ -245,7 +245,7 @@ public abstract class ContiguousSet<C extends Comparable> extends ImmutableSorte
     return new DescendingImmutableSortedSet<>(this);
   }
 
-  /** Returns a short-hand representation of the contents such as {@code "[1..100]"}. */
+  /** Returns a shorthand representation of the contents such as {@code "[1..100]"}. */
   @Override
   public String toString() {
     return range().toString();

--- a/guava/src/com/google/common/collect/FluentIterable.java
+++ b/guava/src/com/google/common/collect/FluentIterable.java
@@ -577,7 +577,7 @@ public abstract class FluentIterable<E extends @Nullable Object> implements Iter
    * iterable skips all of its elements.
    *
    * <p>Modifications to this fluent iterable before a call to {@code iterator()} are reflected in
-   * the returned fluent iterable. That is, the its iterator skips the first {@code numberToSkip}
+   * the returned fluent iterable. That is, the iterator skips the first {@code numberToSkip}
    * elements that exist when the iterator is created, not when {@code skip()} is called.
    *
    * <p>The returned fluent iterable's iterator supports {@code remove()} if the {@code Iterator} of
@@ -727,7 +727,7 @@ public abstract class FluentIterable<E extends @Nullable Object> implements Iter
    *
    * <p><b>{@code Stream} equivalent:</b> {@code stream.collect(Collectors.groupingBy(keyFunction))}
    * behaves similarly, but returns a mutable {@code Map<K, List<E>>} instead, and may not preserve
-   * the order of entries).
+   * the order of entries.
    *
    * @param keyFunction the function used to produce the key for each value
    * @throws NullPointerException if any element of this iterable is {@code null}, or if {@code

--- a/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -53,10 +53,10 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableBiMapFauxverideShim<
    * and values are the result of applying the provided mapping functions to the input elements.
    * Entries appear in the result {@code ImmutableBiMap} in encounter order.
    *
-   * <p>If the mapped keys or values contain duplicates (according to {@link Object#equals(Object)},
-   * an {@code IllegalArgumentException} is thrown when the collection operation is performed. (This
-   * differs from the {@code Collector} returned by {@link Collectors#toMap(Function, Function)},
-   * which throws an {@code IllegalStateException}.)
+   * <p>If the mapped keys or values contain duplicates (according to {@link
+   * Object#equals(Object)}), an {@code IllegalArgumentException} is thrown when the collection
+   * operation is performed. (This differs from the {@code Collector} returned by {@link
+   * Collectors#toMap(Function, Function)}, which throws an {@code IllegalStateException}.)
    *
    * @since 21.0
    */

--- a/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -519,7 +519,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
    * such a set can be performed efficiently, but others (such as {@link Set#hashCode} or {@link
    * Collections#frequency}) can cause major performance problems.
    *
-   * <p>The returned set's {@link Object#toString} method returns a short-hand form of the set's
+   * <p>The returned set's {@link Object#toString} method returns a shorthand form of the set's
    * contents, such as {@code "[1..100]}"}.
    *
    * @throws IllegalArgumentException if neither this range nor the domain has a lower bound, or if

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -864,7 +864,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
 
     /**
      * We attempt to detect deliberate hash flooding attempts. If one is detected, we fall back to a
-     * wrapper around j.u.HashSet, which has built in flooding protection. MAX_RUN_MULTIPLIER was
+     * wrapper around j.u.HashSet, which has built-in flooding protection. MAX_RUN_MULTIPLIER was
      * determined experimentally to match our desired probability of false positives.
      */
     // NB: yes, this is surprisingly high, but that's what the experiments said was necessary

--- a/guava/src/com/google/common/collect/LinkedHashMultimap.java
+++ b/guava/src/com/google/common/collect/LinkedHashMultimap.java
@@ -172,8 +172,8 @@ public final class LinkedHashMultimap<K extends @Nullable Object, V extends @Nul
      * always call succeedsIn*() to initialize them immediately thereafter.
      *
      * The exception is the *InValueSet fields of multimapHeaderEntry, which are never set. (That
-     * works out fine as long as we continue to be careful not to try delete them or iterate past
-     * them.)
+     * works out fine as long as we continue to be careful not to try to delete them or iterate
+     * past them.)
      *
      * We could consider "lying" and omitting @CheckNotNull from all these fields. Normally, I'm not
      * a fan of that: What if we someday implement (presumably to be enabled during tests only)
@@ -187,7 +187,7 @@ public final class LinkedHashMultimap<K extends @Nullable Object, V extends @Nul
      * hopefully could avoid implementing Entry or ValueSetLink at all. (But note that that approach
      * requires us to define extra classes -- unfortunate under Android.) *Then* we could consider
      * lying about the fields below on the grounds that we always initialize them just after the
-     * constructor -- an example of the kind of lying that our hypotheticaly bytecode rewriter would
+     * constructor -- an example of the kind of lying that our hypothetically bytecode rewriter would
      * already have to deal with, thanks to DI frameworks that perform field and method injection,
      * frameworks like Android that define post-construct hooks like Activity.onCreate, etc.
      */

--- a/guava/src/com/google/common/collect/LinkedListMultimap.java
+++ b/guava/src/com/google/common/collect/LinkedListMultimap.java
@@ -213,7 +213,7 @@ public class LinkedListMultimap<K extends @Nullable Object, V extends @Nullable 
   /**
    * Adds a new node for the specified key-value pair before the specified {@code nextSibling}
    * element, or at the end of the list if {@code nextSibling} is null. Note: if {@code nextSibling}
-   * is specified, it MUST be for an node for the same {@code key}!
+   * is specified, it MUST be for a node for the same {@code key}!
    */
   @CanIgnoreReturnValue
   private Node<K, V> addNode(

--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -996,7 +996,7 @@ class MapMakerInternalMap<
 
     /**
      * Returns a freshly created {@link WeakValueReference} for the given {@code entry} (and on the
-     * given {@code queue} with the same value as this {@link WeakValueReference}.
+     * given {@code queue}) with the same value as this {@link WeakValueReference}.
      */
     WeakValueReference<K, V, E> copyFor(ReferenceQueue<V> queue, E entry);
   }
@@ -1033,7 +1033,7 @@ class MapMakerInternalMap<
   }
 
   /**
-   * A singleton {@link WeakValueReference} used to denote an unset value in a entry with weak
+   * A singleton {@link WeakValueReference} used to denote an unset value in an entry with weak
    * values.
    */
   static final WeakValueReference<Object, Object, DummyInternalEntry> UNSET_WEAK_VALUE_REFERENCE =
@@ -1289,7 +1289,7 @@ class MapMakerInternalMap<
      * implementation type.
      *
      * <p>This method is provided as a convenience for tests. Otherwise they'd need to be
-     * knowledgable about all the implementation details of our type system trickery.
+     * knowledgeable about all the implementation details of our type system trickery.
      */
     abstract E castForTesting(InternalEntry<K, V, ?> entry);
 

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1499,7 +1499,7 @@ public final class Maps {
 
   /**
    * Returns an unmodifiable view of the specified map entry. The {@link Entry#setValue} operation
-   * throws an {@link UnsupportedOperationException}. This also has the side-effect of redefining
+   * throws an {@link UnsupportedOperationException}. This also has the side effect of redefining
    * {@code equals} to comply with the Entry contract, to avoid a possible nefarious implementation
    * of equals.
    *

--- a/guava/src/com/google/common/collect/MinMaxPriorityQueue.java
+++ b/guava/src/com/google/common/collect/MinMaxPriorityQueue.java
@@ -518,7 +518,7 @@ public final class MinMaxPriorityQueue<E> extends AbstractQueue<E> {
   }
 
   /**
-   * Each instance of MinMaxPriortyQueue encapsulates two instances of Heap: a min-heap and a
+   * Each instance of MinMaxPriorityQueue encapsulates two instances of Heap: a min-heap and a
    * max-heap. Conceptually, these might each have their own array for storage, but for efficiency's
    * sake they are stored interleaved on alternate heap levels in the same array (MMPQ.queue).
    */

--- a/guava/src/com/google/common/collect/MoreCollectors.java
+++ b/guava/src/com/google/common/collect/MoreCollectors.java
@@ -51,7 +51,7 @@ public final class MoreCollectors {
           Collector.Characteristics.UNORDERED);
 
   /**
-   * A collector that converts a stream of zero or one elements to an {@code Optional}.
+   * A collector that converts a stream of zero or one element to an {@code Optional}.
    *
    * @throws IllegalArgumentException if the stream consists of two or more elements.
    * @throws NullPointerException if any element in the stream is {@code null}.

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -1159,7 +1159,7 @@ public final class Multisets {
   }
 
   /**
-   * Returns a copy of {@code multiset} as an {@link ImmutableMultiset} whose iteration order is
+   * Returns a copy of {@code multiset} as an {@link ImmutableMultiset} whose iteration order is the
    * highest count first, with ties broken by the iteration order of the original multiset.
    *
    * @since 11.0

--- a/guava/src/com/google/common/collect/Ordering.java
+++ b/guava/src/com/google/common/collect/Ordering.java
@@ -565,7 +565,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * <p><b>Java 8 users:</b> If {@code iterable} is a {@link Collection}, use {@code
    * Collections.min(collection, thisComparator)} instead. Otherwise, use {@code
    * Streams.stream(iterable).min(thisComparator).get()} instead. Note that these alternatives do
-   * not guarantee which tied minimum element is returned)
+   * not guarantee which tied minimum element is returned.
    *
    * @param iterable the iterable whose minimum element is to be determined
    * @throws NoSuchElementException if {@code iterable} is empty
@@ -656,7 +656,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * <p><b>Java 8 users:</b> If {@code iterable} is a {@link Collection}, use {@code
    * Collections.max(collection, thisComparator)} instead. Otherwise, use {@code
    * Streams.stream(iterable).max(thisComparator).get()} instead. Note that these alternatives do
-   * not guarantee which tied maximum element is returned)
+   * not guarantee which tied maximum element is returned.
    *
    * @param iterable the iterable whose maximum element is to be determined
    * @throws NoSuchElementException if {@code iterable} is empty
@@ -839,11 +839,10 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * duplicates according to the comparator. The sort performed is <i>stable</i>, meaning that such
    * elements will appear in the returned list in the same order they appeared in {@code elements}.
    *
-   * <p><b>Performance note:</b> According to our
-   * benchmarking
-   * on Open JDK 7, {@link #immutableSortedCopy} generally performs better (in both time and space)
-   * than this method, and this method in turn generally performs better than copying the list and
-   * calling {@link Collections#sort(List)}.
+   * <p><b>Performance note:</b> According to our benchmarking on OpenJDK 7, {@link
+   * #immutableSortedCopy} generally performs better (in both time and space) than this method, and
+   * this method in turn generally performs better than copying the list and calling {@link
+   * Collections#sort(List)}.
    */
   // TODO(kevinb): rerun benchmarks including new options
   public <E extends T> List<E> sortedCopy(Iterable<E> elements) {
@@ -861,9 +860,8 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * duplicates according to the comparator. The sort performed is <i>stable</i>, meaning that such
    * elements will appear in the returned list in the same order they appeared in {@code elements}.
    *
-   * <p><b>Performance note:</b> According to our
-   * benchmarking
-   * on Open JDK 7, this method is the most efficient way to make a sorted copy of a collection.
+   * <p><b>Performance note:</b> According to our benchmarking on OpenJDK 7, this method is the most
+   * efficient way to make a sorted copy of a collection.
    *
    * @throws NullPointerException if any element of {@code elements} is {@code null}
    * @since 3.0
@@ -931,8 +929,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    * @deprecated Use {@link Collections#binarySearch(List, Object, Comparator)} directly.
    */
   @Deprecated
-  public int binarySearch(
-      List<? extends T> sortedList, @ParametricNullness T key) {
+  public int binarySearch(List<? extends T> sortedList, @ParametricNullness T key) {
     return Collections.binarySearch(sortedList, key, this);
   }
 

--- a/guava/src/com/google/common/collect/SortedMultiset.java
+++ b/guava/src/com/google/common/collect/SortedMultiset.java
@@ -92,8 +92,8 @@ public interface SortedMultiset<E extends @Nullable Object>
   /**
    * {@inheritDoc}
    *
-   * <p>The {@code entrySet}'s iterator returns entries in ascending element order according to the
-   * this multiset's comparator.
+   * <p>The {@code entrySet}'s iterator returns entries in ascending element order according to this
+   * multiset's comparator.
    */
   @Override
   Set<Entry<E>> entrySet();

--- a/guava/src/com/google/common/collect/StandardTable.java
+++ b/guava/src/com/google/common/collect/StandardTable.java
@@ -982,7 +982,7 @@ class StandardTable<R, C, V> extends AbstractTable<R, C, V> implements Serializa
       public boolean removeAll(Collection<?> c) {
         /*
          * We can't inherit the normal implementation (which calls
-         * Sets.removeAllImpl(Set, *Collection*) because, under some
+         * Sets.removeAllImpl(Set, *Collection*)) because, under some
          * circumstances, it attempts to call columnKeySet().iterator().remove,
          * which is unsupported.
          */

--- a/guava/src/com/google/common/escape/ArrayBasedUnicodeEscaper.java
+++ b/guava/src/com/google/common/escape/ArrayBasedUnicodeEscaper.java
@@ -128,7 +128,7 @@ public abstract class ArrayBasedUnicodeEscaper extends UnicodeEscaper {
       this.safeMinChar = Character.MAX_VALUE;
       this.safeMaxChar = 0;
     } else {
-      // The safe range is non empty and contains values below the surrogate
+      // The safe range is non-empty and contains values below the surrogate
       // range but may extend above it. We may need to clip the maximum value.
       this.safeMinChar = (char) safeMin;
       this.safeMaxChar = (char) Math.min(safeMax, Character.MIN_HIGH_SURROGATE - 1);

--- a/guava/src/com/google/common/escape/Escapers.java
+++ b/guava/src/com/google/common/escape/Escapers.java
@@ -186,7 +186,7 @@ public final class Escapers {
       return wrap((CharEscaper) escaper);
     }
     // In practice this shouldn't happen because it would be very odd not to
-    // extend either CharEscaper or UnicodeEscaper for non trivial cases.
+    // extend either CharEscaper or UnicodeEscaper for non-trivial cases.
     throw new IllegalArgumentException(
         "Cannot create a UnicodeEscaper from: " + escaper.getClass().getName());
   }

--- a/guava/src/com/google/common/eventbus/Dispatcher.java
+++ b/guava/src/com/google/common/eventbus/Dispatcher.java
@@ -133,7 +133,7 @@ abstract class Dispatcher {
     // This dispatcher matches the original dispatch behavior of AsyncEventBus.
     //
     // We can't really make any guarantees about the overall dispatch order for this dispatcher in
-    // a multithreaded environment for a couple reasons:
+    // a multithreaded environment for a couple of reasons:
     //
     // 1. Subscribers to events posted on different threads can be interleaved with each other
     //    freely. (A event on one thread, B event on another could yield any of

--- a/guava/src/com/google/common/graph/Network.java
+++ b/guava/src/com/google/common/graph/Network.java
@@ -283,9 +283,10 @@ public interface Network<N, E> extends SuccessorsFunction<N>, PredecessorsFuncti
    *
    * <p>In an undirected network, this is equal to {@code edgesConnecting(nodeV, nodeU)}.
    *
-   * <p>The resulting set of edges will be parallel (i.e. have equal {@link #incidentNodes(Object)}.
-   * If this network does not {@link #allowsParallelEdges() allow parallel edges}, the resulting set
-   * will contain at most one edge (equivalent to {@code edgeConnecting(nodeU, nodeV).asSet()}).
+   * <p>The resulting set of edges will be parallel (i.e. have equal {@link
+   * #incidentNodes(Object)}). If this network does not {@link #allowsParallelEdges() allow parallel
+   * edges}, the resulting set will contain at most one edge (equivalent to {@code
+   * edgeConnecting(nodeU, nodeV).asSet()}).
    *
    * @throws IllegalArgumentException if {@code nodeU} or {@code nodeV} is not an element of this
    *     network
@@ -296,9 +297,10 @@ public interface Network<N, E> extends SuccessorsFunction<N>, PredecessorsFuncti
    * Returns the set of edges that each directly connect {@code endpoints} (in the order, if any,
    * specified by {@code endpoints}).
    *
-   * <p>The resulting set of edges will be parallel (i.e. have equal {@link #incidentNodes(Object)}.
-   * If this network does not {@link #allowsParallelEdges() allow parallel edges}, the resulting set
-   * will contain at most one edge (equivalent to {@code edgeConnecting(endpoints).asSet()}).
+   * <p>The resulting set of edges will be parallel (i.e. have equal {@link
+   * #incidentNodes(Object)}). If this network does not {@link #allowsParallelEdges() allow parallel
+   * edges}, the resulting set will contain at most one edge (equivalent to {@code
+   * edgeConnecting(endpoints).asSet()}).
    *
    * <p>If this network is directed, {@code endpoints} must be ordered.
    *

--- a/guava/src/com/google/common/hash/BloomFilterStrategies.java
+++ b/guava/src/com/google/common/hash/BloomFilterStrategies.java
@@ -94,7 +94,7 @@ enum BloomFilterStrategies implements BloomFilter.Strategy {
   },
   /**
    * This strategy uses all 128 bits of {@link Hashing#murmur3_128} when hashing. It looks different
-   * than the implementation in MURMUR128_MITZ_32 because we're avoiding the multiplication in the
+   * from the implementation in MURMUR128_MITZ_32 because we're avoiding the multiplication in the
    * loop and doing a (much simpler) += hash2. We're also changing the index to a positive number by
    * AND'ing with Long.MAX_VALUE instead of flipping the bits.
    */

--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -119,9 +119,7 @@ public final class Files {
     return new FileByteSource(file);
   }
 
-  private static final class FileByteSource extends
-      ByteSource
-  {
+  private static final class FileByteSource extends ByteSource {
 
     private final File file;
 
@@ -342,8 +340,7 @@ public final class Files {
   @InlineMe(
       replacement = "Files.asCharSource(from, charset).copyTo(to)",
       imports = "com.google.common.io.Files")
-  public
-  static void copy(File from, Charset charset, Appendable to) throws IOException {
+  public static void copy(File from, Charset charset, Appendable to) throws IOException {
     asCharSource(from, charset).copyTo(to);
   }
 
@@ -362,8 +359,7 @@ public final class Files {
   @InlineMe(
       replacement = "Files.asCharSink(to, charset, FileWriteMode.APPEND).write(from)",
       imports = {"com.google.common.io.FileWriteMode", "com.google.common.io.Files"})
-  public
-  static void append(CharSequence from, File to, Charset charset) throws IOException {
+  public static void append(CharSequence from, File to, Charset charset) throws IOException {
     asCharSink(to, charset, FileWriteMode.APPEND).write(from);
   }
 
@@ -402,7 +398,7 @@ public final class Files {
    * be exploited to create security vulnerabilities, especially when executable files are to be
    * written into the directory.
    *
-   * <p>Depending on the environmment that this code is run in, the system temporary directory (and
+   * <p>Depending on the environment that this code is run in, the system temporary directory (and
    * thus the directory this method creates) may be more visible that a program would like - files
    * written to this directory may be read or overwritten by hostile programs running on the same
    * machine.
@@ -532,8 +528,7 @@ public final class Files {
       replacement = "Files.asCharSource(file, charset).readFirstLine()",
       imports = "com.google.common.io.Files")
   @CheckForNull
-  public
-  static String readFirstLine(File file, Charset charset) throws IOException {
+  public static String readFirstLine(File file, Charset charset) throws IOException {
     return asCharSource(file, charset).readFirstLine();
   }
 
@@ -592,8 +587,7 @@ public final class Files {
       imports = "com.google.common.io.Files")
   @CanIgnoreReturnValue // some processors won't return a useful result
   @ParametricNullness
-  public
-  static <T extends @Nullable Object> T readLines(
+  public static <T extends @Nullable Object> T readLines(
       File file, Charset charset, LineProcessor<T> callback) throws IOException {
     return asCharSource(file, charset).readLines(callback);
   }
@@ -615,8 +609,7 @@ public final class Files {
       imports = "com.google.common.io.Files")
   @CanIgnoreReturnValue // some processors won't return a useful result
   @ParametricNullness
-  public
-  static <T extends @Nullable Object> T readBytes(File file, ByteProcessor<T> processor)
+  public static <T extends @Nullable Object> T readBytes(File file, ByteProcessor<T> processor)
       throws IOException {
     return asByteSource(file).read(processor);
   }
@@ -635,8 +628,7 @@ public final class Files {
   @InlineMe(
       replacement = "Files.asByteSource(file).hash(hashFunction)",
       imports = "com.google.common.io.Files")
-  public
-  static HashCode hash(File file, HashFunction hashFunction) throws IOException {
+  public static HashCode hash(File file, HashFunction hashFunction) throws IOException {
     return asByteSource(file).hash(hashFunction);
   }
 

--- a/guava/src/com/google/common/io/MoreFiles.java
+++ b/guava/src/com/google/common/io/MoreFiles.java
@@ -87,9 +87,7 @@ public final class MoreFiles {
     return new PathByteSource(path, options);
   }
 
-  private static final class PathByteSource extends
-      ByteSource
-  {
+  private static final class PathByteSource extends ByteSource {
 
     private static final LinkOption[] FOLLOW_LINKS = {};
 
@@ -172,7 +170,7 @@ public final class MoreFiles {
         // If no OpenOptions were passed, delegate to Files.lines, which could have performance
         // advantages. (If OpenOptions were passed we can't, because Files.lines doesn't have an
         // overload taking OpenOptions, meaning we can't guarantee the same behavior w.r.t. things
-        // like following/not following symlinks.
+        // like following/not following symlinks.)
         return new AsCharSource(charset) {
           @SuppressWarnings("FilesLinesLeak") // the user needs to close it in this case
           @Override

--- a/guava/src/com/google/common/io/ReaderInputStream.java
+++ b/guava/src/com/google/common/io/ReaderInputStream.java
@@ -198,8 +198,8 @@ final class ReaderInputStream extends InputStream {
   /** Handle the case of underflow caused by needing more input characters. */
   private void readMoreChars() throws IOException {
     // Possibilities:
-    // 1) array has space available on right hand side (between limit and capacity)
-    // 2) array has space available on left hand side (before position)
+    // 1) array has space available on right-hand side (between limit and capacity)
+    // 2) array has space available on left-hand side (before position)
     // 3) array has no space available
     //
     // In case 2 we shift the existing chars to the left, and in case 3 we create a bigger

--- a/guava/src/com/google/common/math/LongMath.java
+++ b/guava/src/com/google/common/math/LongMath.java
@@ -978,7 +978,7 @@ public final class LongMath {
   }
 
   /*
-   * This bitmask is used as an optimization for cheaply testing for divisiblity by 2, 3, or 5.
+   * This bitmask is used as an optimization for cheaply testing for divisibility by 2, 3, or 5.
    * Each bit is set to 1 for all remainders that indicate divisibility by 2, 3, or 5, so
    * 1, 7, 11, 13, 17, 19, 23, 29 are set to 0. 30 and up don't matter because they won't be hit.
    */

--- a/guava/src/com/google/common/math/Stats.java
+++ b/guava/src/com/google/common/math/Stats.java
@@ -126,9 +126,9 @@ public final class Stats implements Serializable {
    * @param values a series of values
    */
   public static Stats of(double... values) {
-    StatsAccumulator acummulator = new StatsAccumulator();
-    acummulator.addAll(values);
-    return acummulator.snapshot();
+    StatsAccumulator accumulator = new StatsAccumulator();
+    accumulator.addAll(values);
+    return accumulator.snapshot();
   }
 
   /**
@@ -137,9 +137,9 @@ public final class Stats implements Serializable {
    * @param values a series of values
    */
   public static Stats of(int... values) {
-    StatsAccumulator acummulator = new StatsAccumulator();
-    acummulator.addAll(values);
-    return acummulator.snapshot();
+    StatsAccumulator accumulator = new StatsAccumulator();
+    accumulator.addAll(values);
+    return accumulator.snapshot();
   }
 
   /**
@@ -149,9 +149,9 @@ public final class Stats implements Serializable {
    *     cause loss of precision for longs of magnitude over 2^53 (slightly over 9e15))
    */
   public static Stats of(long... values) {
-    StatsAccumulator acummulator = new StatsAccumulator();
-    acummulator.addAll(values);
-    return acummulator.snapshot();
+    StatsAccumulator accumulator = new StatsAccumulator();
+    accumulator.addAll(values);
+    return accumulator.snapshot();
   }
 
   /**

--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -522,7 +522,7 @@ public final class InetAddresses {
    * want to accept ASCII digits only, you can use something like {@code
    * CharMatcher.ascii().matchesAllOf(ipString)}.
    *
-   * @param hostAddr A RFC 3986 section 3.2.2 encoded IPv4 or IPv6 address
+   * @param hostAddr An RFC 3986 section 3.2.2 encoded IPv4 or IPv6 address
    * @return an InetAddress representing the address in {@code hostAddr}
    * @throws IllegalArgumentException if {@code hostAddr} is not a valid IPv4 address, or IPv6
    *     address surrounded by square brackets
@@ -1026,7 +1026,7 @@ public final class InetAddresses {
 
   /**
    * Converts a BigInteger to either an IPv4 or IPv6 address. If the IP is IPv4, it must be
-   * constrainted to 32 bits, otherwise it is constrained to 128 bits.
+   * constrained to 32 bits, otherwise it is constrained to 128 bits.
    *
    * @param address the address represented as a big integer
    * @param isIpv6 whether the created address should be IPv4 or IPv6

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -893,7 +893,7 @@ public final class MediaType {
    * one.
    *
    * <p>If a charset must be specified that is not supported on this JVM (and thus is not
-   * representable as a {@link Charset} instance, use {@link #withParameter}.
+   * representable as a {@link Charset} instance), use {@link #withParameter}.
    */
   public MediaType withCharset(Charset charset) {
     checkNotNull(charset);

--- a/guava/src/com/google/common/net/PercentEscaper.java
+++ b/guava/src/com/google/common/net/PercentEscaper.java
@@ -74,10 +74,10 @@ public final class PercentEscaper extends UnicodeEscaper {
    * space character.
    *
    * <p>Not that it is allowed, but not necessarily desirable to specify {@code %} as a safe
-   * character. This has the effect of creating an escaper which has no well defined inverse but it
+   * character. This has the effect of creating an escaper which has no well-defined inverse but it
    * can be useful when escaping additional characters.
    *
-   * @param safeChars a non null string specifying additional safe characters for this escaper (the
+   * @param safeChars a non-null string specifying additional safe characters for this escaper (the
    *     ranges 0..9, a..z and A..Z are always safe and should not be specified here)
    * @param plusForSpace true if ASCII space should be escaped to {@code +} rather than {@code %20}
    * @throws IllegalArgumentException if any of the parameters were invalid

--- a/guava/src/com/google/common/primitives/Ints.java
+++ b/guava/src/com/google/common/primitives/Ints.java
@@ -552,7 +552,7 @@ public final class Ints extends IntsMethodsForWeb {
     // (3) "Successive". We can consider that we are exchanging a block of size d (a[0..d-1]) with a
     //     block of size n-d (a[d..n-1]), where in general these blocks have different sizes. If we
     //     imagine a line separating the first block from the second, we can proceed by exchanging
-    //     the smaller of these blocks with the far end of the other one. That leaves us with a
+    //     the smallest of these blocks with the far end of the other one. That leaves us with a
     //     smaller version of the same problem.
     //     Say we are rotating abcdefgh by 5. We start with abcde|fgh. The smaller block is [fgh]:
     //     [abc]de|[fgh] -> [fgh]de|[abc]. Now [fgh] is in the right place, but we need to swap [de]

--- a/guava/src/com/google/common/primitives/Longs.java
+++ b/guava/src/com/google/common/primitives/Longs.java
@@ -380,7 +380,7 @@ public final class Longs {
    * <p>Note that strings prefixed with ASCII {@code '+'} are rejected, even under JDK 7, despite
    * the change to {@link Long#parseLong(String, int)} for that version.
    *
-   * @param string the string representation of an long value
+   * @param string the string representation of a long value
    * @param radix the radix to use when parsing
    * @return the long value represented by {@code string} using {@code radix}, or {@code null} if
    *     {@code string} has a length of zero or cannot be parsed as a long value

--- a/guava/src/com/google/common/primitives/UnsignedInteger.java
+++ b/guava/src/com/google/common/primitives/UnsignedInteger.java
@@ -118,7 +118,7 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
   }
 
   /**
-   * Returns the result of adding this and {@code val}. If the result would have more than 32 bits,
+   * Returns the result of adding this and {@code val}. If the result have more than 32 bits,
    * returns the low 32 bits of the result.
    *
    * @since 14.0
@@ -128,8 +128,8 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
   }
 
   /**
-   * Returns the result of subtracting this and {@code val}. If the result would be negative,
-   * returns the low 32 bits of the result.
+   * Returns the result of subtracting this and {@code val}. If the result is negative, returns the
+   * low 32 bits of the result.
    *
    * @since 14.0
    */
@@ -138,8 +138,8 @@ public final class UnsignedInteger extends Number implements Comparable<Unsigned
   }
 
   /**
-   * Returns the result of multiplying this and {@code val}. If the result would have more than 32
-   * bits, returns the low 32 bits of the result.
+   * Returns the result of multiplying this and {@code val}. If the result have more than 32 bits,
+   * returns the low 32 bits of the result.
    *
    * @since 14.0
    */

--- a/guava/src/com/google/common/primitives/UnsignedLong.java
+++ b/guava/src/com/google/common/primitives/UnsignedLong.java
@@ -125,7 +125,7 @@ public final class UnsignedLong extends Number implements Comparable<UnsignedLon
   }
 
   /**
-   * Returns the result of adding this and {@code val}. If the result would have more than 64 bits,
+   * Returns the result of adding this and {@code val}. If the result have more than 64 bits,
    * returns the low 64 bits of the result.
    *
    * @since 14.0
@@ -135,8 +135,8 @@ public final class UnsignedLong extends Number implements Comparable<UnsignedLon
   }
 
   /**
-   * Returns the result of subtracting this and {@code val}. If the result would have more than 64
-   * bits, returns the low 64 bits of the result.
+   * Returns the result of subtracting this and {@code val}. If the result have more than 64 bits,
+   * returns the low 64 bits of the result.
    *
    * @since 14.0
    */
@@ -145,8 +145,8 @@ public final class UnsignedLong extends Number implements Comparable<UnsignedLon
   }
 
   /**
-   * Returns the result of multiplying this and {@code val}. If the result would have more than 64
-   * bits, returns the low 64 bits of the result.
+   * Returns the result of multiplying this and {@code val}. If the result have more than 64 bits,
+   * returns the low 64 bits of the result.
    *
    * @since 14.0
    */

--- a/guava/src/com/google/common/reflect/Reflection.java
+++ b/guava/src/com/google/common/reflect/Reflection.java
@@ -54,7 +54,7 @@ public final class Reflection {
    *
    * <p>WARNING: Normally it's a smell if a class needs to be explicitly initialized, because static
    * state hurts system maintainability and testability. In cases when you have no choice while
-   * inter-operating with a legacy framework, this method helps to keep the code less ugly.
+   * interoperating with a legacy framework, this method helps to keep the code less ugly.
    *
    * @throws ExceptionInInitializerError if an exception is thrown during initialization of a class
    */

--- a/guava/src/com/google/common/reflect/TypeResolver.java
+++ b/guava/src/com/google/common/reflect/TypeResolver.java
@@ -42,7 +42,7 @@ import javax.annotation.CheckForNull;
  *
  * <p>Note that usually type mappings are already implied by the static type hierarchy (for example,
  * the {@code E} type variable declared by class {@code List} naturally maps to {@code String} in
- * the context of {@code class MyStringList implements List<String>}. In such case, prefer to use
+ * the context of {@code class MyStringList implements List<String>}). In such case, prefer to use
  * {@link TypeToken#resolveType} since it's simpler and more type safe. This class should only be
  * used when the type mapping isn't implied by the static type hierarchy, but provided through other
  * means such as an annotation or external configuration file.
@@ -426,7 +426,7 @@ public final class TypeResolver {
         if (var.equalsType(t)) {
           // cycle detected, remove the entire cycle from the mapping so that
           // each type variable resolves deterministically to itself.
-          // Otherwise, a F -> T cycle will end up resolving both F and T
+          // Otherwise, an F -> T cycle will end up resolving both F and T
           // nondeterministically to either F or T.
           for (Type x = arg; x != null; x = mappings.remove(TypeVariableKey.forLookup(x))) {}
           return;

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -1316,7 +1316,7 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
   }
 
   /**
-   * Collects parent types from a sub type.
+   * Collects parent types from a subtype.
    *
    * @param <K> The type "kind". Either a TypeToken, or Class.
    */

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -160,7 +160,7 @@ final class Types {
   }
 
   /**
-   * Returns human readable string representation of {@code type}.
+   * Returns a human-readable string representation of {@code type}.
    *
    * <p>The format is subject to change.
    */

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -400,7 +400,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
   // Timed Get
   // There are a few design constraints to consider
   // * We want to be responsive to small timeouts, unpark() has non trivial latency overheads (I
-  //   have observed 12 micros on 64 bit linux systems to wake up a parked thread). So if the
+  //   have observed 12 micros on 64-bit linux systems to wake up a parked thread). So if the
   //   timeout is small we shouldn't park(). This needs to be traded off with the cpu overhead of
   //   spinning, so we use SPIN_THRESHOLD_NANOS which is what AbstractQueuedSynchronizer uses for
   //   similar purposes.
@@ -1028,7 +1028,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
               continue outer;
             }
           }
-          // other wise the future we were trying to set is already done.
+          // otherwise the future we were trying to set is already done.
         } else {
           /*
            * requireNonNull is safe because the listener stack never contains TOMBSTONE until after
@@ -1119,7 +1119,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
   @CheckForNull
   private Listener clearListeners(@CheckForNull Listener onto) {
     // We need to
-    // 1. atomically swap the listeners with TOMBSTONE, this is because addListener uses that to
+    // 1. atomically swap the listeners with TOMBSTONE, this is because addListener uses that
     //    to synchronize with us
     // 2. reverse the linked list, because despite our rather clear contract, people depend on us
     //    executing listeners in the order they were added
@@ -1151,7 +1151,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
     } else if (isDone()) {
       addDoneString(builder);
     } else {
-      addPendingString(builder); // delegates to addDoneString if future completes mid-way
+      addPendingString(builder); // delegates to addDoneString if future completes midway
     }
     return builder.append("]").toString();
   }
@@ -1279,10 +1279,10 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
   }
 
   private abstract static class AtomicHelper {
-    /** Non volatile write of the thread to the {@link Waiter#thread} field. */
+    /** Non-volatile write of the thread to the {@link Waiter#thread} field. */
     abstract void putThread(Waiter waiter, Thread newValue);
 
-    /** Non volatile write of the waiter to the {@link Waiter#next} field. */
+    /** Non-volatile write of the waiter to the {@link Waiter#next} field. */
     abstract void putNext(Waiter waiter, @CheckForNull Waiter newValue);
 
     /** Performs a CAS operation on the {@link #waiters} field. */

--- a/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractIdleService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * Base class for services that do not need a thread while "running" but may need one during startup
  * and shutdown. Subclasses can implement {@link #startUp} and {@link #shutDown} methods, each which
- * run in a executor which by default uses a separate thread for each method.
+ * run in an executor which by default uses a separate thread for each method.
  *
  * @author Chris Nokleberg
  * @since 1.0

--- a/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractScheduledService.java
@@ -382,7 +382,7 @@ public abstract class AbstractScheduledService implements Service {
     }
     final ScheduledExecutorService executor =
         Executors.newSingleThreadScheduledExecutor(new ThreadFactoryImpl());
-    // Add a listener to shutdown the executor after the service is stopped. This ensures that the
+    // Add a listener to shut down the executor after the service is stopped. This ensures that the
     // JVM shutdown will not be prevented from exiting after this service has stopped or failed.
     // Technically this listener is added after start() was called so it is a little gross, but it
     // is called within doStart() so we know that the service cannot terminate or fail concurrently

--- a/guava/src/com/google/common/util/concurrent/AbstractService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractService.java
@@ -326,7 +326,7 @@ public abstract class AbstractService implements Service {
         monitor.leave();
       }
     } else {
-      // It is possible due to races the we are currently in the expected state even though we
+      // It is possible due to races we are currently in the expected state even though we
       // timed out. e.g. if we weren't event able to grab the lock within the timeout we would never
       // even check the guard. I don't think we care too much about this use case but it could lead
       // to a confusing error message.
@@ -359,7 +359,7 @@ public abstract class AbstractService implements Service {
         monitor.leave();
       }
     } else {
-      // It is possible due to races the we are currently in the expected state even though we
+      // It is possible due to races we are currently in the expected state even though we
       // timed out. e.g. if we weren't event able to grab the lock within the timeout we would never
       // even check the guard. I don't think we care too much about this use case but it could lead
       // to a confusing error message.

--- a/guava/src/com/google/common/util/concurrent/AggregateFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AggregateFuture.java
@@ -357,7 +357,7 @@ abstract class AggregateFuture<InputT extends @Nullable Object, OutputT extends 
          * We've seen this, so we've seen its causes, too. No need to re-add them. (There's one case
          * where this isn't true, but we ignore it: If we record an exception, then someone calls
          * initCause() on it, and then we examine it again, we'll conclude that we've seen the whole
-         * chain before when it fact we haven't. But this should be rare.)
+         * chain before when in fact we haven't. But this should be rare.)
          */
         return false;
       }

--- a/guava/src/com/google/common/util/concurrent/AtomicDoubleArray.java
+++ b/guava/src/com/google/common/util/concurrent/AtomicDoubleArray.java
@@ -191,7 +191,7 @@ public class AtomicDoubleArray implements java.io.Serializable {
 
   /**
    * Atomically updates the element at index {@code i} with the results of applying the given
-   * function to the curernt and given values.
+   * function to the current and given values.
    *
    * @param i the index to update
    * @param x the update value
@@ -207,7 +207,7 @@ public class AtomicDoubleArray implements java.io.Serializable {
 
   /**
    * Atomically updates the element at index {@code i} with the results of applying the given
-   * function to the curernt and given values.
+   * function to the current and given values.
    *
    * @param i the index to update
    * @param x the update value
@@ -223,7 +223,7 @@ public class AtomicDoubleArray implements java.io.Serializable {
 
   /**
    * Atomically updates the element at index {@code i} with the results of applying the given
-   * function to the curernt value.
+   * function to the current value.
    *
    * @param i the index to update
    * @param updaterFunction the update function
@@ -245,7 +245,7 @@ public class AtomicDoubleArray implements java.io.Serializable {
 
   /**
    * Atomically updates the element at index {@code i} with the results of applying the given
-   * function to the curernt value.
+   * function to the current value.
    *
    * @param i the index to update
    * @param updaterFunction the update function

--- a/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -416,7 +416,7 @@ public final class ClosingFuture<V extends @Nullable Object> {
   /**
    * Starts a {@link ClosingFuture} pipeline with a {@link ListenableFuture}.
    *
-   * <p>If {@code future} succeeds, its value will be closed (using {@code closingExecutor)} when
+   * <p>If {@code future} succeeds, its value will be closed (using {@code closingExecutor)}) when
    * the pipeline is done, even if the pipeline is canceled or fails.
    *
    * <p>Cancelling the pipeline will not cancel {@code future}, so that the pipeline can access its

--- a/guava/src/com/google/common/util/concurrent/CollectionFuture.java
+++ b/guava/src/com/google/common/util/concurrent/CollectionFuture.java
@@ -32,7 +32,7 @@ abstract class CollectionFuture<V extends @Nullable Object, C extends @Nullable 
     extends AggregateFuture<V, C> {
   /*
    * We access this field racily but safely. For discussion of a similar situation, see the comments
-   * on the fields of TimeoutFuture. This field is slightly different than the fields discussed
+   * on the fields of TimeoutFuture. This field is slightly different from the fields discussed
    * there: cancel() never reads this field, only writes to it. That makes the race here completely
    * harmless, rather than just 99.99% harmless.
    */

--- a/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
+++ b/guava/src/com/google/common/util/concurrent/ExecutionSequencer.java
@@ -54,7 +54,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *       (However, cancellation can prevent an <i>unstarted</i> task from running.) Therefore, the
  *       next task will wait for any running callable (or pending {@code Future} returned by an
  *       {@code AsyncCallable}) to complete, without interrupting it (and without calling {@code
- *       cancel} on the {@code Future}). So beware: <i>Even if you cancel every precededing {@code
+ *       cancel} on the {@code Future}). So beware: <i>Even if you cancel every preceding {@code
  *       Future} returned by this class, the next task may still have to wait.</i>.
  *   <li>Once an {@code AsyncCallable} returns a {@code Future}, this class considers that task to
  *       be "done" as soon as <i>that</i> {@code Future} completes in any way. Notably, a {@code
@@ -250,7 +250,7 @@ public final class ExecutionSequencer {
             taskFuture.cancel(false);
           }
         };
-    // Adding the listener to both futures guarantees that newFuture will aways be set. Adding to
+    // Adding the listener to both futures guarantees that newFuture will always be set. Adding to
     // taskFuture guarantees completion if the callable is invoked, and adding to outputFuture
     // propagates cancellation if the callable has not yet been invoked.
     outputFuture.addListener(listener, directExecutor());

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -106,7 +106,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   //    (hypothetical) unsafe read by our caller. Note: adding 'volatile' does not fix this issue,
   //    it would just add an edge such that if done() observed non-null, then it would also
   //    definitely observe all earlier writes, but we still have no guarantee that done() would see
-  //    the inital write (just stronger guarantees if it does).
+  //    the initial write (just stronger guarantees if it does).
   //
   // See: http://cs.oswego.edu/pipermail/concurrency-interest/2015-January/013800.html
   // For a (long) discussion about this specific issue and the general futility of life.
@@ -378,7 +378,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * <p>The delegate future is interrupted and cancelled if it times out.
    *
    * @param delegate The future to delegate to.
-   * @param time when to timeout the future
+   * @param time when to time out the future
    * @param scheduledExecutor The executor service to enforce the timeout.
    * @since 28.0
    */
@@ -396,7 +396,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    * <p>The delegate future is interrupted and cancelled if it times out.
    *
    * @param delegate The future to delegate to.
-   * @param time when to timeout the future
+   * @param time when to time out the future
    * @param unit the time unit of the time parameter
    * @param scheduledExecutor The executor service to enforce the timeout.
    * @since 19.0

--- a/guava/src/com/google/common/util/concurrent/ListenerCallQueue.java
+++ b/guava/src/com/google/common/util/concurrent/ListenerCallQueue.java
@@ -147,7 +147,7 @@ final class ListenerCallQueue<L> {
       this.executor = checkNotNull(executor);
     }
 
-    /** Enqueues a event to be run. */
+    /** Enqueues an event to be run. */
     synchronized void add(ListenerCallQueue.Event<L> event, Object label) {
       waitQueue.add(event);
       labelQueue.add(label);


### PR DESCRIPTION
Most of the typos are located in Javadoc and comments. The remaining typo were located in some test class names, some test method names, and some variable names.

The code has been formatted using google-java-format-1.7.