### PR TITLE
clone of https://github.com/google/guava/pull/6730 but without the prod change -- should fail Windows testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
-        root-pom: [ 'pom.xml', 'android/pom.xml' ]
+        java: [ 8 ]
+        root-pom: [ 'pom.xml' ]
         include:
           - os: windows-latest
             java: 17

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,7 +85,7 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
+    System.setProperty("user.name", "thisisabogususername");
     File temp = null;
     try {
       temp = Files.createTempDir();

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,18 +85,14 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "thisisabogususername");
-    File temp = null;
+    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
-      temp = Files.createTempDir();
+      TempFileCreator.testMakingUserPermissionsFromScratch();
       assertThat(isJava8OnWindows).isFalse();
-    } catch (IllegalStateException expectedIfJavaWindows8) {
+    } catch (IOException expectedIfJavaWindows8) {
       assertThat(isJava8OnWindows).isTrue();
     } finally {
       System.setProperty("user.name", save);
-      if (temp != null) {
-        assertThat(temp.delete()).isTrue();
-      }
     }
   }
 

--- a/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/android/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -66,31 +66,39 @@ public class FilesCreateTempDirTest extends TestCase {
   }
 
   public void testBogusSystemPropertiesUsername() {
+    if (isAndroid()) {
+      /*
+       * The test calls directly into the "ACL-based filesystem" code, which isn't available under
+       * old versions of Android. Since Android doesn't use that code path, anyway, there's no need
+       * to test it.
+       */
+      return;
+    }
+
     /*
      * Only under Windows (or hypothetically when running with some other non-POSIX, ACL-based
-     * filesystem) do we look up the username. Thus, this test doesn't test anything interesting
-     * under most environments.
+     * filesystem) does our prod code look up the username. Thus, this test doesn't necessarily test
+     * anything interesting under most environments. Still, we can run it (except for Android, at
+     * least old versions), so we mostly do. This is useful because we don't actually run our CI on
+     * Windows under Java 8, at least as of this writing.
      *
-     * Under Windows, we test that:
+     * Under Windows in particular, we want to test that:
      *
      * - Under Java 9+, createTempDir() succeeds because it can look up the *real* username, rather
      * than relying on the one from the system property.
      *
      * - Under Java 8, createTempDir() fails because it falls back to the bogus username from the
      * system property.
-     *
-     * However: Note that we don't actually run our CI on Windows under Java 8, at least as of this
-     * writing.
      */
-    boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
+    boolean isJava8 = JAVA_SPECIFICATION_VERSION.value().equals("1.8");
 
     String save = System.getProperty("user.name");
     System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
       TempFileCreator.testMakingUserPermissionsFromScratch();
-      assertThat(isJava8OnWindows).isFalse();
-    } catch (IOException expectedIfJavaWindows8) {
-      assertThat(isJava8OnWindows).isTrue();
+      assertThat(isJava8).isFalse();
+    } catch (IOException expectedIfJava8) {
+      assertThat(isJava8).isTrue();
     } finally {
       System.setProperty("user.name", save);
     }

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -23,6 +23,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -98,6 +98,17 @@ abstract class TempFileCreator {
     return new JavaIoCreator();
   }
 
+  /**
+   * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
+   * if previous calls have initialized the PermissionSupplier fields.
+   */
+  @IgnoreJRERequirement // used only when Path is available (and only from tests)
+  @VisibleForTesting
+  static void testMakingUserPermissionsFromScratch() throws IOException {
+    // All we're testing is whether it throws.
+    FileAttribute<?> unused = JavaNioCreator.userPermissions().get();
+  }
+
   @IgnoreJRERequirement // used only when Path is available
   private static final class JavaNioCreator extends TempFileCreator {
     @Override

--- a/android/guava/src/com/google/common/io/TempFileCreator.java
+++ b/android/guava/src/com/google/common/io/TempFileCreator.java
@@ -101,7 +101,10 @@ abstract class TempFileCreator {
 
   /**
    * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
-   * if previous calls have initialized the PermissionSupplier fields.
+   * if previous calls have initialized the {@code PermissionSupplier} fields.
+   *
+   * <p>This lets us test the effects of different values of the {@code user.name} system property
+   * without needing a separate VM or classloader.
    */
   @IgnoreJRERequirement // used only when Path is available (and only from tests)
   @VisibleForTesting

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,7 +85,7 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
+    System.setProperty("user.name", "thisisabogususername");
     File temp = null;
     try {
       temp = Files.createTempDir();

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -85,18 +85,14 @@ public class FilesCreateTempDirTest extends TestCase {
     boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
 
     String save = System.getProperty("user.name");
-    System.setProperty("user.name", "thisisabogususername");
-    File temp = null;
+    System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
-      temp = Files.createTempDir();
+      TempFileCreator.testMakingUserPermissionsFromScratch();
       assertThat(isJava8OnWindows).isFalse();
-    } catch (IllegalStateException expectedIfJavaWindows8) {
+    } catch (IOException expectedIfJavaWindows8) {
       assertThat(isJava8OnWindows).isTrue();
     } finally {
       System.setProperty("user.name", save);
-      if (temp != null) {
-        assertThat(temp.delete()).isTrue();
-      }
     }
   }
 

--- a/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
+++ b/guava-tests/test/com/google/common/io/FilesCreateTempDirTest.java
@@ -66,31 +66,39 @@ public class FilesCreateTempDirTest extends TestCase {
   }
 
   public void testBogusSystemPropertiesUsername() {
+    if (isAndroid()) {
+      /*
+       * The test calls directly into the "ACL-based filesystem" code, which isn't available under
+       * old versions of Android. Since Android doesn't use that code path, anyway, there's no need
+       * to test it.
+       */
+      return;
+    }
+
     /*
      * Only under Windows (or hypothetically when running with some other non-POSIX, ACL-based
-     * filesystem) do we look up the username. Thus, this test doesn't test anything interesting
-     * under most environments.
+     * filesystem) does our prod code look up the username. Thus, this test doesn't necessarily test
+     * anything interesting under most environments. Still, we can run it (except for Android, at
+     * least old versions), so we mostly do. This is useful because we don't actually run our CI on
+     * Windows under Java 8, at least as of this writing.
      *
-     * Under Windows, we test that:
+     * Under Windows in particular, we want to test that:
      *
      * - Under Java 9+, createTempDir() succeeds because it can look up the *real* username, rather
      * than relying on the one from the system property.
      *
      * - Under Java 8, createTempDir() fails because it falls back to the bogus username from the
      * system property.
-     *
-     * However: Note that we don't actually run our CI on Windows under Java 8, at least as of this
-     * writing.
      */
-    boolean isJava8OnWindows = JAVA_SPECIFICATION_VERSION.value().equals("1.8") && isWindows();
+    boolean isJava8 = JAVA_SPECIFICATION_VERSION.value().equals("1.8");
 
     String save = System.getProperty("user.name");
     System.setProperty("user.name", "-this-is-definitely-not-the-username-we-are-running-as//?");
     try {
       TempFileCreator.testMakingUserPermissionsFromScratch();
-      assertThat(isJava8OnWindows).isFalse();
-    } catch (IOException expectedIfJavaWindows8) {
-      assertThat(isJava8OnWindows).isTrue();
+      assertThat(isJava8).isFalse();
+    } catch (IOException expectedIfJava8) {
+      assertThat(isJava8).isTrue();
     } finally {
       System.setProperty("user.name", save);
     }

--- a/guava/src/com/google/common/io/TempFileCreator.java
+++ b/guava/src/com/google/common/io/TempFileCreator.java
@@ -23,6 +23,7 @@ import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
 
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.j2objc.annotations.J2ObjCIncompatible;
 import java.io.File;

--- a/guava/src/com/google/common/io/TempFileCreator.java
+++ b/guava/src/com/google/common/io/TempFileCreator.java
@@ -98,6 +98,17 @@ abstract class TempFileCreator {
     return new JavaIoCreator();
   }
 
+  /**
+   * Creates the permissions normally used for Windows filesystems, looking up the user afresh, even
+   * if previous calls have initialized the PermissionSupplier fields.
+   */
+  @IgnoreJRERequirement // used only when Path is available (and only from tests)
+  @VisibleForTesting
+  static void testMakingUserPermissionsFromScratch() throws IOException {
+    // All we're testing is whether it throws.
+    FileAttribute<?> unused = JavaNioCreator.userPermissions().get();
+  }
+
   @IgnoreJRERequirement // used only when Path is available
   private static final class JavaNioCreator extends TempFileCreator {
     @Override


### PR DESCRIPTION
Fix `Files.createTempDir` and `FileBackedOutputStream` under Windows _services_, a rare use case.

Fixes https://github.com/google/guava/issues/6634

Relevant to https://github.com/google/guava/issues/2686 in that it shows that we would ideally run our Windows testing under both Java 8 *and* a newer version....

RELNOTES=`io`: Fixed `Files.createTempDir` and `FileBackedOutputStream` under [Windows _services_, a rare use case](https://github.com/google/guava/issues/6634).
PiperOrigin-RevId: 568604081
