### PR TITLE
Add Maven wrapper distribution checksum

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionSha256Sum=7822eb593d29558d8edf87845a2c47e36e2a89d17a84cd2390824633214ed423
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+# TODO: Does not work properly on Windows, see https://issues.apache.org/jira/browse/MWRAPPER-103
+# wrapperSha256Sum=e63a53cfb9c4d291ebe3c2b0edacb7622bbc480326beaa5a0456e412f52f066a


### PR DESCRIPTION
Resolves #6805

Currently the checksums are not published ([MWRAPPER-117](https://issues.apache.org/jira/browse/MWRAPPER-117)), so if you want to verify that they are correct you have to calculate them yourself, or locally edit them to something incorrect and see that `mvnw` execution fails (assuming you have deleted previous downloads in `.m2/wrapper/dists`, see [MWRAPPER-93](https://issues.apache.org/jira/browse/MWRAPPER-93)).