### PR TITLE
Fix: Java 18+ Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         root-pom: [ 'pom.xml', 'android/pom.xml' ]
         include:
           - os: windows-latest
-            java: 17
+            java: 21
             root-pom: pom.xml
     runs-on: ${{ matrix.os }}
     env:
@@ -68,11 +68,10 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           server-id: sonatype-nexus-snapshots
           server-username: CI_DEPLOY_USERNAME
@@ -94,11 +93,10 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
       - name: 'Generate latest docs'

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -25,6 +25,7 @@
     <project.build.outputTimestamp>2024-01-02T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.add.opens></test.add.opens>
+    <test.add.args></test.add.args>
     <module.status>integration</module.status>
     <variant.jvmEnvironment>android</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>android</variant.jvmEnvironmentVariantName>
@@ -253,7 +254,7 @@
             <runOrder>alphabetical</runOrder>
             <!-- Set max heap for tests. -->
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
-            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.opens}</argLine>
+            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.args} ${test.add.opens}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -461,6 +462,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>javac-for-jvm18plus</id>
+      <activation>
+        <!--
+            To build and run the tests against JDK 18+, we need to pass java.security.manager=allow, to allow use of
+            the deprecated 'java.lang.SecurityManager' class.
+         -->
+        <jdk>[18,]</jdk>
+      </activation>
+      <properties>
+        <test.add.args>-Djava.security.manager=allow</test.add.args>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <project.build.outputTimestamp>2024-01-02T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.add.opens></test.add.opens>
+    <test.add.args></test.add.args>
     <module.status>integration</module.status>
     <variant.jvmEnvironment>standard-jvm</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>jre</variant.jvmEnvironmentVariantName>
@@ -177,6 +178,13 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>1.23</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>9.6</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <annotations>com.google.common.base.IgnoreJRERequirement,com.google.common.collect.IgnoreJRERequirement,com.google.common.hash.IgnoreJRERequirement,com.google.common.io.IgnoreJRERequirement,com.google.common.reflect.IgnoreJRERequirement,com.google.common.testing.IgnoreJRERequirement</annotations>
             <checkTestClasses>true</checkTestClasses>
@@ -248,7 +256,7 @@
             <runOrder>alphabetical</runOrder>
             <!-- Set max heap for tests. -->
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
-            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.opens}</argLine>
+            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.args} ${test.add.opens}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -456,6 +464,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>javac-for-jvm18plus</id>
+      <activation>
+        <!--
+            To build and run the tests against JDK 18+, we need to pass java.security.manager=allow, to allow use of
+            the deprecated 'java.lang.SecurityManager' class.
+         -->
+        <jdk>[18,]</jdk>
+      </activation>
+      <properties>
+        <test.add.args>-Djava.security.manager=allow</test.add.args>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Summary

Amends the build to be compatible with JDKs newer than 18. Adds JDK21 to the CI matrix.

### Related issues

- Fixes and closes #7065 
- Fixes testsuite up to JVM21 w.r.t. #6245 

## Changelog

- fix: build against embedded jdk sources needs `--enable-preview` when built against jvm21
- fix: add `-Djava.security.manager=allow` to fix security manager tests under modern java
- fix: upgrade asm → latest
- chore: add jvm21 to ci
