### PR TITLE
chore: parallel test and build

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-XX:-TieredCompilation -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -Djava.awt.headless=true

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-T2C
+--strict-checksums

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,10 @@
   <description>Parent for guava artifacts</description>
   <url>https://github.com/google/guava</url>
   <properties>
+    <!-- Enable parallel test execution -->
+    <parallel>all</parallel>
+    <perCoreThreadCount>false</perCoreThreadCount>
+    <threadCount>48</threadCount>
     <!-- Override this with -Dtest.include="**/SomeTest.java" on the CLI -->
     <test.include>%regex[.*.class]</test.include>
     <truth.version>1.4.2</truth.version>
@@ -31,6 +35,7 @@
     <otherVariant.version>HEAD-android-SNAPSHOT</otherVariant.version>
     <otherVariant.jvmEnvironment>android</otherVariant.jvmEnvironment>
     <otherVariant.jvmEnvironmentVariantName>android</otherVariant.jvmEnvironmentVariantName>
+    <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>
@@ -230,7 +235,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.7.2</version>
+          <version>3.2.5</version>
           <configuration>
             <includes>
               <include>${test.include}</include>
@@ -249,6 +254,8 @@
             <!-- Set max heap for tests. -->
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
             <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.opens}</argLine>
+            <reuseForks>true</reuseForks>
+            <forkCount>2C</forkCount>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary

This changeset improves Guava's build and test speed by activating Maven's built-in features for parallel build and test execution. Guava's testsuite is enormous, with over a million tests executed during a build; this PR cuts the execution time for all tests **from ~6.5 minutes to ~2 minutes**. Compile steps also see ~33% speedup.

Some of Guava's tests are understandably flaky when executed like this. There are only 4-5 tests that I've seen be flaky after many runs. Setting a reasonable test-retry count (`3` in this PR) covers this, and I haven't seen the testsuite flake to a failure state since. Split out from work in #7094.

**Representative sample when built and executed serially:**
```
[INFO] Guava Maven Parent ..................... SUCCESS [  0.129 s]
[INFO] Guava: Google Core Libraries for Java .. SUCCESS [ 15.653 s]
[INFO] Guava BOM .............................. SUCCESS [  0.064 s]
[INFO] Guava Testing Library .................. SUCCESS [01:26 min]
[INFO] Guava Unit Tests ....................... SUCCESS [06:26 min] <--
[INFO] Guava GWT compatible libs .............. SUCCESS [ 11.092 s]
```

**Representative sample with this PR applied:**
```
[INFO] Guava Maven Parent ..................... SUCCESS [  0.121 s]
[INFO] Guava: Google Core Libraries for Java .. SUCCESS [  9.681 s]
[INFO] Guava BOM .............................. SUCCESS [  0.120 s]
[INFO] Guava Testing Library .................. SUCCESS [ 47.883 s]
[INFO] Guava Unit Tests ....................... SUCCESS [01:57 min]  <--
[INFO] Guava GWT compatible libs .............. SUCCESS [  6.909 s]
```

<img width="1359" alt="Screenshot 2024-03-10 at 6 31 23 PM" src="https://github.com/google/guava/assets/171897/2e5b3cdf-3314-4d0d-bf22-c974849341b3">


> Raw benchmark data [is available here](https://docs.google.com/spreadsheets/d/11J45MBDuTPDve8KwKI5jAe1JfYmPvyxS7LmLSBZMiJE). Averaged over 5 runs.

<!-- nosound -->
<!-- https://github.com/google/guava/assets/171897/9d626b3d-d488-4e16-a53e-48574a97716c -->

https://github.com/google/guava/assets/171897/85bdfdee-28f0-4729-821b-46acb585a551

> Benchmark was run with full clean/build/test, in two different sessions, on the same machine. Builds are not sharing resources. **At times, this video plays at 8x speed to skip over longer stretches of build time; the timecode counter reflects this.**

Benchmark command:
```
mvnw clean && sleep 1 && mvnw package -Dmaven.javadoc.skip=true -Dgpg.skip=true
```

### CI runs

- **[CI run with Guava's current CI](https://github.com/sgammon/guava/actions/runs/8224662966)**
- **[CI run with changes](https://github.com/sgammon/guava/actions/runs/8225338702) from #7089**

### Concurrency tuning

The current settings are:

- Maven will run with up to **2 threads per core** for builds, and
- Will run with up to **2.5 test forks per core**
- Reuse of forks was also turned on
- Parallel GC was activated for Maven itself

The full JVM argline for Maven:
```
-XX:-TieredCompilation -XX:TieredStopAtLevel=1 -XX:+UseParallelGC -Djava.awt.headless=true
```

### Benchmarking environment

- Apple M2 Max, 96GB RAM
- macOS Sonoma 14.3.1
- GraalVM CE JVM 21.0.2
    
```
openjdk version "21.0.2" 2024-01-16
OpenJDK Runtime Environment GraalVM CE 21.0.2+13.1 (build 21.0.2+13-jvmci-23.1-b30)
OpenJDK 64-Bit Server VM GraalVM CE 21.0.2+13.1 (build 21.0.2+13-jvmci-23.1-b30, mixed mode, sharing)
```

### PR Tree

This PR includes the following PRs, which should be rebased away after they are merged:

- #7092

## Changelog

- chore: enable parallel build
- chore: enable parallel test execution
- chore: enable parallel gc for maven
- chore: tune tiered compilation for maven
- chore: tune thread count for maven
- fix: enable test retries (max = 3) for parallel-flaky tests

cc / @cushon @cpovirk 