### PR TITLE
Fix typo in TypeToken javadoc

### DIFF
--- a/android/guava/src/com/google/common/reflect/TypeToken.java
+++ b/android/guava/src/com/google/common/reflect/TypeToken.java
@@ -89,7 +89,7 @@ import javax.annotation.CheckForNull;
  *
  * <p>{@code TypeToken} is serializable when no type variable is contained in the type.
  *
- * <p>Note to Guice users: {@code} TypeToken is similar to Guice's {@code TypeLiteral} class except
+ * <p>Note to Guice users: {@code TypeToken} is similar to Guice's {@code TypeLiteral} class except
  * that it is serializable and offers numerous additional utility methods.
  *
  * @author Bob Lee

--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -89,7 +89,7 @@ import javax.annotation.CheckForNull;
  *
  * <p>{@code TypeToken} is serializable when no type variable is contained in the type.
  *
- * <p>Note to Guice users: {@code} TypeToken is similar to Guice's {@code TypeLiteral} class except
+ * <p>Note to Guice users: {@code TypeToken} is similar to Guice's {@code TypeLiteral} class except
  * that it is serializable and offers numerous additional utility methods.
  *
  * @author Bob Lee


### PR DESCRIPTION
The `{@code ...}` Javadoc inline tag was incorrectly placed.