### PR TITLE
Document ForwardingExecutorService behavior for default methods

### DIFF
--- a/guava/src/com/google/common/util/concurrent/ForwardingExecutorService.java
+++ b/guava/src/com/google/common/util/concurrent/ForwardingExecutorService.java
@@ -33,6 +33,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * should override one or more methods to modify the behavior of the backing executor service as
  * desired per the <a href="http://en.wikipedia.org/wiki/Decorator_pattern">decorator pattern</a>.
  *
+ * <p><b>{@code default} method warning:</b> This class does <i>not</i> forward calls to {@code
+ * default} methods. Instead, it inherits their default implementations. When those implementations
+ * invoke methods, they invoke methods on the {@code ForwardingExecutorService}.
+ *
  * @author Kurt Alfred Kluever
  * @since 10.0
  */


### PR DESCRIPTION
Currently, Guava is built with Java 9 and `ExecutorService` has no default methods. This changes in Java 19, where `ExecutorService.close` is added. Ensure users have right expectations about future evolution of the `ForwardingExecutorService` and its compatibility with newer Java versions.

Fixes https://github.com/google/guava/issues/6296