### PR TITLE
Add test for CharMatcher.retainFrom()

### DIFF
--- a/guava-tests/test/com/google/common/base/CharMatcherTest.java
+++ b/guava-tests/test/com/google/common/base/CharMatcherTest.java
@@ -652,6 +652,14 @@ public class CharMatcherTest extends TestCase {
     assertEquals("12 &gt; 5", is('>').replaceFrom("12 > 5", "&gt;"));
   }
 
+  public void testRetainFrom() {
+    assertEquals("aaa", is('a').retainFrom("bazaar"));
+    assertEquals("z", is('z').retainFrom("bazaar"));
+    assertEquals("!", is('!').retainFrom("!@#$%^&*()-="));
+    assertEquals("", is('x').retainFrom("bazaar"));
+    assertEquals("", is('a').retainFrom(""));
+  }
+
   public void testPrecomputedOptimizations() {
     // These are testing behavior that's never promised by the API.
     // Some matchers are so efficient that it is a waste of effort to


### PR DESCRIPTION
Related to the following open issue: https://github.com/google/guava/issues/6069

I wanted to close out the above ticket; this code provides a unit test for the currently untested CharMatcher.retainFrom() method. 

Tested locally with `mvn test`: 

```
Running com.google.common.base.CharMatcherTest
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.425 sec
```