### PR TITLE
style: fix Bad Smells in com.google.common.collect.ForwardingMap

### DIFF
--- a/guava/src/com/google/common/collect/ForwardingMap.java
+++ b/guava/src/com/google/common/collect/ForwardingMap.java
@@ -258,7 +258,7 @@ public abstract class ForwardingMap<K extends @Nullable Object, V extends @Nulla
   @Beta
   protected abstract class StandardEntrySet extends Maps.EntrySet<K, V> {
     /** Constructor for use by subclasses. */
-    public StandardEntrySet() {}
+    protected StandardEntrySet() {}
 
     @Override
     Map<K, V> map() {


### PR DESCRIPTION
# Repairing Code Style Issues
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated
## Changes: 
* Constructor `com.google.common.collect.ForwardingMap$StandardEntrySet()` is now protected instead of public
<!-- ruleID: "NonProtectedConstructorInAbstractClass"
filePath: "guava/src/com/google/common/collect/ForwardingMap.java"
position:
  startLine: 261
  endLine: 0
  startColumn: 12
  endColumn: 0
  charOffset: 8713
  charLength: 16
message: "Constructor 'StandardEntrySet()' of an abstract class should not be declared\
  \ 'public'"
messageMarkdown: "Constructor `StandardEntrySet()` of an abstract class should not\
  \ be declared 'public'"
snippet: "  protected abstract class StandardEntrySet extends Maps.EntrySet<K, V>\
  \ {\n    /** Constructor for use by subclasses. */\n    public StandardEntrySet()\
  \ {}\n\n    @Override"
analyzer: "Qodana"
 -->
<!-- fingerprint:-110106559 -->
