### PR TITLE
Make UnmodifiableMultiset.removeIf() unsupported

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/google/UnmodifiableCollectionTests.java
+++ b/guava-testlib/src/com/google/common/collect/testing/google/UnmodifiableCollectionTests.java
@@ -224,6 +224,11 @@ public class UnmodifiableCollectionTests {
     }
     assertCollectionsAreEquivalent(multiset, copy);
 
+    try {
+      multiset.removeIf(x -> false);
+      fail("removeIf(Predicate) succeeded on unmodifiable collection");
+    } catch (UnsupportedOperationException expected) {
+    }
     assertCollectionsAreEquivalent(multiset, copy);
 
     assertSetIsUnmodifiable(multiset.elementSet(), sampleElement);

--- a/guava-tests/test/com/google/common/collect/MultisetsTest.java
+++ b/guava-tests/test/com/google/common/collect/MultisetsTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.collect.testing.DerivedComparable;
+import com.google.common.collect.testing.google.UnmodifiableCollectionTests;
 import com.google.common.testing.CollectorTester;
 import com.google.common.testing.NullPointerTester;
 import java.util.Arrays;
@@ -296,5 +297,10 @@ public class MultisetsTest extends TestCase {
   @GwtIncompatible // NullPointerTester
   public void testNullPointers() {
     new NullPointerTester().testAllPublicStaticMethods(Multisets.class);
+  }
+
+  public void testUnmodifiableMultisetWrites() {
+    Multiset<String> unmodifiableSet = Multisets.unmodifiableMultiset(HashMultiset.create());
+    UnmodifiableCollectionTests.assertMultisetIsUnmodifiable(unmodifiableSet, "test");
   }
 }

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -196,6 +196,11 @@ public final class Multisets {
     }
 
     @Override
+    public boolean removeIf(java.util.function.Predicate<? super E> filter) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean retainAll(Collection<?> elementsToRetain) {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Even if there's nothing to remove, removeIf() should throw an `UnsupportedOperationException`.

see https://github.com/google/guava/issues/6702