### PR TITLE
Put the versions of dependencies directly in Gradle Metadata

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -15,6 +15,10 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.1.3</truth.version>
+    <jsr305.version>3.0.2</jsr305.version>
+    <checker.version>3.33.0</checker.version>
+    <errorprone.version>2.18.0</errorprone.version>
+    <j2objc.version>2.8</j2objc.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -302,22 +306,22 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
+        <version>${jsr305.version}</version>
       </dependency>
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.33.0</version>
+        <version>${checker.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.18.0</version>
+        <version>${errorprone.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
-        <version>2.8</version>
+        <version>${j2objc.version}</version>
       </dependency>
       <!-- We avoid using dependencyManagement for test-only deps because of https://github.com/google/guava/issues/6654 -->
     </dependencies>

--- a/guava/module.json
+++ b/guava/module.json
@@ -28,16 +28,6 @@
       "dependencies": [
         {
           "group": "com.google.guava",
-          "module": "guava-parent",
-          "version": {
-            "requires": "${pom.version}"
-          },
-          "attributes": {
-            "org.gradle.category": "platform"
-          }
-        },
-        {
-          "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
             "requires": "1.0.1"
@@ -52,19 +42,31 @@
         },
         {
           "group": "com.google.code.findbugs",
-          "module": "jsr305"
+          "module": "jsr305",
+          "version": {
+            "requires": "${jsr305.version}"
+          }
         },
         {
           "group": "org.checkerframework",
-          "module": "checker-qual"
+          "module": "checker-qual",
+          "version": {
+            "requires": "${checker.version}"
+          }
         },
         {
           "group": "com.google.errorprone",
-          "module": "error_prone_annotations"
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${errorprone.version}"
+          }
         },
         {
           "group": "com.google.j2objc",
-          "module": "j2objc-annotations"
+          "module": "j2objc-annotations",
+          "version": {
+            "requires": "${j2objc.version}"
+          }
         }
       ],
       "files": [
@@ -99,16 +101,6 @@
       "dependencies": [
         {
           "group": "com.google.guava",
-          "module": "guava-parent",
-          "version": {
-            "requires": "${pom.version}"
-          },
-          "attributes": {
-            "org.gradle.category": "platform"
-          }
-        },
-        {
-          "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
             "requires": "1.0.1"
@@ -123,15 +115,24 @@
         },
         {
           "group": "com.google.code.findbugs",
-          "module": "jsr305"
+          "module": "jsr305",
+          "version": {
+            "requires": "${jsr305.version}"
+          }
         },
         {
           "group": "org.checkerframework",
-          "module": "checker-qual"
+          "module": "checker-qual",
+          "version": {
+            "requires": "${checker.version}"
+          }
         },
         {
           "group": "com.google.errorprone",
-          "module": "error_prone_annotations"
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${errorprone.version}"
+          }
         }
       ],
       "files": [
@@ -166,16 +167,6 @@
       "dependencies": [
         {
           "group": "com.google.guava",
-          "module": "guava-parent",
-          "version": {
-            "requires": "${otherVariant.version}"
-          },
-          "attributes": {
-            "org.gradle.category": "platform"
-          }
-        },
-        {
-          "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
             "requires": "1.0.1"
@@ -190,19 +181,31 @@
         },
         {
           "group": "com.google.code.findbugs",
-          "module": "jsr305"
+          "module": "jsr305",
+          "version": {
+            "requires": "${jsr305.version}"
+          }
         },
         {
           "group": "org.checkerframework",
-          "module": "checker-qual"
+          "module": "checker-qual",
+          "version": {
+            "requires": "${checker.version}"
+          }
         },
         {
           "group": "com.google.errorprone",
-          "module": "error_prone_annotations"
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${errorprone.version}"
+          }
         },
         {
           "group": "com.google.j2objc",
-          "module": "j2objc-annotations"
+          "module": "j2objc-annotations",
+          "version": {
+            "requires": "${j2objc.version}"
+          }
         }
       ],
       "files": [
@@ -237,16 +240,6 @@
       "dependencies": [
         {
           "group": "com.google.guava",
-          "module": "guava-parent",
-          "version": {
-            "requires": "${otherVariant.version}"
-          },
-          "attributes": {
-            "org.gradle.category": "platform"
-          }
-        },
-        {
-          "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
             "requires": "1.0.1"
@@ -261,15 +254,24 @@
         },
         {
           "group": "com.google.code.findbugs",
-          "module": "jsr305"
+          "module": "jsr305",
+          "version": {
+            "requires": "${jsr305.version}"
+          }
         },
         {
           "group": "org.checkerframework",
-          "module": "checker-qual"
+          "module": "checker-qual",
+          "version": {
+            "requires": "${checker.version}"
+          }
         },
         {
           "group": "com.google.errorprone",
-          "module": "error_prone_annotations"
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${errorprone.version}"
+          }
         }
       ],
       "files": [

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.1.3</truth.version>
+    <jsr305.version>3.0.2</jsr305.version>
+    <checker.version>3.33.0</checker.version>
+    <errorprone.version>2.18.0</errorprone.version>
+    <j2objc.version>2.8</j2objc.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <javac.version>9+181-r4173-1</javac.version>
     <!-- Empty for all JDKs but 9-12 -->
@@ -296,22 +300,22 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
+        <version>${jsr305.version}</version>
       </dependency>
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.33.0</version>
+        <version>${checker.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.18.0</version>
+        <version>${errorprone.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
-        <version>2.8</version>
+        <version>${j2objc.version}</version>
       </dependency>
       <!-- We avoid using dependencyManagement for test-only deps because of https://github.com/google/guava/issues/6654 -->
     </dependencies>


### PR DESCRIPTION
This makes the version handling in POM and Gradle Metadata more similar. See https://github.com/google/guava/issues/6654#issuecomment-1656580773

This would allow reverting https://github.com/google/guava/commit/71a16d5a7496857a1faf51f9b4098d1f26fe6cd6