### PR TITLE
#2130 - Stop skipping certain tests under Windows

### DIFF
--- a/android/guava-tests/test/com/google/common/base/ThrowablesTest.java
+++ b/android/guava-tests/test/com/google/common/base/ThrowablesTest.java
@@ -658,9 +658,6 @@ public class ThrowablesTest extends TestCase {
   @J2ktIncompatible
   @GwtIncompatible // getStackTraceAsString(Throwable)
   public void testGetStackTraceAsString() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - We probably just need to accept \r\n line delimiters.
-    }
     class StackTraceException extends Exception {
       StackTraceException(String message) {
         super(message);
@@ -671,8 +668,8 @@ public class ThrowablesTest extends TestCase {
 
     String firstLine = quote(e.getClass().getName() + ": " + e.getMessage());
     String secondLine = "\\s*at " + ThrowablesTest.class.getName() + "\\..*";
-    String moreLines = "(?:.*\n?)*";
-    String expected = firstLine + "\n" + secondLine + "\n" + moreLines;
+    String moreLines = "(?:.*" + System.lineSeparator() + "?)*";
+    String expected = String.join(System.lineSeparator(), firstLine, secondLine, moreLines);
     assertThat(getStackTraceAsString(e)).matches(expected);
   }
 
@@ -791,9 +788,5 @@ public class ThrowablesTest extends TestCase {
   @GwtIncompatible // NullPointerTester
   public void testNullPointers() {
     new NullPointerTester().testAllPublicStaticMethods(Throwables.class);
-  }
-
-  private static boolean isWindows() {
-    return OS_NAME.value().startsWith("Windows");
   }
 }

--- a/android/guava-tests/test/com/google/common/io/ResourcesTest.java
+++ b/android/guava-tests/test/com/google/common/io/ResourcesTest.java
@@ -160,10 +160,7 @@ public class ResourcesTest extends IoTestCase {
       Thread.currentThread().setContextClassLoader(loader);
       URL url = Resources.getResource(tempFile.getName());
       String text = Resources.toString(url, Charsets.UTF_8);
-      if (isWindows()) {
-        return; // TODO: b/136041958 - We probably just need to accept \r\n line delimiters.
-      }
-      assertEquals("rud a chur ar an méar fhada\n", text);
+      assertEquals("rud a chur ar an méar fhada" + System.lineSeparator(), text);
     } finally {
       Thread.currentThread().setContextClassLoader(oldContextLoader);
     }
@@ -193,9 +190,5 @@ public class ResourcesTest extends IoTestCase {
 
   private static URL classfile(Class<?> c) {
     return c.getResource(c.getSimpleName() + ".class");
-  }
-
-  private static boolean isWindows() {
-    return OS_NAME.value().startsWith("Windows");
   }
 }

--- a/guava-tests/test/com/google/common/base/ThrowablesTest.java
+++ b/guava-tests/test/com/google/common/base/ThrowablesTest.java
@@ -658,9 +658,6 @@ public class ThrowablesTest extends TestCase {
   @J2ktIncompatible
   @GwtIncompatible // getStackTraceAsString(Throwable)
   public void testGetStackTraceAsString() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - We probably just need to accept \r\n line delimiters.
-    }
     class StackTraceException extends Exception {
       StackTraceException(String message) {
         super(message);
@@ -671,8 +668,8 @@ public class ThrowablesTest extends TestCase {
 
     String firstLine = quote(e.getClass().getName() + ": " + e.getMessage());
     String secondLine = "\\s*at " + ThrowablesTest.class.getName() + "\\..*";
-    String moreLines = "(?:.*\n?)*";
-    String expected = firstLine + "\n" + secondLine + "\n" + moreLines;
+    String moreLines = "(?:.*" + System.lineSeparator() + "?)*";
+    String expected = String.join(System.lineSeparator(), firstLine, secondLine, moreLines);
     assertThat(getStackTraceAsString(e)).matches(expected);
   }
 
@@ -791,9 +788,5 @@ public class ThrowablesTest extends TestCase {
   @GwtIncompatible // NullPointerTester
   public void testNullPointers() {
     new NullPointerTester().testAllPublicStaticMethods(Throwables.class);
-  }
-
-  private static boolean isWindows() {
-    return OS_NAME.value().startsWith("Windows");
   }
 }

--- a/guava-tests/test/com/google/common/io/ResourcesTest.java
+++ b/guava-tests/test/com/google/common/io/ResourcesTest.java
@@ -160,10 +160,7 @@ public class ResourcesTest extends IoTestCase {
       Thread.currentThread().setContextClassLoader(loader);
       URL url = Resources.getResource(tempFile.getName());
       String text = Resources.toString(url, Charsets.UTF_8);
-      if (isWindows()) {
-        return; // TODO: b/136041958 - We probably just need to accept \r\n line delimiters.
-      }
-      assertEquals("rud a chur ar an méar fhada\n", text);
+      assertEquals("rud a chur ar an méar fhada" + System.lineSeparator(), text);
     } finally {
       Thread.currentThread().setContextClassLoader(oldContextLoader);
     }
@@ -193,9 +190,5 @@ public class ResourcesTest extends IoTestCase {
 
   private static URL classfile(Class<?> c) {
     return c.getResource(c.getSimpleName() + ".class");
-  }
-
-  private static boolean isWindows() {
-    return OS_NAME.value().startsWith("Windows");
   }
 }


### PR DESCRIPTION
Some tests depended on Unix line ending, changing those to use `System.lineSeparator()` instead. Now they can run on Windows too.