### PR TITLE
6176 | Fix for "MediaType.parse doesn't like \r"

### DIFF
--- a/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -586,6 +586,12 @@ public class MediaTypeTest extends TestCase {
                 .withParameters(ImmutableListMultimap.of("a", "2", "a", "1")))
         .addEqualityGroup(MediaType.create("text", "csv"))
         .addEqualityGroup(MediaType.create("application", "atom+xml"))
+        .addEqualityGroup( //case for issue https://github.com/google/guava/issues/6176
+            MediaType.parse("application/pdf; \rname=\"foo\rbar.pdf\""),
+            MediaType.parse("application/pdf; \rname=\"foo\r\n\tbar.pdf\""),
+            MediaType.parse("application/pdf; name=\"foobar.pdf\r\""),
+            MediaType.parse("application/pdf; name=\"foobar.pdf\r\n\t\""),
+            MediaType.parse("application/pdf; name=\"foobar.pdf\""))
         .testEquals();
   }
 

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -1070,7 +1070,9 @@ public final class MediaType {
               tokenizer.consumeCharacter('\\');
               valueBuilder.append(tokenizer.consumeCharacter(ascii()));
             } else {
+              tokenizer.consumeTokenIfPresent(LINEAR_WHITE_SPACE);
               valueBuilder.append(tokenizer.consumeToken(QUOTED_TEXT_MATCHER));
+              tokenizer.consumeTokenIfPresent(LINEAR_WHITE_SPACE);
             }
           }
           value = valueBuilder.toString();


### PR DESCRIPTION
Improved method MediaType::parse to remove linear whitespaces from the attribute value during parsing.

This fixes issue https://github.com/google/guava/issues/6176