### PR TITLE
Create reproducible artifacts

### DIFF
--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -62,7 +62,7 @@
         <extensions>true</extensions>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>5.1.8</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -21,6 +21,7 @@
     <!-- Empty for all JDKs but 9-12 -->
     <maven-javadoc-plugin.additionalJOptions></maven-javadoc-plugin.additionalJOptions>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>

--- a/futures/failureaccess/pom.xml
+++ b/futures/failureaccess/pom.xml
@@ -33,7 +33,7 @@
         <extensions>true</extensions>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>5.1.8</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -62,7 +62,7 @@
         <extensions>true</extensions>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>5.1.8</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <!-- Empty for all JDKs but 9-12 -->
     <maven-javadoc-plugin.additionalJOptions></maven-javadoc-plugin.additionalJOptions>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <issueManagement>


### PR DESCRIPTION
Configures Maven to create bit-by-bit reproducible artifacts.

As with Gradle and Bnd, timestamps in jars are [normalized](https://github.com/gradle/gradle/blob/v7.6.0/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L57) to 1980 February 1st CET.  This is not without controversy, as shown by this example issue: https://github.com/FasterXML/jackson-databind/issues/3680

An alternative albeit slightly more complex approach is to update `project.build.outputTimestamp` at release time, as shown in this FAQ: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#faq

Finally, for reference purposes I've used the excellent [`diffoscope`](https://diffoscope.org/) tool to create a visual diff of `guava-31.1-jre` release vs. the same code built with this change.  Open `index.html` in this archive: [guava-diff.zip](https://github.com/google/guava/files/10692925/guava-diff.zip)

Steps to reproduce the above:
1. `$ git checkout v31.1`
2. `$ git cherry-pick ###` # the commit of this PR
3. `$ mvn clean install -U -DskipTests=true`
4. `$ curl https://repo1.maven.org/maven2/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar --output ~/Downloads/guava-31.1-jre.jar # sha1sum should be 60458f877d055d0c9114d9e1a2efb737b4bc282c`
5. `$ diffoscope --exclude \*.class --html-dir guava-diff ~/Downloads/guava-31.1-jre.jar guava/target/guava-31.1-jre.jar`

The important things to notice in the diff:
* LHS is the released v31.1 jar; RHS is the output of building with this PR
* `zipinfo` output shows normalized timestamps in the zip catalog on RHS
* `META-INF/MANIFEST.MF`: Problematic `Bnd-LastModified` and `Built-By` attributes are gone.  Different `Tool` version is used by `maven-bundle-plugin`.
* `META-INF/**/pom.properties`: Problematic comment with timestamp is gone

Note that in step 5 I excluded class files from analysis; that's because `diffoscope` delegates to a decompiler which seemed confused about inlined Strings and lambdas, creating false-positives.  I suspect this is a difference between my local JDK and/or vendor vs. the released artifact.

NB: There appear to be other past changes related to reproducible builds: #3534, #3681 and #3686