### PR TITLE
extract repeated code segment into a method in DoubleUtils

### DIFF
--- a/android/guava-tests/test/com/google/common/math/DoubleUtilsTest.java
+++ b/android/guava-tests/test/com/google/common/math/DoubleUtilsTest.java
@@ -19,6 +19,8 @@ package com.google.common.math;
 import static com.google.common.math.MathTesting.ALL_BIGINTEGER_CANDIDATES;
 import static com.google.common.math.MathTesting.FINITE_DOUBLE_CANDIDATES;
 import static com.google.common.math.MathTesting.POSITIVE_FINITE_DOUBLE_CANDIDATES;
+import static com.google.common.math.MathTesting.NEGATIVE_INTEGER_CANDIDATES;
+import static com.google.common.math.MathTesting.POSITIVE_INTEGER_CANDIDATES;
 
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -43,6 +45,18 @@ public class DoubleUtilsTest extends TestCase {
       return Math.class.getMethod("nextDown", double.class);
     } catch (NoSuchMethodException expectedBeforeJava8) {
       return Class.forName("sun.misc.FpUtils").getMethod("nextDown", double.class);
+    }
+  }
+
+  public void testNextUp() {
+    for (double d : FINITE_DOUBLE_CANDIDATES) {
+      for (int i : NEGATIVE_INTEGER_CANDIDATES) {
+        assertEquals(d, DoubleUtils.nextUp(i, d));
+      }
+      assertEquals(d, DoubleUtils.nextUp(0, d));
+      for (int i : POSITIVE_INTEGER_CANDIDATES) {
+        assertEquals(Math.nextUp(d), DoubleUtils.nextUp(i, d));
+      }
     }
   }
 

--- a/android/guava/src/com/google/common/math/DoubleUtils.java
+++ b/android/guava/src/com/google/common/math/DoubleUtils.java
@@ -41,6 +41,10 @@ final class DoubleUtils {
     return -Math.nextUp(-d);
   }
 
+  static double nextUp(int value, double nextUpValue){
+    return (value <= 0) ? nextUpValue : Math.nextUp(nextUpValue);
+  }
+
   // The mask for the significand, according to the {@link
   // Double#doubleToRawLongBits(double)} spec.
   static final long SIGNIFICAND_MASK = 0x000fffffffffffffL;

--- a/android/guava/src/com/google/common/math/LongMath.java
+++ b/android/guava/src/com/google/common/math/LongMath.java
@@ -1285,18 +1285,18 @@ public final class LongMath {
             ? roundArbitrarily
             : DoubleUtils.nextDown(roundArbitrarily);
       case CEILING:
-        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
       case DOWN:
         if (x >= 0) {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily
               : DoubleUtils.nextDown(roundArbitrarily);
         } else {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         }
       case UP:
         if (x >= 0) {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         } else {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily

--- a/android/guava/src/com/google/common/math/ToDoubleRounder.java
+++ b/android/guava/src/com/google/common/math/ToDoubleRounder.java
@@ -81,18 +81,18 @@ abstract class ToDoubleRounder<X extends Number & Comparable<X>> {
             ? roundArbitrarily
             : DoubleUtils.nextDown(roundArbitrarily);
       case CEILING:
-        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
       case DOWN:
         if (sign(x) >= 0) {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily
               : DoubleUtils.nextDown(roundArbitrarily);
         } else {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         }
       case UP:
         if (sign(x) >= 0) {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         } else {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily

--- a/guava-tests/test/com/google/common/math/DoubleUtilsTest.java
+++ b/guava-tests/test/com/google/common/math/DoubleUtilsTest.java
@@ -19,6 +19,8 @@ package com.google.common.math;
 import static com.google.common.math.MathTesting.ALL_BIGINTEGER_CANDIDATES;
 import static com.google.common.math.MathTesting.FINITE_DOUBLE_CANDIDATES;
 import static com.google.common.math.MathTesting.POSITIVE_FINITE_DOUBLE_CANDIDATES;
+import static com.google.common.math.MathTesting.NEGATIVE_INTEGER_CANDIDATES;
+import static com.google.common.math.MathTesting.POSITIVE_INTEGER_CANDIDATES;
 
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -35,6 +37,18 @@ public class DoubleUtilsTest extends TestCase {
     Method jdkNextDown = getJdkNextDown();
     for (double d : FINITE_DOUBLE_CANDIDATES) {
       assertEquals(jdkNextDown.invoke(null, d), DoubleUtils.nextDown(d));
+    }
+  }
+
+  public void testNextUp() {
+    for (double d : FINITE_DOUBLE_CANDIDATES) {
+      for (int i : NEGATIVE_INTEGER_CANDIDATES) {
+        assertEquals(d, DoubleUtils.nextUp(i, d));
+      }
+      assertEquals(d, DoubleUtils.nextUp(0, d));
+      for (int i : POSITIVE_INTEGER_CANDIDATES) {
+        assertEquals(Math.nextUp(d), DoubleUtils.nextUp(i, d));
+      }
     }
   }
 

--- a/guava/src/com/google/common/math/DoubleUtils.java
+++ b/guava/src/com/google/common/math/DoubleUtils.java
@@ -41,6 +41,10 @@ final class DoubleUtils {
     return -Math.nextUp(-d);
   }
 
+  static double nextUp(int value, double nextUpValue){
+    return (value <= 0) ? nextUpValue : Math.nextUp(nextUpValue);
+  }
+
   // The mask for the significand, according to the {@link
   // Double#doubleToRawLongBits(double)} spec.
   static final long SIGNIFICAND_MASK = 0x000fffffffffffffL;

--- a/guava/src/com/google/common/math/LongMath.java
+++ b/guava/src/com/google/common/math/LongMath.java
@@ -1285,18 +1285,18 @@ public final class LongMath {
             ? roundArbitrarily
             : DoubleUtils.nextDown(roundArbitrarily);
       case CEILING:
-        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
       case DOWN:
         if (x >= 0) {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily
               : DoubleUtils.nextDown(roundArbitrarily);
         } else {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         }
       case UP:
         if (x >= 0) {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         } else {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily

--- a/guava/src/com/google/common/math/ToDoubleRounder.java
+++ b/guava/src/com/google/common/math/ToDoubleRounder.java
@@ -81,18 +81,18 @@ abstract class ToDoubleRounder<X extends Number & Comparable<X>> {
             ? roundArbitrarily
             : DoubleUtils.nextDown(roundArbitrarily);
       case CEILING:
-        return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+        return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
       case DOWN:
         if (sign(x) >= 0) {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily
               : DoubleUtils.nextDown(roundArbitrarily);
         } else {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         }
       case UP:
         if (sign(x) >= 0) {
-          return (cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);
+          return DoubleUtils.nextUp(cmpXToRoundArbitrarily, roundArbitrarily);
         } else {
           return (cmpXToRoundArbitrarily >= 0)
               ? roundArbitrarily


### PR DESCRIPTION
Following code segment repeats 12 times in the code base:

`(cmpXToRoundArbitrarily <= 0) ? roundArbitrarily : Math.nextUp(roundArbitrarily);`

We can extract it into a new method in `DoubleUtils`.

If you think this refactoring is fine, please also suggest a better name for the new method.
 (current signature: ` double nextUp(int value, double nextUpValue) `)