### PR TITLE
added not thread-safe description on consumingIterable func's

### DIFF
--- a/guava/src/com/google/common/collect/Iterables.java
+++ b/guava/src/com/google/common/collect/Iterables.java
@@ -1000,7 +1000,8 @@ public final class Iterables {
    * <p>Note: If {@code iterable} is a {@link Queue}, the returned iterable will get entries from
    * {@link Queue#remove()} since {@link Queue}'s iteration order is undefined. Calling {@link
    * Iterator#hasNext()} on a generated iterator from the returned iterable may cause an item to be
-   * immediately dequeued for return on a subsequent call to {@link Iterator#next()}.
+   * immediately dequeued for return on a subsequent call to {@link Iterator#next()}. Thus, the returned
+   * {@code iterable} is not thread-safe.
    *
    * @param iterable the iterable to wrap
    * @return a view of the supplied iterable that wraps each generated iterator through {@link

--- a/guava/src/com/google/common/collect/Iterators.java
+++ b/guava/src/com/google/common/collect/Iterators.java
@@ -988,7 +988,7 @@ public final class Iterators {
    * {@code iterator} as it is returned.
    *
    * <p>The provided iterator must support {@link Iterator#remove()} or else the returned iterator
-   * will fail on the first call to {@code next}.
+   * will fail on the first call to {@code next}. The returned {@code iterator} is also not thread-safe.
    *
    * @param iterator the iterator to remove and return elements from
    * @return an iterator that removes and returns elements from the supplied iterator


### PR DESCRIPTION
related to #6141 

addressing comment https://github.com/google/guava/pull/6305#issuecomment-1399267361