### PR TITLE
generalize Functions#constant to accept any key type

### DIFF
--- a/guava-tests/test/com/google/common/base/FunctionsTest.java
+++ b/guava-tests/test/com/google/common/base/FunctionsTest.java
@@ -350,11 +350,11 @@ public class FunctionsTest extends TestCase {
   }
 
   public void testConstant() {
-    Function<@Nullable Object, Object> f = Functions.<Object>constant("correct");
+    Function<@Nullable Object, Object> f = Functions.constant("correct");
     assertEquals("correct", f.apply(new Object()));
     assertEquals("correct", f.apply(null));
 
-    Function<@Nullable Object, @Nullable String> g = Functions.constant(null);
+    Function<@Nullable Integer, @Nullable String> g = Functions.constant(null);
     assertEquals(null, g.apply(2));
     assertEquals(null, g.apply(null));
 
@@ -366,7 +366,7 @@ public class FunctionsTest extends TestCase {
         .testEquals();
 
     new EqualsTester()
-        .addEqualityGroup(g, Functions.<@Nullable Object>constant(null))
+        .addEqualityGroup(g, Functions.constant(null))
         .addEqualityGroup(Functions.constant("incorrect"))
         .addEqualityGroup(Functions.toStringFunction())
         .addEqualityGroup(f)

--- a/guava/src/com/google/common/base/Functions.java
+++ b/guava/src/com/google/common/base/Functions.java
@@ -340,29 +340,29 @@ public final class Functions {
    * @param value the constant value for the function to return
    * @return a function that always returns {@code value}
    */
-  public static <E extends @Nullable Object> Function<@Nullable Object, E> constant(
-      @ParametricNullness E value) {
+  public static <F extends @Nullable Object, T extends @Nullable Object> Function<F, T> constant(
+      @ParametricNullness T value) {
     return new ConstantFunction<>(value);
   }
 
-  private static class ConstantFunction<E extends @Nullable Object>
-      implements Function<@Nullable Object, E>, Serializable {
-    @ParametricNullness private final E value;
+  private static class ConstantFunction<F extends @Nullable Object, T extends @Nullable Object>
+      implements Function<F, T>, Serializable {
+    @ParametricNullness private final T value;
 
-    public ConstantFunction(@ParametricNullness E value) {
+    public ConstantFunction(@ParametricNullness T value) {
       this.value = value;
     }
 
     @Override
     @ParametricNullness
-    public E apply(@CheckForNull Object from) {
+    public T apply(@CheckForNull Object from) {
       return value;
     }
 
     @Override
     public boolean equals(@CheckForNull Object obj) {
       if (obj instanceof ConstantFunction) {
-        ConstantFunction<?> that = (ConstantFunction<?>) obj;
+        ConstantFunction<?, ?> that = (ConstantFunction<?, ?>) obj;
         return Objects.equal(value, that.value);
       }
       return false;


### PR DESCRIPTION
This generalizes the interface for `Functions#constant` so that it is more lenient. Currently, this method can only be used in places that expect `Function<Object, K>`. Due to the covariance/contravariance rules of Java, this function cannot be passed to an arbitrary method, i.e. a method that may accept `Function<Integer, E>`. The alternative is to do `Functions.forSupplier(Supplies.ofInstance(...))`, which is clunky. 

This is sort of a breaking change for those using the method with explicit type definition using `<>`. The interface goes from `Functions.<E>constant` to `Functions.<F, T>constant`. However, most people are probably not doing...

