### PR TITLE
Replace deprecated gradle instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ To add a dependency using Gradle:
 
 ```gradle
 dependencies {
-  compile 'com.google.guava:guava:{{ site.latest_release }}-jre'
+  implementation 'com.google.guava:guava:{{ site.latest_release }}-jre'
   // or, for Android:
   api 'com.google.guava:guava:{{ site.latest_release }}-android'
 }


### PR DESCRIPTION
The gradle docs state that
> Dependencies should no longer be declared using the compile and runtime configurations
https://docs.gradle.org/current/userguide/upgrading_version_5.html#changes_6.0