### PR TITLE
#2130 - Stop skipping certain tests under Windows

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -218,9 +218,6 @@ public class AbstractFutureTest extends TestCase {
   }
 
   public void testToString_oom() throws Exception {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     SettableFuture<Object> future = SettableFuture.create();
     future.set(
         new Object() {
@@ -300,9 +297,6 @@ public class AbstractFutureTest extends TestCase {
   @SuppressWarnings({"DeprecatedThreadMethods", "ThreadPriorityCheck"})
   @AndroidIncompatible // Thread.suspend
   public void testToString_delayedTimeout() throws Exception {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     Integer javaVersion = Ints.tryParse(JAVA_SPECIFICATION_VERSION.value());
     // Parsing to an integer might fail because Java 8 returns "1.8" instead of "8."
     // We can continue if it's 1.8, and we can continue if it's an integer in [9, 20).
@@ -392,9 +386,6 @@ public class AbstractFutureTest extends TestCase {
   }
 
   public void testCompletionFinishesWithDone() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     ExecutorService executor = Executors.newFixedThreadPool(10);
     for (int i = 0; i < 50000; i++) {
       final AbstractFuture<String> future = new AbstractFuture<String>() {};
@@ -446,9 +437,6 @@ public class AbstractFutureTest extends TestCase {
    */
 
   public void testFutureBash() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     final CyclicBarrier barrier =
         new CyclicBarrier(
             6 // for the setter threads
@@ -630,9 +618,6 @@ public class AbstractFutureTest extends TestCase {
 
   // setFuture and cancel() interact in more complicated ways than the other setters.
   public void testSetFutureCancelBash() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     final int size = 50;
     final CyclicBarrier barrier =
         new CyclicBarrier(
@@ -768,9 +753,6 @@ public class AbstractFutureTest extends TestCase {
   // Test to ensure that when calling setFuture with a done future only setFuture or cancel can
   // return true.
   public void testSetFutureCancelBash_withDoneFuture() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     final CyclicBarrier barrier =
         new CyclicBarrier(
             2 // for the setter threads
@@ -854,9 +836,6 @@ public class AbstractFutureTest extends TestCase {
   // In a previous implementation this would cause a stack overflow after ~2000 futures chained
   // together.  Now it should only be limited by available memory (and time)
   public void testSetFuture_stackOverflow() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     SettableFuture<String> orig = SettableFuture.create();
     SettableFuture<String> prev = orig;
     for (int i = 0; i < 100000; i++) {
@@ -874,9 +853,6 @@ public class AbstractFutureTest extends TestCase {
   @GwtIncompatible
   @AndroidIncompatible
   public void testSetFutureToString_stackOverflow() {
-    if (isWindows()) {
-      return; // TODO: b/136041958 - Some tests in this file are slow, but I'm not sure which.
-    }
     SettableFuture<String> orig = SettableFuture.create();
     SettableFuture<String> prev = orig;
     for (int i = 0; i < 100000; i++) {
@@ -1349,9 +1325,5 @@ public class AbstractFutureTest extends TestCase {
       assertFalse(interruptTaskWasCalled);
       interruptTaskWasCalled = true;
     }
-  }
-
-  private static boolean isWindows() {
-    return OS_NAME.value().startsWith("Windows");
   }
 }

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -437,6 +437,9 @@ public class AbstractFutureTest extends TestCase {
    */
 
   public void testFutureBash() {
+    if (isWindows()) {
+      return; // TODO: b/136041958 - Running very slowly on Windows.
+    }
     final CyclicBarrier barrier =
         new CyclicBarrier(
             6 // for the setter threads
@@ -618,6 +621,9 @@ public class AbstractFutureTest extends TestCase {
 
   // setFuture and cancel() interact in more complicated ways than the other setters.
   public void testSetFutureCancelBash() {
+    if (isWindows()) {
+      return; // TODO: b/136041958 - Running very slowly on Windows.
+    }
     final int size = 50;
     final CyclicBarrier barrier =
         new CyclicBarrier(
@@ -1325,5 +1331,9 @@ public class AbstractFutureTest extends TestCase {
       assertFalse(interruptTaskWasCalled);
       interruptTaskWasCalled = true;
     }
+  }
+
+  private static boolean isWindows() {
+    return OS_NAME.value().startsWith("Windows");
   }
 }


### PR DESCRIPTION
_(Edited: what I first thought was completely demolished by the CI results, see the other comments below)_

Certain tests were deactivated within AbstractFutureTest on Windows with the explanation that a subset of these test cases run slowly. This is certainly the case, but these tests also exhibit slow performance on Unix. However, they are marginally faster on Unix compared to Windows for some unknown reason. Overall, the difference in execution times doesn't appear to be significant enough to warrant excluding tests on any particular platform.