### PR TITLE
Add back `Boolean` constructor calls to `BooleansTest`

### DIFF
--- a/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -576,16 +576,16 @@ public class BooleansTest extends TestCase {
 
   public void testAsListCanonicalValues() {
     List<Boolean> list = Booleans.asList(true, false);
-    assertThat(list.get(0)).isSameInstanceAs(true);
-    assertThat(list.get(1)).isSameInstanceAs(false);
+    assertThat(list.get(0)).isSameInstanceAs(Boolean.TRUE);
+    assertThat(list.get(1)).isSameInstanceAs(Boolean.FALSE);
     @SuppressWarnings("deprecation")
-    Boolean anotherTrue = true;
+    Boolean anotherTrue = new Boolean(true); // intentionally calls `new Boolean(...)`
     @SuppressWarnings("deprecation")
-    Boolean anotherFalse = false;
+    Boolean anotherFalse = new Boolean(false); // intentionally calls `new Boolean(...)`
     list.set(0, anotherTrue);
-    assertThat(list.get(0)).isSameInstanceAs(true);
+    assertThat(list.get(0)).isSameInstanceAs(Boolean.TRUE);
     list.set(1, anotherFalse);
-    assertThat(list.get(1)).isSameInstanceAs(false);
+    assertThat(list.get(1)).isSameInstanceAs(Boolean.FALSE);
   }
 
   public void testCountTrue() {

--- a/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -576,16 +576,16 @@ public class BooleansTest extends TestCase {
 
   public void testAsListCanonicalValues() {
     List<Boolean> list = Booleans.asList(true, false);
-    assertThat(list.get(0)).isSameInstanceAs(true);
-    assertThat(list.get(1)).isSameInstanceAs(false);
+    assertThat(list.get(0)).isSameInstanceAs(Boolean.TRUE);
+    assertThat(list.get(1)).isSameInstanceAs(Boolean.FALSE);
     @SuppressWarnings("deprecation")
-    Boolean anotherTrue = true;
+    Boolean anotherTrue = new Boolean(true); // intentionally calls `new Boolean(...)`
     @SuppressWarnings("deprecation")
-    Boolean anotherFalse = false;
+    Boolean anotherFalse = new Boolean(false); // intentionally calls `new Boolean(...)`
     list.set(0, anotherTrue);
-    assertThat(list.get(0)).isSameInstanceAs(true);
+    assertThat(list.get(0)).isSameInstanceAs(Boolean.TRUE);
     list.set(1, anotherFalse);
-    assertThat(list.get(1)).isSameInstanceAs(false);
+    assertThat(list.get(1)).isSameInstanceAs(Boolean.FALSE);
   }
 
   public void testCountTrue() {


### PR DESCRIPTION
The test explicitly checks that other `Boolean` instances, created with `new Boolean(...)`, are canonicalized to `Boolean.TRUE` and `Boolean.FALSE`.

See 25ebb6447803ef07906ed4d5432c0cce27b0ff2d which added this test.

Partially reverts #7026, CC @kluever
I think the other changes there are fine though.

However, if there are internal reasons why `new Boolean(...)` cannot be used then maybe it would be necessary to rewrite or completely remove these tests.