### PR TITLE
Guava + JPMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ consult the
 ## Snapshots and Documentation
 
 Snapshots of Guava built from the `master` branch are available through Maven
-using version `HEAD-jre-SNAPSHOT`, or `HEAD-android-SNAPSHOT` for the Android
+using version `1.0-HEAD-jre-SNAPSHOT`, or `1.0-HEAD-android-SNAPSHOT` for the Android
 flavor.
 
 [Snapshot API Javadoc][guava-snapshot-api-docs] as well as
@@ -108,7 +108,7 @@ flavor.
     options open in case of surprises (like, say, a serious security problem).
 
 3.  Guava has one dependency that is needed for linkage at runtime:
-    `com.google.guava:failureaccess:1.0.2`. It also has
+    `com.google.guava:failureaccess:1.0.3`. It also has
     [some annotation-only dependencies][guava-deps], which we discuss in more
     detail at that link.
 

--- a/android/guava-bom/pom.xml
+++ b/android/guava-bom/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.google.guava</groupId>
   <artifactId>guava-bom</artifactId>
-  <version>HEAD-android-SNAPSHOT</version>
+  <version>1.0-HEAD-android-SNAPSHOT</version>
   <packaging>pom</packaging>
   
   <parent>

--- a/android/guava-testlib/pom.xml
+++ b/android/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-android-SNAPSHOT</version>
+    <version>1.0-HEAD-android-SNAPSHOT</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>

--- a/android/guava-tests/pom.xml
+++ b/android/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-android-SNAPSHOT</version>
+    <version>1.0-HEAD-android-SNAPSHOT</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/android/guava/pom.xml
+++ b/android/guava/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-android-SNAPSHOT</version>
+    <version>1.0-HEAD-android-SNAPSHOT</version>
   </parent>
   <artifactId>guava</artifactId>
   <packaging>bundle</packaging>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent</artifactId>
-  <version>HEAD-android-SNAPSHOT</version>
+  <version>1.0-HEAD-android-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
   <description>Parent for guava artifacts</description>
@@ -42,7 +42,7 @@
     <module.status>integration</module.status>
     <variant.jvmEnvironment>android</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>android</variant.jvmEnvironmentVariantName>
-    <otherVariant.version>HEAD-jre-SNAPSHOT</otherVariant.version>
+    <otherVariant.version>1.0-HEAD-jre-SNAPSHOT</otherVariant.version>
     <otherVariant.jvmEnvironment>standard-jvm</otherVariant.jvmEnvironment>
     <otherVariant.jvmEnvironmentVariantName>jre</otherVariant.jvmEnvironmentVariantName>
   </properties>
@@ -86,6 +86,7 @@
     <module>guava-bom</module>
     <module>guava-testlib</module>
     <module>guava-tests</module>
+    <module>../futures/failureaccess</module>
   </modules>
   <build>
     <!-- Handle where Guava deviates from Maven defaults -->
@@ -211,7 +212,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/futures/failureaccess/pom.xml
+++ b/futures/failureaccess/pom.xml
@@ -5,11 +5,12 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>26.0-android</version>
+    <version>1.0-HEAD-jre-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>failureaccess</artifactId>
-  <version>1.0.2</version>
-  <packaging>bundle</packaging>
+  <version>1.0.3</version>
+  <packaging>jar</packaging>
   <name>Guava InternalFutureFailureAccess and InternalFutures</name>
   <description>
     Contains
@@ -23,13 +24,33 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile-java9</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifestEntries>
-              <Automatic-Module-Name>com.google.common.util.concurrent.internal</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
             </manifestEntries>
           </archive>
+          <excludes>
+            <exclude>/module-info.class</exclude>
+            <exclude>META-INF/versions/9/com/google/common/util/concurrent/internal/*.class</exclude>
+          </excludes>
         </configuration>
       </plugin>
       <plugin>
@@ -55,7 +76,8 @@
         </executions>
         <configuration>
           <instructions>
-            <Export-Package>com.google.common.util.concurrent.internal</Export-Package>
+            <_fixupmessages>^Classes found in the wrong directory: .*</_fixupmessages>
+            <Export-Package>com.google.common.util.concurrent.internal,!META-INF.*</Export-Package>
             <Bundle-DocURL>https://github.com/google/guava/</Bundle-DocURL>
           </instructions>
         </configuration>

--- a/futures/failureaccess/src/module-info.java
+++ b/futures/failureaccess/src/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Guava: Future Internals.
+ */
+module com.google.common.util.concurrent.internal {
+  exports com.google.common.util.concurrent.internal;
+}

--- a/guava-bom/pom.xml
+++ b/guava-bom/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.google.guava</groupId>
   <artifactId>guava-bom</artifactId>
-  <version>HEAD-jre-SNAPSHOT</version>
+  <version>1.0-HEAD-jre-SNAPSHOT</version>
   <packaging>pom</packaging>
   
   <parent>

--- a/guava-gwt/pom.xml
+++ b/guava-gwt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-jre-SNAPSHOT</version>
+    <version>1.0-HEAD-jre-SNAPSHOT</version>
   </parent>
   <artifactId>guava-gwt</artifactId>
   <name>Guava GWT compatible libs</name>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -134,15 +134,20 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <!-- Yes, we want to exclude ForceGuavaCompilation 4 times: -->
-            <!-- (And we might as well exclude DummyJavadocClass 3 times (though it would be harmless to include).) -->
-            <!-- 1. Don't compile it (since that requires a *non-test* dep on gwt-user. -->
-            <exclude>**/ForceGuavaCompilation*</exclude>
-            <exclude>**/DummyJavadocClass*</exclude>
-          </excludes>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <excludes>
+                <!-- Yes, we want to exclude ForceGuavaCompilation 4 times: -->
+                <!-- (And we might as well exclude DummyJavadocClass 3 times (though it would be harmless to include).) -->
+                <!-- 1. Don't compile it (since that requires a *non-test* dep on gwt-user. -->
+                <exclude>**/ForceGuavaCompilation*</exclude>
+                <exclude>**/DummyJavadocClass*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
@@ -262,7 +267,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.3</version>
             <classifier>sources</classifier>
           </dependency>
           <dependency>

--- a/guava-testlib/pom.xml
+++ b/guava-testlib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-jre-SNAPSHOT</version>
+    <version>1.0-HEAD-jre-SNAPSHOT</version>
   </parent>
   <artifactId>guava-testlib</artifactId>
   <name>Guava Testing Library</name>
@@ -71,6 +71,45 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <compilerArgs combine.children="append" combine.self="append">
+		 <arg>-XDignore.symbol.file</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java9</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src</compileSourceRoot>
+              </compileSourceRoots>
+
+              <!--
+                JPMS needs access to the module sources to complete a modular Java build. We also need to override
+                the base compiler settings (in the root `pom.xml`) to enable MRJAR output.
+              -->
+              <compilerArgs combine.self="override" combine.children="append">
+                <arg>-sourcepath</arg>
+                <arg>${project.basedir}/src</arg>
+                <arg>--add-reads=com.google.common=ALL-UNNAMED</arg>
+                <arg>--add-reads=com.google.common.testlib=ALL-UNNAMED</arg>
+                <!-- https://errorprone.info/docs/installation#maven -->
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xlint:-removal</arg>
+                <arg>-Xlint:-options</arg>
+              </compilerArgs>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/guava-testlib/src/module-info.java
+++ b/guava-testlib/src/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Guava Testlib
+ */
+open module com.google.common.testlib {
+  requires java.logging;
+  requires com.google.common;
+  requires com.google.common.util.concurrent.internal;
+
+  exports com.google.common.collect.testing;
+  exports com.google.common.collect.testing.features;
+  exports com.google.common.collect.testing.google;
+  exports com.google.common.collect.testing.testers;
+  exports com.google.common.escape.testing;
+  exports com.google.common.testing;
+  exports com.google.common.util.concurrent.testing;
+}

--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-jre-SNAPSHOT</version>
+    <version>1.0-HEAD-jre-SNAPSHOT</version>
   </parent>
   <artifactId>guava-tests</artifactId>
   <name>Guava Unit Tests</name>

--- a/guava/module.json
+++ b/guava/module.json
@@ -30,7 +30,7 @@
           "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
-            "requires": "1.0.2"
+            "requires": "1.0.3"
           }
         },
         {
@@ -96,7 +96,7 @@
           "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
-            "requires": "1.0.2"
+            "requires": "1.0.3"
           }
         },
         {
@@ -162,7 +162,7 @@
           "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
-            "requires": "1.0.2"
+            "requires": "1.0.3"
           }
         },
         {
@@ -228,7 +228,7 @@
           "group": "com.google.guava",
           "module": "failureaccess",
           "version": {
-            "requires": "1.0.2"
+            "requires": "1.0.3"
           }
         },
         {

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-parent</artifactId>
-    <version>HEAD-jre-SNAPSHOT</version>
+    <version>1.0-HEAD-jre-SNAPSHOT</version>
   </parent>
   <artifactId>guava</artifactId>
   <packaging>bundle</packaging>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -62,19 +62,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>com.google.common</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
       </plugin>
       <plugin>
         <extensions>true</extensions>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.8</version>
+        <version>5.1.9</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -89,6 +82,7 @@
             <Export-Package>
               !com.google.common.base.internal,
               !com.google.common.util.concurrent.internal,
+              !META-INF.*,
               com.google.common.*
             </Export-Package>
             <Import-Package>
@@ -103,6 +97,42 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <compilerArgs combine.children="append" combine.self="append">
+                <arg>-XDignore.symbol.file</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java9</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src</compileSourceRoot>
+              </compileSourceRoots>
+
+              <!--
+                JPMS needs access to the module sources to complete a modular Java build. We also need to override the
+                base compile settings (in the root `pom.xml`) to enable MRJAR output.
+              -->
+              <compilerArgs combine.self="override" combine.children="append">
+                <arg>-sourcepath</arg>
+                <arg>${project.basedir}/src</arg>
+                <arg>--add-reads=com.google.common=ALL-UNNAMED</arg>
+                <!-- https://errorprone.info/docs/installation#maven -->
+                <arg>-XDcompilePolicy=simple</arg>
+              </compilerArgs>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/guava/src/module-info.java
+++ b/guava/src/module-info.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Google Guava
+ */
+module com.google.common {
+  requires static jdk.unsupported;
+  requires java.logging;
+  requires com.google.common.util.concurrent.internal;
+
+  exports com.google.common.annotations;
+  exports com.google.common.base;
+  exports com.google.common.cache;
+  exports com.google.common.collect;
+  exports com.google.common.escape;
+  exports com.google.common.eventbus;
+  exports com.google.common.graph;
+  exports com.google.common.hash;
+  exports com.google.common.html;
+  exports com.google.common.io;
+  exports com.google.common.math;
+  exports com.google.common.net;
+  exports com.google.common.primitives;
+  exports com.google.common.reflect;
+  exports com.google.common.util.concurrent;
+  exports com.google.common.xml;
+}

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -7,7 +7,7 @@ val guavaVersionJre =
 val expectedReducedRuntimeClasspathAndroidVersion =
   setOf(
     "guava-${guavaVersionJre.replace("jre", "android")}.jar",
-    "failureaccess-1.0.2.jar",
+    "failureaccess-1.0.3.jar",
     "j2objc-annotations-3.0.0.jar",
     "jspecify-1.0.0.jar",
     "error_prone_annotations-2.36.0.jar",
@@ -16,7 +16,7 @@ val expectedReducedRuntimeClasspathAndroidVersion =
 val expectedReducedRuntimeClasspathJreVersion =
   setOf(
     "guava-$guavaVersionJre.jar",
-    "failureaccess-1.0.2.jar",
+    "failureaccess-1.0.3.jar",
     "j2objc-annotations-3.0.0.jar",
     "jspecify-1.0.0.jar",
     "error_prone_annotations-2.36.0.jar",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.guava</groupId>
   <artifactId>guava-parent</artifactId>
-  <version>HEAD-jre-SNAPSHOT</version>
+  <version>1.0-HEAD-jre-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Guava Maven Parent</name>
   <description>Parent for guava artifacts</description>
@@ -42,7 +42,7 @@
     <module.status>integration</module.status>
     <variant.jvmEnvironment>standard-jvm</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>jre</variant.jvmEnvironmentVariantName>
-    <otherVariant.version>HEAD-android-SNAPSHOT</otherVariant.version>
+    <otherVariant.version>1.0-HEAD-android-SNAPSHOT</otherVariant.version>
     <otherVariant.jvmEnvironment>android</otherVariant.jvmEnvironment>
     <otherVariant.jvmEnvironmentVariantName>android</otherVariant.jvmEnvironmentVariantName>
   </properties>
@@ -87,6 +87,7 @@
     <module>guava-gwt</module>
     <module>guava-testlib</module>
     <module>guava-tests</module>
+    <module>futures/failureaccess</module>
   </modules>
   <build>
     <!-- Handle where Guava deviates from Maven defaults -->
@@ -146,15 +147,7 @@
             <target>1.8</target>
             <encoding>UTF-8</encoding>
             <parameters>true</parameters>
-            <compilerArgs>
-              <!--
-                   Make includes/excludes fully work:
-                   https://issues.apache.org/jira/browse/MCOMPILER-174
-
-                   (Compare what guava-gwt has to do for maven-javadoc-plugin.)
-              -->
-              <arg>-sourcepath</arg>
-              <arg>doesnotexist</arg>
+            <compilerArgs combine.children="override">
               <!-- https://errorprone.info/docs/installation#maven -->
               <arg>-XDcompilePolicy=simple</arg>
               <arg>--should-stop=ifError=FLOW</arg>
@@ -182,6 +175,7 @@
               <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
               <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
               <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              <arg>-Xlint:-removal,-options</arg>
             </compilerArgs>
             <annotationProcessorPaths>
               <path>
@@ -193,6 +187,35 @@
             <!-- Fork because we need args like add-exports. (But see the TODO above about .mvn/jvm.config.) -->
             <fork>true</fork>
           </configuration>
+          <executions>
+            <execution>
+              <id>default-compile</id>
+              <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+                <excludes>
+                  <exclude>module-info.java</exclude>
+                </excludes>
+                <compilerArgs>
+                  <!--
+                      Make includes/excludes fully work:
+                      https://issues.apache.org/jira/browse/MCOMPILER-174
+                      (Compare what guava-gwt has to do for maven-javadoc-plugin.)
+                  -->
+                  <arg>-sourcepath</arg>
+                  <arg>doesnotexist</arg>
+                </compilerArgs>
+              </configuration>
+            </execution>
+            <execution>
+              <id>default-testCompile</id>
+              <configuration>
+                <compilerArgs>
+                  <compilerArg>-Xlint:-removal</compilerArg>
+                </compilerArgs>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
@@ -212,7 +235,20 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.4.0</version>
+          <configuration>
+            <excludes>
+              <!-- The root module (where applicable) is withheld because it is provided at `META-INF/versions/9/`. -->
+              <exclude>/module-info.class</exclude>
+              <!-- Avoid duplicating compiled classes within the `META-INF/versions/9/` root. -->
+              <exclude>META-INF/versions/9/com/**/*.class</exclude>
+            </excludes>
+            <archive>
+              <manifestEntries>
+                <Multi-Release>true</Multi-Release>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
## Summary

This PR adds modular Java support to Guava, by adding a `module-info.java` definition to the `guava` and `guava-testlib` modules. Upstream work in the [Error Prone Compiler](https://github.com/google/error-prone/pull/4311), [J2ObjC Annotations](https://github.com/google/j2objc/pull/2302), and [Checker Framework](https://github.com/typetools/checker-framework/pull/6326) has also completed, rendering Guava able to build entirely on the `modulepath`.

Fixes and closes #2970 

### Current Status

- ✅ Guava builds as a module
- ✅ Guava builds completely on `modulepath`
- ✅ All tests pass
- ✅ All warnings fixed (within reason, some cannot be fixed or suppressed)
- ✅ Javadoc builds at JVM21
- ✅ Integration and smoke tests
- ✅ Final PR cleanup + autorebase

<details>
<summary>Old PR tree</summary>

### PR Tree

On the way to a finished PR, there were a number of other changes and improvements that surfaced. These have been broken out into their own PRs for easier review; they are listed below as _Downstream_ PRs.

PRs that are _Included_ in this PR can be rebased away, either when they are merged or closed without merging, at the Guava team's choosing.

The following PRs relate to this one:

- **Downstream:** (Pending: benchmark split)
- **Downstream:** #7093
- **Downstream:** #7092
- **Included:** #7089
- **Included:** #7087 
- **Upstream:** google/error-prone#4314
- **Upstream:** google/error-prone#4311
- **Upstream:** google/j2objc#2302
- **Upstream:** typetools/checker-framework#6326

</details>

### Using Modular Guava

From a Java 9+ application, in **`module-info.java`**:
```java
module my.module {
  requires com.google.common;
}
```

**Maven:**
```xml
<dependency>
  <groupId>com.google.guava</groupId>
  <artifactId>guava</artifactId>
  <version>33.4.0-jre-jpms</version>
</dependency>
```

**Gradle (Groovy):**
```groovy
dependencies {
  api('com.google.guava:guava:33.4.0-jre-jpms')
}
```

**Gradle (Kotlin):**
```kotlin
dependencies {
  api("com.google.guava:guava:33.4.0-jre-jpms")
}
```

**Gradle (Version Catalog + Kotlin):**
```toml
[versions]
guava = "33.4.0-jre-jpms"

[libraries]
guava = { module = "com.google.guava:guava", version.ref = "guava" }
```
```kotlin
dependencies {
  api(libs.guava)
}
```

### Forcing Resolution

Sometimes, your build will resolve to a different version of Guava. This usually happens because of a transitive dependency. Here are some instructions for Gradle:

**`build.gradle.kts`:**
```kotlin
configurations.all {
  resolutionStrategy.force("com.google.guava:guava:33.4.0-jre-jpms")
}
```

## Changelog

<details>
<summary>Expand for full changelog</summary>
<pre>
- feat: add `module-info.java` to `guava` module
- feat(jpms): add `module-info.java` to `failureaccess`
- feat(jpms): add `module-info.java` to `testlib`
- fix: necessary fixes to get testsuite running on modular java
- chore: update `guava` to build mrjar
- chore: adjust dev version → `1.0-HEAD-[jre|android]-SNAPSHOT`
- chore: upgrade maven compiler plugin → `3.14.0`
</pre>
</details>
