### PR TITLE
clone of https://github.com/google/guava/pull/6730 but with Windows testing on JDK8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
-        root-pom: [ 'pom.xml', 'android/pom.xml' ]
+        java: [ 8 ]
+        root-pom: [ 'pom.xml' ]
         include:
           - os: windows-latest
-            java: 17
+            java: 8
             root-pom: pom.xml
     runs-on: ${{ matrix.os }}
     env:

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,7 +85,7 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
+    System.setProperty("user.name", "thisisabogususername");
     File temp = null;
     try {
       temp = Files.createTempDir();

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,18 +85,14 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "thisisabogususername");
-    File temp = null;
+    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
-      temp = Files.createTempDir();
+      TempFileCreator.testMakingUserPermissionsFromScratch();
       assertThat(isJava8OnWindows).isFalse();
-    } catch (IllegalStateException expectedIfJavaWindows8) {
+    } catch (IOException expectedIfJavaWindows8) {
       assertThat(isJava8OnWindows).isTrue();
     } finally {
       System.setProperty("user.name", save);
-      if (temp != null) {
-        assertThat(temp.delete()).isTrue();
-      }
     }
   }
 

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -66,31 +66,39 @@ public class FilesCreateTempDirTest extends TestCase {
   }
 
   public void testBogusSystemPropertiesUsername() {
+    if (isAndroid()) {
+      /*
+       * The test calls directly into the "ACL-based filesystem" code, which isn't available under
+       * old versions of Android. Since Android doesn't use that code path, anyway, there's no need
+       * to test it.
+       */
+      return;
+    }
+
     /*
      * Only under Windows (or hypothetically when running with some other non-POSIX, ACL-based
-     * filesystem) do we look up the username. Thus, this test doesn't test anything interesting
-     * under most environments.
+     * filesystem) does our prod code look up the username. Thus, this test doesn't necessarily test
+     * anything interesting under most environments. Still, we can run it (except for Android, at
+     * least old versions), so we mostly do. This is useful because we don't actually run our CI on
+     * Windows under Java 8, at least as of this writing.
      *
-     * Under Windows, we test that:
+     * Under Windows in particular, we want to test that:
      *
      * - Under Java 9+, createTempDir() succeeds because it can look up the *real* username, rather
      * than relying on the one from the system property.
      *
      * - Under Java 8, createTempDir() fails because it falls back to the bogus username from the
      * system property.
-     *
-     * However: Note that we don't actually run our CI on Windows under Java 8, at least as of this
-     * writing.
      */
-    boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
+    boolean isJava8 = JAVA_SPECIFICATION_VERSION.value().equals("1.8");
 
     String save = System.getProperty("user.name");
     System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
       TempFileCreator.testMakingUserPermissionsFromScratch();
-      assertThat(isJava8OnWindows).isFalse();
-    } catch (IOException expectedIfJavaWindows8) {
-      assertThat(isJava8OnWindows).isTrue();
+      assertThat(isJava8).isFalse();
+    } catch (IOException expectedIfJava8) {
+      assertThat(isJava8).isTrue();
     } finally {
       System.setProperty("user.name", save);
     }

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -105,7 +105,10 @@ abstract class TempFileCreator {
 
   /**
    * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
-   * if previous calls have initialized the PermissionSupplier fields.
+   * if previous calls have initialized the {@code PermissionSupplier} fields.
+   *
+   * <p>This lets us test the effects of different values of the {@code user.name} system property
+   * without needing a separate VM or classloader.
    */
   @IgnoreJRERequirement // used only when Path is available (and only from tests)
   @VisibleForTesting

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -16,10 +16,12 @@ package com.google.common.io;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_IO_TMPDIR;
 import static com.google.common.base.StandardSystemProperty.USER_NAME;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.nio.file.attribute.AclEntryFlag.DIRECTORY_INHERIT;
 import static java.nio.file.attribute.AclEntryFlag.FILE_INHERIT;
 import static java.nio.file.attribute.AclEntryType.ALLOW;
 import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -27,6 +29,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.FileSystems;
 import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
@@ -150,7 +154,7 @@ abstract class TempFileCreator {
         UserPrincipal user =
             FileSystems.getDefault()
                 .getUserPrincipalLookupService()
-                .lookupPrincipalByName(USER_NAME.value());
+                .lookupPrincipalByName(getUsername());
         ImmutableList<AclEntry> acl =
             ImmutableList.of(
                 AclEntry.newBuilder()
@@ -177,6 +181,62 @@ abstract class TempFileCreator {
         return () -> {
           throw new IOException("Could not find user", e);
         };
+      }
+    }
+
+    private static String getUsername() {
+      /*
+       * https://github.com/google/guava/issues/6634: ProcessHandle has more accurate information,
+       * but that class isn't available under all environments that we support. We use it if
+       * available and fall back if not.
+       */
+      String fromSystemProperty = requireNonNull(USER_NAME.value());
+
+      try {
+        Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
+        Class<?> processHandleInfoClass = Class.forName("java.lang.ProcessHandle$Info");
+        Class<?> optionalClass = Class.forName("java.util.Optional");
+        /*
+         * We don't *need* to use reflection to access Optional: It's available on all JDKs we
+         * support, and Android code won't get this far, anyway, because ProcessHandle is
+         * unavailable. But given how much other reflection we're using, we might as well use it
+         * here, too, so that we don't need to also suppress an AndroidApiChecker error.
+         */
+
+        Method currentMethod = processHandleClass.getMethod("current");
+        Method infoMethod = processHandleClass.getMethod("info");
+        Method userMethod = processHandleInfoClass.getMethod("user");
+        Method orElseMethod = optionalClass.getMethod("orElse", Object.class);
+
+        Object current = currentMethod.invoke(null);
+        Object info = infoMethod.invoke(current);
+        Object user = userMethod.invoke(info);
+        return (String) requireNonNull(orElseMethod.invoke(user, fromSystemProperty));
+      } catch (ClassNotFoundException runningUnderAndroidOrJava8) {
+        /*
+         * I'm not sure that we could actually get here for *Android*: I would expect us to enter
+         * the POSIX code path instead. And if we tried this code path, we'd have trouble unless we
+         * were running under a new enough version of Android to support NIO.
+         *
+         * So this is probably just the "Windows Java 8" case. In that case, if we wanted *another*
+         * layer of fallback before consulting the system property, we could try
+         * com.sun.security.auth.module.NTSystem.
+         *
+         * But for now, we use the value from the system property as our best guess.
+         */
+        return fromSystemProperty;
+      } catch (InvocationTargetException e) {
+        throwIfUnchecked(e.getCause()); // in case it's an Error or something
+        return fromSystemProperty; // should be impossible
+      } catch (NoSuchMethodException shouldBeImpossible) {
+        return fromSystemProperty;
+      } catch (IllegalAccessException shouldBeImpossible) {
+        /*
+         * We don't merge these into `catch (ReflectiveOperationException ...)` or an equivalent
+         * multicatch because ReflectiveOperationException isn't available under Android:
+         * b/124188803
+         */
+        return fromSystemProperty;
       }
     }
   }

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;
@@ -100,6 +101,17 @@ abstract class TempFileCreator {
     // https://github.com/google/guava/issues/4011#issuecomment-770020802
     // So we can create files there with any permissions and still get security from the isolation.
     return new JavaIoCreator();
+  }
+
+  /**
+   * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
+   * if previous calls have initialized the PermissionSupplier fields.
+   */
+  @IgnoreJRERequirement // used only when Path is available (and only from tests)
+  @VisibleForTesting
+  static void testMakingUserPermissionsFromScratch() throws IOException {
+    // All we're testing is whether it throws.
+    FileAttribute<?> unused = JavaNioCreator.userPermissions().get();
   }
 
   @IgnoreJRERequirement // used only when Path is available

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,7 +85,7 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
+    System.setProperty("user.name", "thisisabogususername");
     File temp = null;
     try {
       temp = Files.createTempDir();

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,18 +85,14 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "thisisabogususername");
-    File temp = null;
+    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
-      temp = Files.createTempDir();
+      TempFileCreator.testMakingUserPermissionsFromScratch();
       assertThat(isJava8OnWindows).isFalse();
-    } catch (IllegalStateException expectedIfJavaWindows8) {
+    } catch (IOException expectedIfJavaWindows8) {
       assertThat(isJava8OnWindows).isTrue();
     } finally {
       System.setProperty("user.name", save);
-      if (temp != null) {
-        assertThat(temp.delete()).isTrue();
-      }
     }
   }
 

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -66,31 +66,39 @@ public class FilesCreateTempDirTest extends TestCase {
   }
 
   public void testBogusSystemPropertiesUsername() {
+    if (isAndroid()) {
+      /*
+       * The test calls directly into the "ACL-based filesystem" code, which isn't available under
+       * old versions of Android. Since Android doesn't use that code path, anyway, there's no need
+       * to test it.
+       */
+      return;
+    }
+
     /*
      * Only under Windows (or hypothetically when running with some other non-POSIX, ACL-based
-     * filesystem) do we look up the username. Thus, this test doesn't test anything interesting
-     * under most environments.
+     * filesystem) does our prod code look up the username. Thus, this test doesn't necessarily test
+     * anything interesting under most environments. Still, we can run it (except for Android, at
+     * least old versions), so we mostly do. This is useful because we don't actually run our CI on
+     * Windows under Java 8, at least as of this writing.
      *
-     * Under Windows, we test that:
+     * Under Windows in particular, we want to test that:
      *
      * - Under Java 9+, createTempDir() succeeds because it can look up the *real* username, rather
      * than relying on the one from the system property.
      *
      * - Under Java 8, createTempDir() fails because it falls back to the bogus username from the
      * system property.
-     *
-     * However: Note that we don't actually run our CI on Windows under Java 8, at least as of this
-     * writing.
      */
-    boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
+    boolean isJava8 = JAVA_SPECIFICATION_VERSION.value().equals("1.8");
 
     String save = System.getProperty("user.name");
     System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
       TempFileCreator.testMakingUserPermissionsFromScratch();
-      assertThat(isJava8OnWindows).isFalse();
-    } catch (IOException expectedIfJavaWindows8) {
-      assertThat(isJava8OnWindows).isTrue();
+      assertThat(isJava8).isFalse();
+    } catch (IOException expectedIfJava8) {
+      assertThat(isJava8).isTrue();
     } finally {
       System.setProperty("user.name", save);
     }

--- a/guava/src/com/google/common/io/TempFileCreator.java
+++ b/guava/src/com/google/common/io/TempFileCreator.java
@@ -16,10 +16,12 @@ package com.google.common.io;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_IO_TMPDIR;
 import static com.google.common.base.StandardSystemProperty.USER_NAME;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.nio.file.attribute.AclEntryFlag.DIRECTORY_INHERIT;
 import static java.nio.file.attribute.AclEntryFlag.FILE_INHERIT;
 import static java.nio.file.attribute.AclEntryType.ALLOW;
 import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
@@ -27,6 +29,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.FileSystems;
 import java.nio.file.Paths;
 import java.nio.file.attribute.AclEntry;
@@ -150,7 +154,7 @@ abstract class TempFileCreator {
         UserPrincipal user =
             FileSystems.getDefault()
                 .getUserPrincipalLookupService()
-                .lookupPrincipalByName(USER_NAME.value());
+                .lookupPrincipalByName(getUsername());
         ImmutableList<AclEntry> acl =
             ImmutableList.of(
                 AclEntry.newBuilder()
@@ -177,6 +181,62 @@ abstract class TempFileCreator {
         return () -> {
           throw new IOException("Could not find user", e);
         };
+      }
+    }
+
+    private static String getUsername() {
+      /*
+       * https://github.com/google/guava/issues/6634: ProcessHandle has more accurate information,
+       * but that class isn't available under all environments that we support. We use it if
+       * available and fall back if not.
+       */
+      String fromSystemProperty = requireNonNull(USER_NAME.value());
+
+      try {
+        Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
+        Class<?> processHandleInfoClass = Class.forName("java.lang.ProcessHandle$Info");
+        Class<?> optionalClass = Class.forName("java.util.Optional");
+        /*
+         * We don't *need* to use reflection to access Optional: It's available on all JDKs we
+         * support, and Android code won't get this far, anyway, because ProcessHandle is
+         * unavailable. But given how much other reflection we're using, we might as well use it
+         * here, too, so that we don't need to also suppress an AndroidApiChecker error.
+         */
+
+        Method currentMethod = processHandleClass.getMethod("current");
+        Method infoMethod = processHandleClass.getMethod("info");
+        Method userMethod = processHandleInfoClass.getMethod("user");
+        Method orElseMethod = optionalClass.getMethod("orElse", Object.class);
+
+        Object current = currentMethod.invoke(null);
+        Object info = infoMethod.invoke(current);
+        Object user = userMethod.invoke(info);
+        return (String) requireNonNull(orElseMethod.invoke(user, fromSystemProperty));
+      } catch (ClassNotFoundException runningUnderAndroidOrJava8) {
+        /*
+         * I'm not sure that we could actually get here for *Android*: I would expect us to enter
+         * the POSIX code path instead. And if we tried this code path, we'd have trouble unless we
+         * were running under a new enough version of Android to support NIO.
+         *
+         * So this is probably just the "Windows Java 8" case. In that case, if we wanted *another*
+         * layer of fallback before consulting the system property, we could try
+         * com.sun.security.auth.module.NTSystem.
+         *
+         * But for now, we use the value from the system property as our best guess.
+         */
+        return fromSystemProperty;
+      } catch (InvocationTargetException e) {
+        throwIfUnchecked(e.getCause()); // in case it's an Error or something
+        return fromSystemProperty; // should be impossible
+      } catch (NoSuchMethodException shouldBeImpossible) {
+        return fromSystemProperty;
+      } catch (IllegalAccessException shouldBeImpossible) {
+        /*
+         * We don't merge these into `catch (ReflectiveOperationException ...)` or an equivalent
+         * multicatch because ReflectiveOperationException isn't available under Android:
+         * b/124188803
+         */
+        return fromSystemProperty;
       }
     }
   }

--- a/guava/src/com/google/common/io/TempFileCreator.java
+++ b/guava/src/com/google/common/io/TempFileCreator.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;
@@ -100,6 +101,17 @@ abstract class TempFileCreator {
     // https://github.com/google/guava/issues/4011#issuecomment-770020802
     // So we can create files there with any permissions and still get security from the isolation.
     return new JavaIoCreator();
+  }
+
+  /**
+   * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
+   * if previous calls have initialized the PermissionSupplier fields.
+   */
+  @IgnoreJRERequirement // used only when Path is available (and only from tests)
+  @VisibleForTesting
+  static void testMakingUserPermissionsFromScratch() throws IOException {
+    // All we're testing is whether it throws.
+    FileAttribute<?> unused = JavaNioCreator.userPermissions().get();
   }
 
   @IgnoreJRERequirement // used only when Path is available


### PR DESCRIPTION
Fix `Files.createTempDir` and `FileBackedOutputStream` under Windows _services_, a rare use case.

Fixes https://github.com/google/guava/issues/6634

Relevant to https://github.com/google/guava/issues/2686 in that it shows that we would ideally run our Windows testing under both Java 8 *and* a newer version....

RELNOTES=`io`: Fixed `Files.createTempDir` and `FileBackedOutputStream` under [Windows _services_, a rare use case](https://github.com/google/guava/issues/6634).
PiperOrigin-RevId: 568604081
