### PR TITLE
Fix Sonar rule S2293 The diamond operator ('<>') should be used

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
@@ -137,12 +137,12 @@ abstract class AbstractIteratorTester<E extends @Nullable Object, I extends Iter
      * The elements to be returned by future calls to {@code next()}, with the first at the top of
      * the stack.
      */
-    final Stack<E> nextElements = new Stack<E>();
+    final Stack<E> nextElements = new Stack<>();
     /**
      * The elements to be returned by future calls to {@code previous()}, with the first at the top
      * of the stack.
      */
-    final Stack<E> previousElements = new Stack<E>();
+    final Stack<E> previousElements = new Stack<>();
     /**
      * {@link #nextElements} if {@code next()} was called more recently then {@code previous},
      * {@link #previousElements} if the reverse is true, or -- overriding both of these -- {@code
@@ -256,7 +256,7 @@ abstract class AbstractIteratorTester<E extends @Nullable Object, I extends Iter
     }
 
     private List<E> getElements() {
-      List<E> elements = new ArrayList<E>();
+      List<E> elements = new ArrayList<>();
       Helpers.addAll(elements, previousElements);
       Helpers.addAll(elements, Helpers.reverse(nextElements));
       return elements;

--- a/android/guava-testlib/src/com/google/common/collect/testing/TestsForMapsInJavaUtil.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/TestsForMapsInJavaUtil.java
@@ -465,7 +465,7 @@ public class TestsForMapsInJavaUtil {
   }
 
   static <T> Comparator<T> arbitraryNullFriendlyComparator() {
-    return new NullFriendlyComparator<T>();
+    return new NullFriendlyComparator<>();
   }
 
   private static final class NullFriendlyComparator<T> implements Comparator<T>, Serializable {

--- a/android/guava-testlib/src/com/google/common/collect/testing/TestsForSetsInJavaUtil.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/TestsForSetsInJavaUtil.java
@@ -434,7 +434,7 @@ public class TestsForSetsInJavaUtil {
   }
 
   static <T> Comparator<T> arbitraryNullFriendlyComparator() {
-    return new NullFriendlyComparator<T>();
+    return new NullFriendlyComparator<>();
   }
 
   private static final class NullFriendlyComparator<T> implements Comparator<T>, Serializable {

--- a/android/guava/src/com/google/common/base/Equivalence.java
+++ b/android/guava/src/com/google/common/base/Equivalence.java
@@ -275,7 +275,7 @@ public abstract class Equivalence<T> {
    * @since 10.0
    */
   public final Predicate<@Nullable T> equivalentTo(@CheckForNull T target) {
-    return new EquivalentToPredicate<T>(this, target);
+    return new EquivalentToPredicate<>(this, target);
   }
 
   private static final class EquivalentToPredicate<T>

--- a/android/guava/src/com/google/common/base/Optional.java
+++ b/android/guava/src/com/google/common/base/Optional.java
@@ -105,7 +105,7 @@ public abstract class Optional<T> implements Serializable {
    * @throws NullPointerException if {@code reference} is null
    */
   public static <T> Optional<T> of(T reference) {
-    return new Present<T>(checkNotNull(reference));
+    return new Present<>(checkNotNull(reference));
   }
 
   /**

--- a/android/guava/src/com/google/common/base/Predicates.java
+++ b/android/guava/src/com/google/common/base/Predicates.java
@@ -106,7 +106,7 @@ public final class Predicates {
    */
   @SafeVarargs
   public static <T extends @Nullable Object> Predicate<T> and(Predicate<? super T>... components) {
-    return new AndPredicate<T>(defensiveCopy(components));
+    return new AndPredicate<>(defensiveCopy(components));
   }
 
   /**
@@ -140,7 +140,7 @@ public final class Predicates {
    */
   @SafeVarargs
   public static <T extends @Nullable Object> Predicate<T> or(Predicate<? super T>... components) {
-    return new OrPredicate<T>(defensiveCopy(components));
+    return new OrPredicate<>(defensiveCopy(components));
   }
 
   /**

--- a/android/guava/src/com/google/common/base/Suppliers.java
+++ b/android/guava/src/com/google/common/base/Suppliers.java
@@ -265,7 +265,7 @@ public final class Suppliers {
     // The alternative of `duration.compareTo(Duration.ZERO) > 0` causes J2ObjC trouble.
     checkArgument(
         !duration.isNegative() && !duration.isZero(), "duration (%s) must be > 0", duration);
-    return new ExpiringMemoizingSupplier<T>(delegate, toNanosSaturated(duration));
+    return new ExpiringMemoizingSupplier<>(delegate, toNanosSaturated(duration));
   }
 
   @VisibleForTesting

--- a/android/guava/src/com/google/common/collect/ArrayListMultimap.java
+++ b/android/guava/src/com/google/common/collect/ArrayListMultimap.java
@@ -133,7 +133,7 @@ public final class ArrayListMultimap<K extends @Nullable Object, V extends @Null
    */
   @Override
   List<V> createCollection() {
-    return new ArrayList<V>(expectedValuesPerKey);
+    return new ArrayList<>(expectedValuesPerKey);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/Collections2.java
+++ b/android/guava/src/com/google/common/collect/Collections2.java
@@ -91,7 +91,7 @@ public final class Collections2 {
       return ((FilteredCollection<E>) unfiltered).createCombined(predicate);
     }
 
-    return new FilteredCollection<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredCollection<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -130,7 +130,7 @@ public final class Collections2 {
     }
 
     FilteredCollection<E> createCombined(Predicate<? super E> newPredicate) {
-      return new FilteredCollection<E>(unfiltered, Predicates.<E>and(predicate, newPredicate));
+      return new FilteredCollection<>(unfiltered, Predicates.<E>and(predicate, newPredicate));
       // .<E> above needed to compile in JDK 5
     }
 
@@ -616,7 +616,7 @@ public final class Collections2 {
     int j;
 
     PermutationIterator(List<E> list) {
-      this.list = new ArrayList<E>(list);
+      this.list = new ArrayList<>(list);
       int n = list.size();
       c = new int[n];
       o = new int[n];

--- a/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/android/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -125,7 +125,7 @@ class CompactLinkedHashMap<K extends @Nullable Object, V extends @Nullable Objec
 
   @Override
   Map<K, V> createHashFloodingResistantDelegate(int tableSize) {
-    return new LinkedHashMap<K, V>(tableSize, 1.0f, accessOrder);
+    return new LinkedHashMap<>(tableSize, 1.0f, accessOrder);
   }
 
   @Override

--- a/android/guava/src/com/google/common/collect/EnumMultiset.java
+++ b/android/guava/src/com/google/common/collect/EnumMultiset.java
@@ -51,7 +51,7 @@ public final class EnumMultiset<E extends Enum<E>> extends AbstractMultiset<E>
     implements Serializable {
   /** Creates an empty {@code EnumMultiset}. */
   public static <E extends Enum<E>> EnumMultiset<E> create(Class<E> type) {
-    return new EnumMultiset<E>(type);
+    return new EnumMultiset<>(type);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/HashMultiset.java
+++ b/android/guava/src/com/google/common/collect/HashMultiset.java
@@ -45,7 +45,7 @@ public final class HashMultiset<E extends @Nullable Object> extends AbstractMapB
    * @throws IllegalArgumentException if {@code distinctElements} is negative
    */
   public static <E extends @Nullable Object> HashMultiset<E> create(int distinctElements) {
-    return new HashMultiset<E>(distinctElements);
+    return new HashMultiset<>(distinctElements);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/ImmutableBiMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableBiMap.java
@@ -90,7 +90,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
   public static <K, V> ImmutableBiMap<K, V> of(K k1, V v1, K k2, V v2) {
     checkEntryNotNull(k1, v1);
     checkEntryNotNull(k2, v2);
-    return new RegularImmutableBiMap<K, V>(new Object[] {k1, v1, k2, v2}, 2);
+    return new RegularImmutableBiMap<>(new Object[] {k1, v1, k2, v2}, 2);
   }
 
   /**
@@ -102,7 +102,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k1, v1);
     checkEntryNotNull(k2, v2);
     checkEntryNotNull(k3, v3);
-    return new RegularImmutableBiMap<K, V>(new Object[] {k1, v1, k2, v2, k3, v3}, 3);
+    return new RegularImmutableBiMap<>(new Object[] {k1, v1, k2, v2, k3, v3}, 3);
   }
 
   /**
@@ -115,7 +115,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k2, v2);
     checkEntryNotNull(k3, v3);
     checkEntryNotNull(k4, v4);
-    return new RegularImmutableBiMap<K, V>(new Object[] {k1, v1, k2, v2, k3, v3, k4, v4}, 4);
+    return new RegularImmutableBiMap<>(new Object[] {k1, v1, k2, v2, k3, v3, k4, v4}, 4);
   }
 
   /**
@@ -130,7 +130,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k3, v3);
     checkEntryNotNull(k4, v4);
     checkEntryNotNull(k5, v5);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {k1, v1, k2, v2, k3, v3, k4, v4, k5, v5}, 5);
   }
 
@@ -148,7 +148,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k4, v4);
     checkEntryNotNull(k5, v5);
     checkEntryNotNull(k6, v6);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6}, 6);
   }
   /**
@@ -166,7 +166,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k5, v5);
     checkEntryNotNull(k6, v6);
     checkEntryNotNull(k7, v7);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7}, 7);
   }
   /**
@@ -200,7 +200,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k6, v6);
     checkEntryNotNull(k7, v7);
     checkEntryNotNull(k8, v8);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8}, 8);
   }
   /**
@@ -237,7 +237,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k7, v7);
     checkEntryNotNull(k8, v8);
     checkEntryNotNull(k9, v9);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9}, 9);
   }
   /**
@@ -277,7 +277,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
     checkEntryNotNull(k8, v8);
     checkEntryNotNull(k9, v9);
     checkEntryNotNull(k10, v10);
-    return new RegularImmutableBiMap<K, V>(
+    return new RegularImmutableBiMap<>(
         new Object[] {
           k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10
         },
@@ -477,7 +477,7 @@ public abstract class ImmutableBiMap<K, V> extends ImmutableMap<K, V> implements
         sortEntries(alternatingKeysAndValues, size, valueComparator);
       }
       entriesUsed = true;
-      return new RegularImmutableBiMap<K, V>(alternatingKeysAndValues, size);
+      return new RegularImmutableBiMap<>(alternatingKeysAndValues, size);
     }
 
     /**

--- a/android/guava/src/com/google/common/collect/ImmutableEnumSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableEnumSet.java
@@ -42,7 +42,7 @@ final class ImmutableEnumSet<E extends Enum<E>> extends ImmutableSet<E> {
       case 1:
         return ImmutableSet.of(Iterables.getOnlyElement(set));
       default:
-        return new ImmutableEnumSet<E>(set);
+        return new ImmutableEnumSet<>(set);
     }
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableList.java
+++ b/android/guava/src/com/google/common/collect/ImmutableList.java
@@ -359,7 +359,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
     if (length == 0) {
       return of();
     }
-    return new RegularImmutableList<E>(elements, length);
+    return new RegularImmutableList<>(elements, length);
   }
 
   ImmutableList() {}
@@ -383,13 +383,13 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
     if (isEmpty()) {
       return (UnmodifiableListIterator<E>) EMPTY_ITR;
     } else {
-      return new Itr<E>(this, index);
+      return new Itr<>(this, index);
     }
   }
 
   /** A singleton implementation of iterator() for the empty ImmutableList. */
   private static final UnmodifiableListIterator<Object> EMPTY_ITR =
-      new Itr<Object>(RegularImmutableList.EMPTY, 0);
+      new Itr<>(RegularImmutableList.EMPTY, 0);
 
   static class Itr<E> extends AbstractIndexedListIterator<E> {
     private final ImmutableList<E> list;
@@ -724,7 +724,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**
@@ -741,7 +741,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    */
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
-    return new ImmutableList.Builder<E>(expectedSize);
+    return new ImmutableList.Builder<>(expectedSize);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/ImmutableMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMap.java
@@ -651,7 +651,7 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
         Object key = requireNonNull(alternatingKeysAndValues[2 * i]);
         @SuppressWarnings("unchecked")
         V value = (V) requireNonNull(alternatingKeysAndValues[2 * i + 1]);
-        entries[i] = new AbstractMap.SimpleImmutableEntry<Object, V>(key, value);
+        entries[i] = new AbstractMap.SimpleImmutableEntry<>(key, value);
       }
       Arrays.sort(
           entries, 0, size, Ordering.from(valueComparator).onResultOf(Maps.<V>valueFunction()));
@@ -743,7 +743,7 @@ public abstract class ImmutableMap<K, V> implements Map<K, V>, Serializable {
         (entries instanceof Collection)
             ? ((Collection<?>) entries).size()
             : ImmutableCollection.Builder.DEFAULT_INITIAL_CAPACITY;
-    ImmutableMap.Builder<K, V> builder = new ImmutableMap.Builder<K, V>(initialCapacity);
+    ImmutableMap.Builder<K, V> builder = new ImmutableMap.Builder<>(initialCapacity);
     builder.putAll(entries);
     return builder.build();
   }

--- a/android/guava/src/com/google/common/collect/ImmutableMultiset.java
+++ b/android/guava/src/com/google/common/collect/ImmutableMultiset.java
@@ -187,7 +187,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
       }
     }
     ImmutableMultiset.Builder<E> builder =
-        new ImmutableMultiset.Builder<E>(Multisets.inferDistinctElements(elements));
+        new ImmutableMultiset.Builder<>(Multisets.inferDistinctElements(elements));
     builder.addAll(elements);
     return builder.build();
   }
@@ -208,7 +208,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
 
   static <E> ImmutableMultiset<E> copyFromEntries(
       Collection<? extends Entry<? extends E>> entries) {
-    ImmutableMultiset.Builder<E> builder = new ImmutableMultiset.Builder<E>(entries.size());
+    ImmutableMultiset.Builder<E> builder = new ImmutableMultiset.Builder<>(entries.size());
     for (Entry<? extends E> entry : entries) {
       builder.addCopies(entry.getElement(), entry.getCount());
     }
@@ -439,7 +439,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**
@@ -543,7 +543,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
         return this;
       }
       if (buildInvoked) {
-        contents = new ObjectCountHashMap<E>(contents);
+        contents = new ObjectCountHashMap<>(contents);
         isLinkedHash = false;
       }
       buildInvoked = false;
@@ -566,12 +566,12 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
     public Builder<E> setCount(E element, int count) {
       requireNonNull(contents); // see the comment on the field
       if (count == 0 && !isLinkedHash) {
-        contents = new ObjectCountLinkedHashMap<E>(contents);
+        contents = new ObjectCountLinkedHashMap<>(contents);
         isLinkedHash = true;
         // to preserve insertion order through deletions, we have to switch to an actual linked
         // implementation at least for now, but this should be a super rare case
       } else if (buildInvoked) {
-        contents = new ObjectCountHashMap<E>(contents);
+        contents = new ObjectCountHashMap<>(contents);
         isLinkedHash = false;
       }
       buildInvoked = false;
@@ -659,12 +659,12 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
       if (isLinkedHash) {
         // we need ObjectCountHashMap-backed contents, with its keys and values array in direct
         // insertion order
-        contents = new ObjectCountHashMap<E>(contents);
+        contents = new ObjectCountHashMap<>(contents);
         isLinkedHash = false;
       }
       buildInvoked = true;
       // contents is now ObjectCountHashMap, but still guaranteed to be in insertion order!
-      return new RegularImmutableMultiset<E>(contents);
+      return new RegularImmutableMultiset<>(contents);
     }
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -88,7 +88,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
     }
     Map<Range<K>, ? extends V> map = rangeMap.asMapOfRanges();
     ImmutableList.Builder<Range<K>> rangesBuilder = new ImmutableList.Builder<>(map.size());
-    ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<V>(map.size());
+    ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<>(map.size());
     for (Entry<Range<K>, ? extends V> entry : map.entrySet()) {
       rangesBuilder.add(entry.getKey());
       valuesBuilder.add(entry.getValue());
@@ -152,7 +152,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
     public ImmutableRangeMap<K, V> build() {
       Collections.sort(entries, Range.<K>rangeLexOrdering().onKeys());
       ImmutableList.Builder<Range<K>> rangesBuilder = new ImmutableList.Builder<>(entries.size());
-      ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<V>(entries.size());
+      ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<>(entries.size());
       for (int i = 0; i < entries.size(); i++) {
         Range<K> range = entries.get(i).getKey();
         if (i > 0) {

--- a/android/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -93,7 +93,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
     } else if (range.equals(Range.all())) {
       return all();
     } else {
-      return new ImmutableRangeSet<C>(ImmutableList.of(range));
+      return new ImmutableRangeSet<>(ImmutableList.of(range));
     }
   }
 
@@ -118,7 +118,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
         return immutableRangeSet;
       }
     }
-    return new ImmutableRangeSet<C>(ImmutableList.copyOf(rangeSet.asRanges()));
+    return new ImmutableRangeSet<>(ImmutableList.copyOf(rangeSet.asRanges()));
   }
 
   /**
@@ -390,7 +390,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
       return complement = of();
     } else {
       ImmutableList<Range<C>> complementRanges = new ComplementRanges();
-      result = complement = new ImmutableRangeSet<C>(complementRanges, this);
+      result = complement = new ImmutableRangeSet<>(complementRanges, this);
     }
     return result;
   }
@@ -517,7 +517,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
       if (range.encloses(span)) {
         return this;
       } else if (range.isConnected(span)) {
-        return new ImmutableRangeSet<C>(intersectRanges(range));
+        return new ImmutableRangeSet<>(intersectRanges(range));
       }
     }
     return of();
@@ -695,7 +695,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
     @Override
     ImmutableSortedSet<C> createDescendingSet() {
-      return new DescendingImmutableSortedSet<C>(this);
+      return new DescendingImmutableSortedSet<>(this);
     }
 
     @Override
@@ -746,7 +746,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
   /** Returns a new builder for an immutable range set. */
   public static <C extends Comparable<?>> Builder<C> builder() {
-    return new Builder<C>();
+    return new Builder<>();
   }
 
   /**
@@ -841,7 +841,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
           && Iterables.getOnlyElement(mergedRanges).equals(Range.all())) {
         return all();
       } else {
-        return new ImmutableRangeSet<C>(mergedRanges);
+        return new ImmutableRangeSet<>(mergedRanges);
       }
     }
   }

--- a/android/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSet.java
@@ -82,7 +82,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    * type conveys the immutability guarantee.
    */
   public static <E> ImmutableSet<E> of(E element) {
-    return new SingletonImmutableSet<E>(element);
+    return new SingletonImmutableSet<>(element);
   }
 
   /**
@@ -199,7 +199,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
       @SuppressWarnings("unchecked") // we are careful to only pass in E
       // requireNonNull is safe because the first `uniques` elements are non-null.
       E element = (E) requireNonNull(elements[0]);
-      return new SingletonImmutableSet<E>(element);
+      return new SingletonImmutableSet<>(element);
     } else if (chooseTableSize(uniques) < tableSize / 2) {
       // Resize the table when the array includes too many duplicates.
       return construct(uniques, elements);
@@ -207,7 +207,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
       @Nullable
       Object[] uniqueElements =
           shouldTrim(uniques, elements.length) ? Arrays.copyOf(elements, uniques) : elements;
-      return new RegularImmutableSet<E>(uniqueElements, hashCode, table, mask, uniques);
+      return new RegularImmutableSet<>(uniqueElements, hashCode, table, mask, uniques);
     }
   }
 
@@ -417,7 +417,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**
@@ -434,7 +434,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    */
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
-    return new Builder<E>(expectedSize);
+    return new Builder<>(expectedSize);
   }
 
   /**
@@ -610,7 +610,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
             Object[] uniqueElements =
                 shouldTrim(size, contents.length) ? Arrays.copyOf(contents, size) : contents;
             result =
-                new RegularImmutableSet<E>(
+                new RegularImmutableSet<>(
                     uniqueElements, hashCode, hashTable, hashTable.length - 1, size);
           } else {
             result = construct(size, contents);

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMap.java
@@ -775,7 +775,7 @@ public final class ImmutableSortedMap<K, V> extends ImmutableMap<K, V>
                 Arrays.binarySearch((K[]) sortedKeys, (K) requireNonNull(keys[i]), comparator);
             sortedValues[index] = requireNonNull(values[i]);
           }
-          return new ImmutableSortedMap<K, V>(
+          return new ImmutableSortedMap<>(
               new RegularImmutableSortedSet<K>(
                   ImmutableList.<K>asImmutableList(sortedKeys), comparator),
               ImmutableList.<V>asImmutableList(sortedValues));

--- a/android/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -137,7 +137,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     RegularImmutableSortedSet<E> elementSet =
         (RegularImmutableSortedSet<E>) ImmutableSortedSet.of(element);
     long[] cumulativeCounts = {0, 1};
-    return new RegularImmutableSortedMultiset<E>(elementSet, cumulativeCounts, 0, 1);
+    return new RegularImmutableSortedMultiset<>(elementSet, cumulativeCounts, 0, 1);
   }
 
   /**
@@ -316,7 +316,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     if (entries.isEmpty()) {
       return emptyMultiset(comparator);
     }
-    ImmutableList.Builder<E> elementsBuilder = new ImmutableList.Builder<E>(entries.size());
+    ImmutableList.Builder<E> elementsBuilder = new ImmutableList.Builder<>(entries.size());
     long[] cumulativeCounts = new long[entries.size() + 1];
     int i = 0;
     for (Entry<E> entry : entries) {
@@ -324,7 +324,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
       cumulativeCounts[i + 1] = cumulativeCounts[i] + entry.getCount();
       i++;
     }
-    return new RegularImmutableSortedMultiset<E>(
+    return new RegularImmutableSortedMultiset<>(
         new RegularImmutableSortedSet<E>(elementsBuilder.build(), comparator),
         cumulativeCounts,
         0,
@@ -336,7 +336,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     if (Ordering.natural().equals(comparator)) {
       return (ImmutableSortedMultiset<E>) RegularImmutableSortedMultiset.NATURAL_EMPTY_MULTISET;
     } else {
-      return new RegularImmutableSortedMultiset<E>(comparator);
+      return new RegularImmutableSortedMultiset<>(comparator);
     }
   }
 
@@ -424,7 +424,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * @throws NullPointerException if {@code comparator} is null
    */
   public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
-    return new Builder<E>(comparator);
+    return new Builder<>(comparator);
   }
 
   /**
@@ -436,7 +436,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6468354">bug 6468354</a>.
    */
   public static <E extends Comparable<?>> Builder<E> reverseOrder() {
-    return new Builder<E>(Ordering.<E>natural().reverse());
+    return new Builder<>(Ordering.<E>natural().reverse());
   }
 
   /**
@@ -450,7 +450,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6468354">bug 6468354</a>.
    */
   public static <E extends Comparable<?>> Builder<E> naturalOrder() {
-    return new Builder<E>(Ordering.natural());
+    return new Builder<>(Ordering.natural());
   }
 
   /**
@@ -701,7 +701,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
         cumulativeCounts[i + 1] = cumulativeCounts[i] + counts[i];
       }
       forceCopyElements = true;
-      return new RegularImmutableSortedMultiset<E>(elementSet, cumulativeCounts, 0, length);
+      return new RegularImmutableSortedMultiset<>(elementSet, cumulativeCounts, 0, length);
     }
   }
 

--- a/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/android/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -84,7 +84,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
           (RegularImmutableSortedSet<E>) RegularImmutableSortedSet.NATURAL_EMPTY_SET;
       return result;
     } else {
-      return new RegularImmutableSortedSet<E>(ImmutableList.<E>of(), comparator);
+      return new RegularImmutableSortedSet<>(ImmutableList.<E>of(), comparator);
     }
   }
 
@@ -100,7 +100,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
 
   /** Returns an immutable sorted set containing a single element. */
   public static <E extends Comparable<? super E>> ImmutableSortedSet<E> of(E element) {
-    return new RegularImmutableSortedSet<E>(ImmutableList.of(element), Ordering.natural());
+    return new RegularImmutableSortedSet<>(ImmutableList.of(element), Ordering.natural());
   }
 
   /**
@@ -344,7 +344,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
     if (list.isEmpty()) {
       return emptySet(comparator);
     } else {
-      return new RegularImmutableSortedSet<E>(list, comparator);
+      return new RegularImmutableSortedSet<>(list, comparator);
     }
   }
 
@@ -380,7 +380,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
       // large array relative to the number of elements, so we cap the ratio.
       contents = Arrays.copyOf(contents, uniques);
     }
-    return new RegularImmutableSortedSet<E>(
+    return new RegularImmutableSortedSet<>(
         ImmutableList.<E>asImmutableList(contents, uniques), comparator);
   }
 
@@ -393,7 +393,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
    * @throws NullPointerException if {@code comparator} is null
    */
   public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
-    return new Builder<E>(comparator);
+    return new Builder<>(comparator);
   }
 
   /**
@@ -401,7 +401,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
    * of their natural ordering.
    */
   public static <E extends Comparable<?>> Builder<E> reverseOrder() {
-    return new Builder<E>(Collections.reverseOrder());
+    return new Builder<>(Collections.reverseOrder());
   }
 
   /**
@@ -411,7 +411,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet<E>
    * implement {@link Comparable}.
    */
   public static <E extends Comparable<?>> Builder<E> naturalOrder() {
-    return new Builder<E>(Ordering.natural());
+    return new Builder<>(Ordering.natural());
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/LinkedHashMultiset.java
+++ b/android/guava/src/com/google/common/collect/LinkedHashMultiset.java
@@ -51,7 +51,7 @@ public final class LinkedHashMultiset<E extends @Nullable Object>
    * @throws IllegalArgumentException if {@code distinctElements} is negative
    */
   public static <E extends @Nullable Object> LinkedHashMultiset<E> create(int distinctElements) {
-    return new LinkedHashMultiset<E>(distinctElements);
+    return new LinkedHashMultiset<>(distinctElements);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/android/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -636,7 +636,7 @@ class MapMakerInternalMap<
           MapMakerInternalMap<K, Dummy, StrongKeyDummyValueEntry<K>, StrongKeyDummyValueSegment<K>>
               map,
           int initialCapacity) {
-        return new StrongKeyDummyValueSegment<K>(map, initialCapacity);
+        return new StrongKeyDummyValueSegment<>(map, initialCapacity);
       }
 
       @Override
@@ -1274,7 +1274,7 @@ class MapMakerInternalMap<
     }
 
     AtomicReferenceArray<E> newEntryArray(int size) {
-      return new AtomicReferenceArray<E>(size);
+      return new AtomicReferenceArray<>(size);
     }
 
     void initTable(AtomicReferenceArray<E> newTable) {
@@ -2066,7 +2066,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for strong keys and weak values. */
   static final class StrongKeyWeakValueSegment<K, V>
       extends Segment<K, V, StrongKeyWeakValueEntry<K, V>, StrongKeyWeakValueSegment<K, V>> {
-    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<V>();
+    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<>();
 
     StrongKeyWeakValueSegment(
         MapMakerInternalMap<K, V, StrongKeyWeakValueEntry<K, V>, StrongKeyWeakValueSegment<K, V>>
@@ -2154,7 +2154,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and strong values. */
   static final class WeakKeyStrongValueSegment<K, V>
       extends Segment<K, V, WeakKeyStrongValueEntry<K, V>, WeakKeyStrongValueSegment<K, V>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
 
     WeakKeyStrongValueSegment(
         MapMakerInternalMap<K, V, WeakKeyStrongValueEntry<K, V>, WeakKeyStrongValueSegment<K, V>>
@@ -2193,8 +2193,8 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and weak values. */
   static final class WeakKeyWeakValueSegment<K, V>
       extends Segment<K, V, WeakKeyWeakValueEntry<K, V>, WeakKeyWeakValueSegment<K, V>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
-    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<V>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
+    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<>();
 
     WeakKeyWeakValueSegment(
         MapMakerInternalMap<K, V, WeakKeyWeakValueEntry<K, V>, WeakKeyWeakValueSegment<K, V>> map,
@@ -2264,7 +2264,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and {@link Dummy} values. */
   static final class WeakKeyDummyValueSegment<K>
       extends Segment<K, Dummy, WeakKeyDummyValueEntry<K>, WeakKeyDummyValueSegment<K>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
 
     WeakKeyDummyValueSegment(
         MapMakerInternalMap<K, Dummy, WeakKeyDummyValueEntry<K>, WeakKeyDummyValueSegment<K>> map,
@@ -2303,7 +2303,7 @@ class MapMakerInternalMap<
     final WeakReference<MapMakerInternalMap<?, ?, ?, ?>> mapReference;
 
     public CleanupMapTask(MapMakerInternalMap<?, ?, ?, ?> map) {
-      this.mapReference = new WeakReference<MapMakerInternalMap<?, ?, ?, ?>>(map);
+      this.mapReference = new WeakReference<>(map);
     }
 
     @Override

--- a/android/guava/src/com/google/common/collect/Maps.java
+++ b/android/guava/src/com/google/common/collect/Maps.java
@@ -683,7 +683,7 @@ public final class Maps {
 
     static <V extends @Nullable Object> ValueDifference<V> create(
         @ParametricNullness V left, @ParametricNullness V right) {
-      return new ValueDifferenceImpl<V>(left, right);
+      return new ValueDifferenceImpl<>(left, right);
     }
 
     private ValueDifferenceImpl(@ParametricNullness V left, @ParametricNullness V right) {

--- a/android/guava/src/com/google/common/collect/Multimaps.java
+++ b/android/guava/src/com/google/common/collect/Multimaps.java
@@ -1215,7 +1215,7 @@ public final class Multimaps {
 
     @Override
     public Set<V> removeAll(@CheckForNull Object key) {
-      Set<V> values = new HashSet<V>(2);
+      Set<V> values = new HashSet<>(2);
       if (!map.containsKey(key)) {
         return values;
       }

--- a/android/guava/src/com/google/common/collect/Multisets.java
+++ b/android/guava/src/com/google/common/collect/Multisets.java
@@ -105,7 +105,7 @@ public final class Multisets {
       Multiset<E> result = (Multiset<E>) multiset;
       return result;
     }
-    return new UnmodifiableMultiset<E>(checkNotNull(multiset));
+    return new UnmodifiableMultiset<>(checkNotNull(multiset));
   }
 
   /**
@@ -231,7 +231,7 @@ public final class Multisets {
   public static <E extends @Nullable Object> SortedMultiset<E> unmodifiableSortedMultiset(
       SortedMultiset<E> sortedMultiset) {
     // it's in its own file so it can be emulated for GWT
-    return new UnmodifiableSortedMultiset<E>(checkNotNull(sortedMultiset));
+    return new UnmodifiableSortedMultiset<>(checkNotNull(sortedMultiset));
   }
 
   /**
@@ -244,7 +244,7 @@ public final class Multisets {
    */
   public static <E extends @Nullable Object> Multiset.Entry<E> immutableEntry(
       @ParametricNullness E e, int n) {
-    return new ImmutableEntry<E>(e, n);
+    return new ImmutableEntry<>(e, n);
   }
 
   static class ImmutableEntry<E extends @Nullable Object> extends AbstractEntry<E>
@@ -309,9 +309,9 @@ public final class Multisets {
       // collection.
       FilteredMultiset<E> filtered = (FilteredMultiset<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredMultiset<E>(filtered.unfiltered, combinedPredicate);
+      return new FilteredMultiset<>(filtered.unfiltered, combinedPredicate);
     }
-    return new FilteredMultiset<E>(unfiltered, predicate);
+    return new FilteredMultiset<>(unfiltered, predicate);
   }
 
   private static final class FilteredMultiset<E extends @Nullable Object> extends ViewMultiset<E> {
@@ -1079,7 +1079,7 @@ public final class Multisets {
 
   /** An implementation of {@link Multiset#iterator}. */
   static <E extends @Nullable Object> Iterator<E> iteratorImpl(Multiset<E> multiset) {
-    return new MultisetIteratorImpl<E>(multiset, multiset.entrySet().iterator());
+    return new MultisetIteratorImpl<>(multiset, multiset.entrySet().iterator());
   }
 
   static final class MultisetIteratorImpl<E extends @Nullable Object> implements Iterator<E> {

--- a/android/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
+++ b/android/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
@@ -58,7 +58,7 @@ public final class MutableClassToInstanceMap<B extends @Nullable Object>
    * default initial capacity and load factor.
    */
   public static <B extends @Nullable Object> MutableClassToInstanceMap<B> create() {
-    return new MutableClassToInstanceMap<B>(new HashMap<Class<? extends @NonNull B>, B>());
+    return new MutableClassToInstanceMap<>(new HashMap<Class<? extends @NonNull B>, B>());
   }
 
   /**
@@ -68,7 +68,7 @@ public final class MutableClassToInstanceMap<B extends @Nullable Object>
    */
   public static <B extends @Nullable Object> MutableClassToInstanceMap<B> create(
       Map<Class<? extends @NonNull B>, B> backingMap) {
-    return new MutableClassToInstanceMap<B>(backingMap);
+    return new MutableClassToInstanceMap<>(backingMap);
   }
 
   private final Map<Class<? extends @NonNull B>, B> delegate;

--- a/android/guava/src/com/google/common/collect/ObjectCountHashMap.java
+++ b/android/guava/src/com/google/common/collect/ObjectCountHashMap.java
@@ -44,7 +44,7 @@ class ObjectCountHashMap<K extends @Nullable Object> {
 
   /** Creates an empty {@code ObjectCountHashMap} instance. */
   static <K extends @Nullable Object> ObjectCountHashMap<K> create() {
-    return new ObjectCountHashMap<K>();
+    return new ObjectCountHashMap<>();
   }
 
   /**
@@ -58,7 +58,7 @@ class ObjectCountHashMap<K extends @Nullable Object> {
    */
   static <K extends @Nullable Object> ObjectCountHashMap<K> createWithExpectedSize(
       int expectedSize) {
-    return new ObjectCountHashMap<K>(expectedSize);
+    return new ObjectCountHashMap<>(expectedSize);
   }
 
   private static final int MAXIMUM_CAPACITY = 1 << 30;

--- a/android/guava/src/com/google/common/collect/ObjectCountLinkedHashMap.java
+++ b/android/guava/src/com/google/common/collect/ObjectCountLinkedHashMap.java
@@ -32,7 +32,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 class ObjectCountLinkedHashMap<K extends @Nullable Object> extends ObjectCountHashMap<K> {
   /** Creates an empty {@code ObjectCountLinkedHashMap} instance. */
   static <K extends @Nullable Object> ObjectCountLinkedHashMap<K> create() {
-    return new ObjectCountLinkedHashMap<K>();
+    return new ObjectCountLinkedHashMap<>();
   }
 
   /**
@@ -46,7 +46,7 @@ class ObjectCountLinkedHashMap<K extends @Nullable Object> extends ObjectCountHa
    */
   static <K extends @Nullable Object> ObjectCountLinkedHashMap<K> createWithExpectedSize(
       int expectedSize) {
-    return new ObjectCountLinkedHashMap<K>(expectedSize);
+    return new ObjectCountLinkedHashMap<>(expectedSize);
   }
 
   private static final int ENDPOINT = -2;

--- a/android/guava/src/com/google/common/collect/Ordering.java
+++ b/android/guava/src/com/google/common/collect/Ordering.java
@@ -224,7 +224,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // TODO(kevinb): provide replacement
   @GwtCompatible(serializable = true)
   public static <T> Ordering<T> explicit(List<T> valuesInOrder) {
-    return new ExplicitOrdering<T>(valuesInOrder);
+    return new ExplicitOrdering<>(valuesInOrder);
   }
 
   /**
@@ -411,7 +411,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().reverse();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<S> reverse() {
-    return new ReverseOrdering<S>(this);
+    return new ReverseOrdering<>(this);
   }
 
   /**
@@ -426,7 +426,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().nullsFirst();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<@Nullable S> nullsFirst() {
-    return new NullsFirstOrdering<S>(this);
+    return new NullsFirstOrdering<>(this);
   }
 
   /**
@@ -441,7 +441,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().nullsLast();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<@Nullable S> nullsLast() {
-    return new NullsLastOrdering<S>(this);
+    return new NullsLastOrdering<>(this);
   }
 
   /**
@@ -484,7 +484,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    */
   @GwtCompatible(serializable = true)
   public <U extends T> Ordering<U> compound(Comparator<? super U> secondaryComparator) {
-    return new CompoundOrdering<U>(this, checkNotNull(secondaryComparator));
+    return new CompoundOrdering<>(this, checkNotNull(secondaryComparator));
   }
 
   /**
@@ -511,7 +511,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   @GwtCompatible(serializable = true)
   public static <T extends @Nullable Object> Ordering<T> compound(
       Iterable<? extends Comparator<? super T>> comparators) {
-    return new CompoundOrdering<T>(comparators);
+    return new CompoundOrdering<>(comparators);
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/Queues.java
+++ b/android/guava/src/com/google/common/collect/Queues.java
@@ -55,7 +55,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // ArrayBlockingQueue
   public static <E> ArrayBlockingQueue<E> newArrayBlockingQueue(int capacity) {
-    return new ArrayBlockingQueue<E>(capacity);
+    return new ArrayBlockingQueue<>(capacity);
   }
 
   // ArrayDeque
@@ -66,7 +66,7 @@ public final class Queues {
    * @since 12.0
    */
   public static <E> ArrayDeque<E> newArrayDeque() {
-    return new ArrayDeque<E>();
+    return new ArrayDeque<>();
   }
 
   /**
@@ -77,9 +77,9 @@ public final class Queues {
    */
   public static <E> ArrayDeque<E> newArrayDeque(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new ArrayDeque<E>((Collection<? extends E>) elements);
+      return new ArrayDeque<>((Collection<? extends E>) elements);
     }
-    ArrayDeque<E> deque = new ArrayDeque<E>();
+    ArrayDeque<E> deque = new ArrayDeque<>();
     Iterables.addAll(deque, elements);
     return deque;
   }
@@ -90,7 +90,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // ConcurrentLinkedQueue
   public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue() {
-    return new ConcurrentLinkedQueue<E>();
+    return new ConcurrentLinkedQueue<>();
   }
 
   /**
@@ -102,9 +102,9 @@ public final class Queues {
   public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new ConcurrentLinkedQueue<E>((Collection<? extends E>) elements);
+      return new ConcurrentLinkedQueue<>((Collection<? extends E>) elements);
     }
-    ConcurrentLinkedQueue<E> queue = new ConcurrentLinkedQueue<E>();
+    ConcurrentLinkedQueue<E> queue = new ConcurrentLinkedQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -119,7 +119,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque() {
-    return new LinkedBlockingDeque<E>();
+    return new LinkedBlockingDeque<>();
   }
 
   /**
@@ -131,7 +131,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(int capacity) {
-    return new LinkedBlockingDeque<E>(capacity);
+    return new LinkedBlockingDeque<>(capacity);
   }
 
   /**
@@ -145,9 +145,9 @@ public final class Queues {
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedBlockingDeque<E>((Collection<? extends E>) elements);
+      return new LinkedBlockingDeque<>((Collection<? extends E>) elements);
     }
-    LinkedBlockingDeque<E> deque = new LinkedBlockingDeque<E>();
+    LinkedBlockingDeque<E> deque = new LinkedBlockingDeque<>();
     Iterables.addAll(deque, elements);
     return deque;
   }
@@ -158,7 +158,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue() {
-    return new LinkedBlockingQueue<E>();
+    return new LinkedBlockingQueue<>();
   }
 
   /**
@@ -169,7 +169,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(int capacity) {
-    return new LinkedBlockingQueue<E>(capacity);
+    return new LinkedBlockingQueue<>(capacity);
   }
 
   /**
@@ -184,9 +184,9 @@ public final class Queues {
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedBlockingQueue<E>((Collection<? extends E>) elements);
+      return new LinkedBlockingQueue<>((Collection<? extends E>) elements);
     }
-    LinkedBlockingQueue<E> queue = new LinkedBlockingQueue<E>();
+    LinkedBlockingQueue<E> queue = new LinkedBlockingQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -206,7 +206,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // PriorityBlockingQueue
   public static <E extends Comparable> PriorityBlockingQueue<E> newPriorityBlockingQueue() {
-    return new PriorityBlockingQueue<E>();
+    return new PriorityBlockingQueue<>();
   }
 
   /**
@@ -224,9 +224,9 @@ public final class Queues {
   public static <E extends Comparable> PriorityBlockingQueue<E> newPriorityBlockingQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new PriorityBlockingQueue<E>((Collection<? extends E>) elements);
+      return new PriorityBlockingQueue<>((Collection<? extends E>) elements);
     }
-    PriorityBlockingQueue<E> queue = new PriorityBlockingQueue<E>();
+    PriorityBlockingQueue<E> queue = new PriorityBlockingQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -242,7 +242,7 @@ public final class Queues {
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> PriorityQueue<E> newPriorityQueue() {
-    return new PriorityQueue<E>();
+    return new PriorityQueue<>();
   }
 
   /**
@@ -258,9 +258,9 @@ public final class Queues {
   public static <E extends Comparable> PriorityQueue<E> newPriorityQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new PriorityQueue<E>((Collection<? extends E>) elements);
+      return new PriorityQueue<>((Collection<? extends E>) elements);
     }
-    PriorityQueue<E> queue = new PriorityQueue<E>();
+    PriorityQueue<E> queue = new PriorityQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -271,7 +271,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // SynchronousQueue
   public static <E> SynchronousQueue<E> newSynchronousQueue() {
-    return new SynchronousQueue<E>();
+    return new SynchronousQueue<>();
   }
 
   /**

--- a/android/guava/src/com/google/common/collect/RegularImmutableBiMap.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableBiMap.java
@@ -61,7 +61,7 @@ final class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
     Object valueHashTable =
         RegularImmutableMap.createHashTableOrThrow(alternatingKeysAndValues, size, tableSize, 1);
     this.inverse =
-        new RegularImmutableBiMap<V, K>(valueHashTable, alternatingKeysAndValues, size, this);
+        new RegularImmutableBiMap<>(valueHashTable, alternatingKeysAndValues, size, this);
   }
 
   /** V-to-K constructor. */

--- a/android/guava/src/com/google/common/collect/RegularImmutableMap.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableMap.java
@@ -109,7 +109,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
       // requireNonNull is safe because the first `2*n` elements have been filled in.
       checkEntryNotNull(
           requireNonNull(alternatingKeysAndValues[0]), requireNonNull(alternatingKeysAndValues[1]));
-      return new RegularImmutableMap<K, V>(null, alternatingKeysAndValues, 1);
+      return new RegularImmutableMap<>(null, alternatingKeysAndValues, 1);
     }
     checkPositionIndex(n, alternatingKeysAndValues.length >> 1);
     int tableSize = ImmutableSet.chooseTableSize(n);
@@ -133,7 +133,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     } else {
       hashTable = hashTablePlus;
     }
-    return new RegularImmutableMap<K, V>(hashTable, alternatingKeysAndValues, n);
+    return new RegularImmutableMap<>(hashTable, alternatingKeysAndValues, n);
   }
 
   /**
@@ -424,7 +424,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
           K key = (K) requireNonNull(alternatingKeysAndValues[2 * index + keyOffset]);
           @SuppressWarnings("unchecked")
           V value = (V) requireNonNull(alternatingKeysAndValues[2 * index + (keyOffset ^ 1)]);
-          return new AbstractMap.SimpleImmutableEntry<K, V>(key, value);
+          return new AbstractMap.SimpleImmutableEntry<>(key, value);
         }
 
         @Override
@@ -483,7 +483,7 @@ final class RegularImmutableMap<K, V> extends ImmutableMap<K, V> {
     @SuppressWarnings("unchecked")
     ImmutableList<K> keyList =
         (ImmutableList<K>) new KeysOrValuesAsList(alternatingKeysAndValues, 0, size);
-    return new KeySet<K>(this, keyList);
+    return new KeySet<>(this, keyList);
   }
 
   static final class KeysOrValuesAsList extends ImmutableList<Object> {

--- a/android/guava/src/com/google/common/collect/RegularImmutableMultiset.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableMultiset.java
@@ -130,7 +130,7 @@ class RegularImmutableMultiset<E> extends ImmutableMultiset<E> {
 
     Object readResolve() {
       ImmutableMultiset.Builder<Object> builder =
-          new ImmutableMultiset.Builder<Object>(elements.length);
+          new ImmutableMultiset.Builder<>(elements.length);
       for (int i = 0; i < elements.length; i++) {
         builder.addCopies(elements[i], counts[i]);
       }

--- a/android/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
@@ -116,7 +116,7 @@ final class RegularImmutableSortedMultiset<E> extends ImmutableSortedMultiset<E>
       return this;
     } else {
       RegularImmutableSortedSet<E> subElementSet = elementSet.getSubSet(from, to);
-      return new RegularImmutableSortedMultiset<E>(
+      return new RegularImmutableSortedMultiset<>(
           subElementSet, cumulativeCounts, offset + from, to - from);
     }
   }

--- a/android/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
+++ b/android/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
@@ -287,7 +287,7 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
     if (newFromIndex == 0 && newToIndex == size()) {
       return this;
     } else if (newFromIndex < newToIndex) {
-      return new RegularImmutableSortedSet<E>(
+      return new RegularImmutableSortedSet<>(
           elements.subList(newFromIndex, newToIndex), comparator);
     } else {
       return emptySet(comparator);

--- a/android/guava/src/com/google/common/collect/Sets.java
+++ b/android/guava/src/com/google/common/collect/Sets.java
@@ -178,7 +178,7 @@ public final class Sets {
    * href="http://goo.gl/iz2Wi">"diamond" syntax</a>.
    */
   public static <E extends @Nullable Object> HashSet<E> newHashSet() {
-    return new HashSet<E>();
+    return new HashSet<>();
   }
 
   /**
@@ -257,7 +257,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> HashSet<E> newHashSetWithExpectedSize(
       int expectedSize) {
-    return new HashSet<E>(Maps.capacity(expectedSize));
+    return new HashSet<>(Maps.capacity(expectedSize));
   }
 
   /**
@@ -307,7 +307,7 @@ public final class Sets {
    * @return a new, empty {@code LinkedHashSet}
    */
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSet() {
-    return new LinkedHashSet<E>();
+    return new LinkedHashSet<>();
   }
 
   /**
@@ -328,7 +328,7 @@ public final class Sets {
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSet(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedHashSet<E>((Collection<? extends E>) elements);
+      return new LinkedHashSet<>((Collection<? extends E>) elements);
     }
     LinkedHashSet<E> set = newLinkedHashSet();
     Iterables.addAll(set, elements);
@@ -349,7 +349,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(
       int expectedSize) {
-    return new LinkedHashSet<E>(Maps.capacity(expectedSize));
+    return new LinkedHashSet<>(Maps.capacity(expectedSize));
   }
 
   // TreeSet
@@ -368,7 +368,7 @@ public final class Sets {
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> TreeSet<E> newTreeSet() {
-    return new TreeSet<E>();
+    return new TreeSet<>();
   }
 
   /**
@@ -417,7 +417,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> TreeSet<E> newTreeSet(
       Comparator<? super E> comparator) {
-    return new TreeSet<E>(checkNotNull(comparator));
+    return new TreeSet<>(checkNotNull(comparator));
   }
 
   /**
@@ -445,7 +445,7 @@ public final class Sets {
   @J2ktIncompatible
   @GwtIncompatible // CopyOnWriteArraySet
   public static <E extends @Nullable Object> CopyOnWriteArraySet<E> newCopyOnWriteArraySet() {
-    return new CopyOnWriteArraySet<E>();
+    return new CopyOnWriteArraySet<>();
   }
 
   /**
@@ -465,7 +465,7 @@ public final class Sets {
         (elements instanceof Collection)
             ? (Collection<? extends E>) elements
             : Lists.newArrayList(elements);
-    return new CopyOnWriteArraySet<E>(elementsCollection);
+    return new CopyOnWriteArraySet<>(elementsCollection);
   }
 
   /**
@@ -1013,10 +1013,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredSet<E>((Set<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredSet<>((Set<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -1050,10 +1050,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredSortedSet<E>((SortedSet<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredSortedSet<>((SortedSet<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredSortedSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredSortedSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -1088,10 +1088,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredNavigableSet<E>((NavigableSet<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredNavigableSet<>((NavigableSet<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredNavigableSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredNavigableSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   private static class FilteredSet<E extends @Nullable Object> extends FilteredCollection<E>
@@ -1126,18 +1126,18 @@ public final class Sets {
 
     @Override
     public SortedSet<E> subSet(@ParametricNullness E fromElement, @ParametricNullness E toElement) {
-      return new FilteredSortedSet<E>(
+      return new FilteredSortedSet<>(
           ((SortedSet<E>) unfiltered).subSet(fromElement, toElement), predicate);
     }
 
     @Override
     public SortedSet<E> headSet(@ParametricNullness E toElement) {
-      return new FilteredSortedSet<E>(((SortedSet<E>) unfiltered).headSet(toElement), predicate);
+      return new FilteredSortedSet<>(((SortedSet<E>) unfiltered).headSet(toElement), predicate);
     }
 
     @Override
     public SortedSet<E> tailSet(@ParametricNullness E fromElement) {
-      return new FilteredSortedSet<E>(((SortedSet<E>) unfiltered).tailSet(fromElement), predicate);
+      return new FilteredSortedSet<>(((SortedSet<E>) unfiltered).tailSet(fromElement), predicate);
     }
 
     @Override
@@ -1567,7 +1567,7 @@ public final class Sets {
       return new AbstractIndexedListIterator<Set<E>>(size()) {
         @Override
         protected Set<E> get(final int setBits) {
-          return new SubSet<E>(inputSet, setBits);
+          return new SubSet<>(inputSet, setBits);
         }
       };
     }
@@ -1779,7 +1779,7 @@ public final class Sets {
     if (set instanceof ImmutableCollection || set instanceof UnmodifiableNavigableSet) {
       return set;
     }
-    return new UnmodifiableNavigableSet<E>(set);
+    return new UnmodifiableNavigableSet<>(set);
   }
 
   static final class UnmodifiableNavigableSet<E extends @Nullable Object>
@@ -1839,7 +1839,7 @@ public final class Sets {
     public NavigableSet<E> descendingSet() {
       UnmodifiableNavigableSet<E> result = descendingSet;
       if (result == null) {
-        result = descendingSet = new UnmodifiableNavigableSet<E>(delegate.descendingSet());
+        result = descendingSet = new UnmodifiableNavigableSet<>(delegate.descendingSet());
         result.descendingSet = this;
       }
       return result;

--- a/android/guava/src/com/google/common/collect/Synchronized.java
+++ b/android/guava/src/com/google/common/collect/Synchronized.java
@@ -111,7 +111,7 @@ final class Synchronized {
 
   private static <E extends @Nullable Object> Collection<E> collection(
       Collection<E> collection, @CheckForNull Object mutex) {
-    return new SynchronizedCollection<E>(collection, mutex);
+    return new SynchronizedCollection<>(collection, mutex);
   }
 
   @VisibleForTesting
@@ -222,7 +222,7 @@ final class Synchronized {
 
   @VisibleForTesting
   static <E extends @Nullable Object> Set<E> set(Set<E> set, @CheckForNull Object mutex) {
-    return new SynchronizedSet<E>(set, mutex);
+    return new SynchronizedSet<>(set, mutex);
   }
 
   static class SynchronizedSet<E extends @Nullable Object> extends SynchronizedCollection<E>
@@ -259,7 +259,7 @@ final class Synchronized {
 
   private static <E extends @Nullable Object> SortedSet<E> sortedSet(
       SortedSet<E> set, @CheckForNull Object mutex) {
-    return new SynchronizedSortedSet<E>(set, mutex);
+    return new SynchronizedSortedSet<>(set, mutex);
   }
 
   static class SynchronizedSortedSet<E extends @Nullable Object> extends SynchronizedSet<E>
@@ -437,7 +437,7 @@ final class Synchronized {
     if (multiset instanceof SynchronizedMultiset || multiset instanceof ImmutableMultiset) {
       return multiset;
     }
-    return new SynchronizedMultiset<E>(multiset, mutex);
+    return new SynchronizedMultiset<>(multiset, mutex);
   }
 
   static final class SynchronizedMultiset<E extends @Nullable Object>
@@ -1439,7 +1439,7 @@ final class Synchronized {
   @GwtIncompatible // NavigableSet
   static <E extends @Nullable Object> NavigableSet<E> navigableSet(
       NavigableSet<E> navigableSet, @CheckForNull Object mutex) {
-    return new SynchronizedNavigableSet<E>(navigableSet, mutex);
+    return new SynchronizedNavigableSet<>(navigableSet, mutex);
   }
 
   @GwtIncompatible // NavigableSet
@@ -1771,7 +1771,7 @@ final class Synchronized {
   }
 
   static <E extends @Nullable Object> Deque<E> deque(Deque<E> deque, @CheckForNull Object mutex) {
-    return new SynchronizedDeque<E>(deque, mutex);
+    return new SynchronizedDeque<>(deque, mutex);
   }
 
   static final class SynchronizedDeque<E extends @Nullable Object> extends SynchronizedQueue<E>

--- a/android/guava/src/com/google/common/collect/TopKSelector.java
+++ b/android/guava/src/com/google/common/collect/TopKSelector.java
@@ -76,7 +76,7 @@ final class TopKSelector<
    */
   public static <T extends @Nullable Object> TopKSelector<T> least(
       int k, Comparator<? super T> comparator) {
-    return new TopKSelector<T>(comparator, k);
+    return new TopKSelector<>(comparator, k);
   }
 
   /**
@@ -98,7 +98,7 @@ final class TopKSelector<
    */
   public static <T extends @Nullable Object> TopKSelector<T> greatest(
       int k, Comparator<? super T> comparator) {
-    return new TopKSelector<T>(Ordering.from(comparator).reverse(), k);
+    return new TopKSelector<>(Ordering.from(comparator).reverse(), k);
   }
 
   private final int k;

--- a/android/guava/src/com/google/common/collect/TreeMultiset.java
+++ b/android/guava/src/com/google/common/collect/TreeMultiset.java
@@ -75,7 +75,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> TreeMultiset<E> create() {
-    return new TreeMultiset<E>(Ordering.natural());
+    return new TreeMultiset<>(Ordering.natural());
   }
 
   /**
@@ -266,7 +266,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     AvlNode<E> root = rootReference.get();
     if (root == null) {
       int unused = comparator().compare(element, element);
-      AvlNode<E> newRoot = new AvlNode<E>(element, occurrences);
+      AvlNode<E> newRoot = new AvlNode<>(element, occurrences);
       successor(header, newRoot, header);
       rootReference.checkAndSet(root, newRoot);
       return 0;
@@ -539,7 +539,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
 
   @Override
   public SortedMultiset<E> headMultiset(@ParametricNullness E upperBound, BoundType boundType) {
-    return new TreeMultiset<E>(
+    return new TreeMultiset<>(
         rootReference,
         range.intersect(GeneralRange.upTo(comparator(), upperBound, boundType)),
         header);
@@ -547,7 +547,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
 
   @Override
   public SortedMultiset<E> tailMultiset(@ParametricNullness E lowerBound, BoundType boundType) {
-    return new TreeMultiset<E>(
+    return new TreeMultiset<>(
         rootReference,
         range.intersect(GeneralRange.downTo(comparator(), lowerBound, boundType)),
         header);
@@ -647,7 +647,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     }
 
     private AvlNode<E> addRightChild(@ParametricNullness E e, int count) {
-      right = new AvlNode<E>(e, count);
+      right = new AvlNode<>(e, count);
       successor(this, right, succ());
       height = Math.max(2, height);
       distinctElements++;
@@ -656,7 +656,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     }
 
     private AvlNode<E> addLeftChild(@ParametricNullness E e, int count) {
-      left = new AvlNode<E>(e, count);
+      left = new AvlNode<>(e, count);
       successor(pred(), left, this);
       height = Math.max(2, height);
       distinctElements++;

--- a/android/guava/src/com/google/common/collect/TreeTraverser.java
+++ b/android/guava/src/com/google/common/collect/TreeTraverser.java
@@ -215,7 +215,7 @@ public abstract class TreeTraverser<T> {
     }
 
     private PostOrderNode<T> expand(T t) {
-      return new PostOrderNode<T>(t, children(t).iterator());
+      return new PostOrderNode<>(t, children(t).iterator());
     }
   }
 
@@ -245,7 +245,7 @@ public abstract class TreeTraverser<T> {
     private final Queue<T> queue;
 
     BreadthFirstIterator(T root) {
-      this.queue = new ArrayDeque<T>();
+      this.queue = new ArrayDeque<>();
       queue.add(root);
     }
 

--- a/android/guava/src/com/google/common/graph/Graphs.java
+++ b/android/guava/src/com/google/common/graph/Graphs.java
@@ -166,7 +166,7 @@ public final class Graphs extends GraphsBridgeMethods {
     } else {
       // An optimization for the undirected case: for every node B reachable from node A,
       // node A and node B have the same reachability set.
-      Set<N> visitedNodes = new HashSet<N>();
+      Set<N> visitedNodes = new HashSet<>();
       for (N node : graph.nodes()) {
         if (!visitedNodes.contains(node)) {
           Set<N> reachableNodes = reachableNodes(graph, node);
@@ -218,7 +218,7 @@ public final class Graphs extends GraphsBridgeMethods {
       return ((TransposedGraph<N>) graph).graph;
     }
 
-    return new TransposedGraph<N>(graph);
+    return new TransposedGraph<>(graph);
   }
 
   /**

--- a/android/guava/src/com/google/common/hash/BloomFilter.java
+++ b/android/guava/src/com/google/common/hash/BloomFilter.java
@@ -138,7 +138,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * @since 12.0
    */
   public BloomFilter<T> copy() {
-    return new BloomFilter<T>(bits.copy(), numHashFunctions, funnel, strategy);
+    return new BloomFilter<>(bits.copy(), numHashFunctions, funnel, strategy);
   }
 
   /**
@@ -369,7 +369,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
     long numBits = optimalNumOfBits(expectedInsertions, fpp);
     int numHashFunctions = optimalNumOfHashFunctions(expectedInsertions, numBits);
     try {
-      return new BloomFilter<T>(new LockFreeBitArray(numBits), numHashFunctions, funnel, strategy);
+      return new BloomFilter<>(new LockFreeBitArray(numBits), numHashFunctions, funnel, strategy);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Could not create BloomFilter of " + numBits + " bits", e);
     }
@@ -554,7 +554,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
         dataArray.putData(i, din.readLong());
       }
 
-      return new BloomFilter<T>(dataArray, numHashFunctions, funnel, strategy);
+      return new BloomFilter<>(dataArray, numHashFunctions, funnel, strategy);
     } catch (IOException e) {
       throw e;
     } catch (Exception e) { // sneaky checked exception

--- a/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -860,7 +860,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
         }
         return false;
       }
-      SetFuture<V> valueToSet = new SetFuture<V>(this, future);
+      SetFuture<V> valueToSet = new SetFuture<>(this, future);
       if (ATOMIC_HELPER.casValue(this, null, valueToSet)) {
         // the listener is responsible for calling completeWithFuture, directExecutor is appropriate
         // since all we are doing is unpacking a completed future which should be fast.

--- a/android/guava/src/com/google/common/util/concurrent/AtomicLongMap.java
+++ b/android/guava/src/com/google/common/util/concurrent/AtomicLongMap.java
@@ -68,7 +68,7 @@ public final class AtomicLongMap<K> implements Serializable {
 
   /** Creates an {@code AtomicLongMap}. */
   public static <K> AtomicLongMap<K> create() {
-    return new AtomicLongMap<K>(new ConcurrentHashMap<K, AtomicLong>());
+    return new AtomicLongMap<>(new ConcurrentHashMap<K, AtomicLong>());
   }
 
   /** Creates an {@code AtomicLongMap} with the same mappings as the specified {@code Map}. */

--- a/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/android/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -406,7 +406,7 @@ public final class ClosingFuture<V extends @Nullable Object> {
    * when the pipeline is done, use {@link #submit(ClosingCallable, Executor)} instead.
    */
   public static <V extends @Nullable Object> ClosingFuture<V> from(ListenableFuture<V> future) {
-    return new ClosingFuture<V>(future);
+    return new ClosingFuture<>(future);
   }
 
   /**

--- a/android/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/android/guava/src/com/google/common/util/concurrent/Futures.java
@@ -161,7 +161,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   public static <V extends @Nullable Object> ListenableFuture<V> immediateFailedFuture(
       Throwable throwable) {
     checkNotNull(throwable);
-    return new ImmediateFailedFuture<V>(throwable);
+    return new ImmediateFailedFuture<>(throwable);
   }
 
   /**
@@ -584,7 +584,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @SafeVarargs
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllComplete(
       ListenableFuture<? extends V>... futures) {
-    return new FutureCombiner<V>(false, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(false, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -597,7 +597,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllComplete(
       Iterable<? extends ListenableFuture<? extends V>> futures) {
-    return new FutureCombiner<V>(false, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(false, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -610,7 +610,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @SafeVarargs
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllSucceed(
       ListenableFuture<? extends V>... futures) {
-    return new FutureCombiner<V>(true, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(true, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -622,7 +622,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllSucceed(
       Iterable<? extends ListenableFuture<? extends V>> futures) {
-    return new FutureCombiner<V>(true, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(true, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -684,7 +684,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
      */
     public <C extends @Nullable Object> ListenableFuture<C> callAsync(
         AsyncCallable<C> combiner, Executor executor) {
-      return new CombinedFuture<C>(futures, allMustSucceed, executor, combiner);
+      return new CombinedFuture<>(futures, allMustSucceed, executor, combiner);
     }
 
     /**
@@ -709,7 +709,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
      */
     public <C extends @Nullable Object> ListenableFuture<C> call(
         Callable<C> combiner, Executor executor) {
-      return new CombinedFuture<C>(futures, allMustSucceed, executor, combiner);
+      return new CombinedFuture<>(futures, allMustSucceed, executor, combiner);
     }
 
     /**

--- a/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/android/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -610,7 +610,7 @@ public final class MoreExecutors {
         Callable<V> callable, long delay, TimeUnit unit) {
       TrustedListenableFutureTask<V> task = TrustedListenableFutureTask.create(callable);
       ScheduledFuture<?> scheduled = delegate.schedule(task, delay, unit);
-      return new ListenableScheduledTask<V>(task, scheduled);
+      return new ListenableScheduledTask<>(task, scheduled);
     }
 
     @Override

--- a/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/AbstractIteratorTester.java
@@ -137,12 +137,12 @@ abstract class AbstractIteratorTester<E extends @Nullable Object, I extends Iter
      * The elements to be returned by future calls to {@code next()}, with the first at the top of
      * the stack.
      */
-    final Stack<E> nextElements = new Stack<E>();
+    final Stack<E> nextElements = new Stack<>();
     /**
      * The elements to be returned by future calls to {@code previous()}, with the first at the top
      * of the stack.
      */
-    final Stack<E> previousElements = new Stack<E>();
+    final Stack<E> previousElements = new Stack<>();
     /**
      * {@link #nextElements} if {@code next()} was called more recently then {@code previous},
      * {@link #previousElements} if the reverse is true, or -- overriding both of these -- {@code
@@ -256,7 +256,7 @@ abstract class AbstractIteratorTester<E extends @Nullable Object, I extends Iter
     }
 
     private List<E> getElements() {
-      List<E> elements = new ArrayList<E>();
+      List<E> elements = new ArrayList<>();
       Helpers.addAll(elements, previousElements);
       Helpers.addAll(elements, Helpers.reverse(nextElements));
       return elements;
@@ -325,7 +325,7 @@ abstract class AbstractIteratorTester<E extends @Nullable Object, I extends Iter
 
   public void testForEachRemaining() {
     for (int i = 0; i < expectedElements.size() - 1; i++) {
-      List<E> targetElements = new ArrayList<E>();
+      List<E> targetElements = new ArrayList<>();
       Iterator<E> iterator = newTargetIterator();
       for (int j = 0; j < i; j++) {
         targetElements.add(iterator.next());

--- a/guava-testlib/src/com/google/common/collect/testing/TestsForMapsInJavaUtil.java
+++ b/guava-testlib/src/com/google/common/collect/testing/TestsForMapsInJavaUtil.java
@@ -587,7 +587,7 @@ public class TestsForMapsInJavaUtil {
   }
 
   static <T> Comparator<T> arbitraryNullFriendlyComparator() {
-    return new NullFriendlyComparator<T>();
+    return new NullFriendlyComparator<>();
   }
 
   private static final class NullFriendlyComparator<T> implements Comparator<T>, Serializable {

--- a/guava-testlib/src/com/google/common/collect/testing/TestsForSetsInJavaUtil.java
+++ b/guava-testlib/src/com/google/common/collect/testing/TestsForSetsInJavaUtil.java
@@ -560,7 +560,7 @@ public class TestsForSetsInJavaUtil {
   }
 
   static <T> Comparator<T> arbitraryNullFriendlyComparator() {
-    return new NullFriendlyComparator<T>();
+    return new NullFriendlyComparator<>();
   }
 
   private static final class NullFriendlyComparator<T> implements Comparator<T>, Serializable {

--- a/guava/src/com/google/common/base/Equivalence.java
+++ b/guava/src/com/google/common/base/Equivalence.java
@@ -287,7 +287,7 @@ public abstract class Equivalence<T> implements BiPredicate<@Nullable T, @Nullab
    * @since 10.0
    */
   public final Predicate<@Nullable T> equivalentTo(@CheckForNull T target) {
-    return new EquivalentToPredicate<T>(this, target);
+    return new EquivalentToPredicate<>(this, target);
   }
 
   private static final class EquivalentToPredicate<T>

--- a/guava/src/com/google/common/base/Optional.java
+++ b/guava/src/com/google/common/base/Optional.java
@@ -105,7 +105,7 @@ public abstract class Optional<T> implements Serializable {
    * @throws NullPointerException if {@code reference} is null
    */
   public static <T> Optional<T> of(T reference) {
-    return new Present<T>(checkNotNull(reference));
+    return new Present<>(checkNotNull(reference));
   }
 
   /**

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -265,7 +265,7 @@ public final class Suppliers {
     // The alternative of `duration.compareTo(Duration.ZERO) > 0` causes J2ObjC trouble.
     checkArgument(
         !duration.isNegative() && !duration.isZero(), "duration (%s) must be > 0", duration);
-    return new ExpiringMemoizingSupplier<T>(delegate, toNanosSaturated(duration));
+    return new ExpiringMemoizingSupplier<>(delegate, toNanosSaturated(duration));
   }
 
   @VisibleForTesting

--- a/guava/src/com/google/common/collect/ArrayListMultimap.java
+++ b/guava/src/com/google/common/collect/ArrayListMultimap.java
@@ -133,7 +133,7 @@ public final class ArrayListMultimap<K extends @Nullable Object, V extends @Null
    */
   @Override
   List<V> createCollection() {
-    return new ArrayList<V>(expectedValuesPerKey);
+    return new ArrayList<>(expectedValuesPerKey);
   }
 
   /**

--- a/guava/src/com/google/common/collect/Collections2.java
+++ b/guava/src/com/google/common/collect/Collections2.java
@@ -93,7 +93,7 @@ public final class Collections2 {
       return ((FilteredCollection<E>) unfiltered).createCombined(predicate);
     }
 
-    return new FilteredCollection<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredCollection<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -132,7 +132,7 @@ public final class Collections2 {
     }
 
     FilteredCollection<E> createCombined(Predicate<? super E> newPredicate) {
-      return new FilteredCollection<E>(unfiltered, Predicates.<E>and(predicate, newPredicate));
+      return new FilteredCollection<>(unfiltered, Predicates.<E>and(predicate, newPredicate));
       // .<E> above needed to compile in JDK 5
     }
 
@@ -639,7 +639,7 @@ public final class Collections2 {
     int j;
 
     PermutationIterator(List<E> list) {
-      this.list = new ArrayList<E>(list);
+      this.list = new ArrayList<>(list);
       int n = list.size();
       c = new int[n];
       o = new int[n];

--- a/guava/src/com/google/common/collect/CompactLinkedHashMap.java
+++ b/guava/src/com/google/common/collect/CompactLinkedHashMap.java
@@ -130,7 +130,7 @@ class CompactLinkedHashMap<K extends @Nullable Object, V extends @Nullable Objec
 
   @Override
   Map<K, V> createHashFloodingResistantDelegate(int tableSize) {
-    return new LinkedHashMap<K, V>(tableSize, 1.0f, accessOrder);
+    return new LinkedHashMap<>(tableSize, 1.0f, accessOrder);
   }
 
   @Override

--- a/guava/src/com/google/common/collect/EnumMultiset.java
+++ b/guava/src/com/google/common/collect/EnumMultiset.java
@@ -52,7 +52,7 @@ public final class EnumMultiset<E extends Enum<E>> extends AbstractMultiset<E>
     implements Serializable {
   /** Creates an empty {@code EnumMultiset}. */
   public static <E extends Enum<E>> EnumMultiset<E> create(Class<E> type) {
-    return new EnumMultiset<E>(type);
+    return new EnumMultiset<>(type);
   }
 
   /**

--- a/guava/src/com/google/common/collect/HashMultiset.java
+++ b/guava/src/com/google/common/collect/HashMultiset.java
@@ -38,7 +38,7 @@ public final class HashMultiset<E extends @Nullable Object> extends AbstractMapB
 
   /** Creates a new, empty {@code HashMultiset} using the default initial capacity. */
   public static <E extends @Nullable Object> HashMultiset<E> create() {
-    return new HashMultiset<E>();
+    return new HashMultiset<>();
   }
 
   /**
@@ -49,7 +49,7 @@ public final class HashMultiset<E extends @Nullable Object> extends AbstractMapB
    * @throws IllegalArgumentException if {@code distinctElements} is negative
    */
   public static <E extends @Nullable Object> HashMultiset<E> create(int distinctElements) {
-    return new HashMultiset<E>(distinctElements);
+    return new HashMultiset<>(distinctElements);
   }
 
   /**

--- a/guava/src/com/google/common/collect/ImmutableCollection.java
+++ b/guava/src/com/google/common/collect/ImmutableCollection.java
@@ -368,7 +368,7 @@ public abstract class ImmutableCollection<E> extends AbstractCollection<E> imple
       case 1:
         return ImmutableList.of(iterator().next());
       default:
-        return new RegularImmutableAsList<E>(this, toArray());
+        return new RegularImmutableAsList<>(this, toArray());
     }
   }
 

--- a/guava/src/com/google/common/collect/ImmutableEnumSet.java
+++ b/guava/src/com/google/common/collect/ImmutableEnumSet.java
@@ -44,7 +44,7 @@ final class ImmutableEnumSet<E extends Enum<E>> extends ImmutableSet<E> {
       case 1:
         return ImmutableSet.of(Iterables.getOnlyElement(set));
       default:
-        return new ImmutableEnumSet<E>(set);
+        return new ImmutableEnumSet<>(set);
     }
   }
 

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -98,7 +98,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    * @throws NullPointerException if {@code element} is null
    */
   public static <E> ImmutableList<E> of(E element) {
-    return new SingletonImmutableList<E>(element);
+    return new SingletonImmutableList<>(element);
   }
 
   /**
@@ -387,7 +387,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
         @SuppressWarnings("nullness")
         Object[] elementsWithoutTrailingNulls =
             length < elements.length ? Arrays.copyOf(elements, length) : elements;
-        return new RegularImmutableList<E>(elementsWithoutTrailingNulls);
+        return new RegularImmutableList<>(elementsWithoutTrailingNulls);
     }
   }
 
@@ -759,7 +759,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**
@@ -776,7 +776,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    */
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
-    return new ImmutableList.Builder<E>(expectedSize);
+    return new ImmutableList.Builder<>(expectedSize);
   }
 
   /**

--- a/guava/src/com/google/common/collect/ImmutableMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableMultiset.java
@@ -452,7 +452,7 @@ public abstract class ImmutableMultiset<E> extends ImmutableMultisetGwtSerializa
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**

--- a/guava/src/com/google/common/collect/ImmutableRangeMap.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeMap.java
@@ -89,7 +89,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
     }
     Map<Range<K>, ? extends V> map = rangeMap.asMapOfRanges();
     ImmutableList.Builder<Range<K>> rangesBuilder = new ImmutableList.Builder<>(map.size());
-    ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<V>(map.size());
+    ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<>(map.size());
     for (Entry<Range<K>, ? extends V> entry : map.entrySet()) {
       rangesBuilder.add(entry.getKey());
       valuesBuilder.add(entry.getValue());
@@ -153,7 +153,7 @@ public class ImmutableRangeMap<K extends Comparable<?>, V> implements RangeMap<K
     public ImmutableRangeMap<K, V> build() {
       Collections.sort(entries, Range.<K>rangeLexOrdering().onKeys());
       ImmutableList.Builder<Range<K>> rangesBuilder = new ImmutableList.Builder<>(entries.size());
-      ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<V>(entries.size());
+      ImmutableList.Builder<V> valuesBuilder = new ImmutableList.Builder<>(entries.size());
       for (int i = 0; i < entries.size(); i++) {
         Range<K> range = entries.get(i).getKey();
         if (i > 0) {

--- a/guava/src/com/google/common/collect/ImmutableRangeSet.java
+++ b/guava/src/com/google/common/collect/ImmutableRangeSet.java
@@ -93,7 +93,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
     } else if (range.equals(Range.all())) {
       return all();
     } else {
-      return new ImmutableRangeSet<C>(ImmutableList.of(range));
+      return new ImmutableRangeSet<>(ImmutableList.of(range));
     }
   }
 
@@ -118,7 +118,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
         return immutableRangeSet;
       }
     }
-    return new ImmutableRangeSet<C>(ImmutableList.copyOf(rangeSet.asRanges()));
+    return new ImmutableRangeSet<>(ImmutableList.copyOf(rangeSet.asRanges()));
   }
 
   /**
@@ -390,7 +390,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
       return complement = of();
     } else {
       ImmutableList<Range<C>> complementRanges = new ComplementRanges();
-      result = complement = new ImmutableRangeSet<C>(complementRanges, this);
+      result = complement = new ImmutableRangeSet<>(complementRanges, this);
     }
     return result;
   }
@@ -517,7 +517,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
       if (range.encloses(span)) {
         return this;
       } else if (range.isConnected(span)) {
-        return new ImmutableRangeSet<C>(intersectRanges(range));
+        return new ImmutableRangeSet<>(intersectRanges(range));
       }
     }
     return of();
@@ -695,7 +695,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
     @Override
     ImmutableSortedSet<C> createDescendingSet() {
-      return new DescendingImmutableSortedSet<C>(this);
+      return new DescendingImmutableSortedSet<>(this);
     }
 
     @Override
@@ -746,7 +746,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
 
   /** Returns a new builder for an immutable range set. */
   public static <C extends Comparable<?>> Builder<C> builder() {
-    return new Builder<C>();
+    return new Builder<>();
   }
 
   /**
@@ -841,7 +841,7 @@ public final class ImmutableRangeSet<C extends Comparable> extends AbstractRange
           && Iterables.getOnlyElement(mergedRanges).equals(Range.all())) {
         return all();
       } else {
-        return new ImmutableRangeSet<C>(mergedRanges);
+        return new ImmutableRangeSet<>(mergedRanges);
       }
     }
   }

--- a/guava/src/com/google/common/collect/ImmutableSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSet.java
@@ -89,7 +89,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    * type conveys the immutability guarantee.
    */
   public static <E> ImmutableSet<E> of(E element) {
-    return new SingletonImmutableSet<E>(element);
+    return new SingletonImmutableSet<>(element);
   }
 
   /*
@@ -148,7 +148,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
   public static <E> ImmutableSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E... others) {
     checkArgument(
         others.length <= Integer.MAX_VALUE - 6, "the total number of elements must fit in an int");
-    SetBuilderImpl<E> builder = new RegularSetBuilderImpl<E>(6 + others.length);
+    SetBuilderImpl<E> builder = new RegularSetBuilderImpl<>(6 + others.length);
     builder = builder.add(e1).add(e2).add(e3).add(e4).add(e5).add(e6);
     for (int i = 0; i < others.length; i++) {
       builder = builder.add(others[i]);
@@ -262,7 +262,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
       case 1:
         return of(elements[0]);
       default:
-        SetBuilderImpl<E> builder = new RegularSetBuilderImpl<E>(expectedSize);
+        SetBuilderImpl<E> builder = new RegularSetBuilderImpl<>(expectedSize);
         for (int i = 0; i < elements.length; i++) {
           builder = builder.add(elements[i]);
         }
@@ -321,7 +321,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
     }
 
     ImmutableList<E> createAsList() {
-      return new RegularImmutableAsList<E>(this, toArray());
+      return new RegularImmutableAsList<>(this, toArray());
     }
 
     // redeclare to help optimizers with b/310253115
@@ -433,7 +433,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    * Builder} constructor.
    */
   public static <E> Builder<E> builder() {
-    return new Builder<E>();
+    return new Builder<>();
   }
 
   /**
@@ -450,7 +450,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
    */
   public static <E> Builder<E> builderWithExpectedSize(int expectedSize) {
     checkNonnegative(expectedSize, "expectedSize");
-    return new Builder<E>(expectedSize);
+    return new Builder<>(expectedSize);
   }
 
   /**
@@ -486,7 +486,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
 
     Builder(int capacity) {
       if (capacity > 0) {
-        impl = new RegularSetBuilderImpl<E>(capacity);
+        impl = new RegularSetBuilderImpl<>(capacity);
       } else {
         impl = EmptySetBuilderImpl.instance();
       }
@@ -499,7 +499,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
     @VisibleForTesting
     void forceJdk() {
       requireNonNull(impl); // see the comment on the field
-      this.impl = new JdkBackedSetBuilderImpl<E>(impl);
+      this.impl = new JdkBackedSetBuilderImpl<>(impl);
     }
 
     final void copyIfNecessary() {
@@ -783,7 +783,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
 
     @Override
     SetBuilderImpl<E> copy() {
-      return new RegularSetBuilderImpl<E>(this);
+      return new RegularSetBuilderImpl<>(this);
     }
 
     @Override
@@ -821,7 +821,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
               (distinct == dedupedElements.length)
                   ? dedupedElements
                   : Arrays.copyOf(dedupedElements, distinct);
-          return new RegularImmutableSet<E>(
+          return new RegularImmutableSet<>(
               elements, hashCode, requireNonNull(hashTable), hashTable.length - 1);
       }
     }
@@ -980,7 +980,7 @@ public abstract class ImmutableSet<E> extends ImmutableCollection<E> implements 
            */
           return of(requireNonNull(dedupedElements[0]));
         default:
-          return new JdkBackedImmutableSet<E>(
+          return new JdkBackedImmutableSet<>(
               delegate, ImmutableList.asImmutableList(dedupedElements, distinct));
       }
     }

--- a/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedMultiset.java
@@ -118,7 +118,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     RegularImmutableSortedSet<E> elementSet =
         (RegularImmutableSortedSet<E>) ImmutableSortedSet.of(element);
     long[] cumulativeCounts = {0, 1};
-    return new RegularImmutableSortedMultiset<E>(elementSet, cumulativeCounts, 0, 1);
+    return new RegularImmutableSortedMultiset<>(elementSet, cumulativeCounts, 0, 1);
   }
 
   /**
@@ -300,7 +300,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     if (entries.isEmpty()) {
       return emptyMultiset(comparator);
     }
-    ImmutableList.Builder<E> elementsBuilder = new ImmutableList.Builder<E>(entries.size());
+    ImmutableList.Builder<E> elementsBuilder = new ImmutableList.Builder<>(entries.size());
     long[] cumulativeCounts = new long[entries.size() + 1];
     int i = 0;
     for (Entry<E> entry : entries) {
@@ -308,7 +308,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
       cumulativeCounts[i + 1] = cumulativeCounts[i] + entry.getCount();
       i++;
     }
-    return new RegularImmutableSortedMultiset<E>(
+    return new RegularImmutableSortedMultiset<>(
         new RegularImmutableSortedSet<E>(elementsBuilder.build(), comparator),
         cumulativeCounts,
         0,
@@ -320,7 +320,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
     if (Ordering.natural().equals(comparator)) {
       return (ImmutableSortedMultiset<E>) RegularImmutableSortedMultiset.NATURAL_EMPTY_MULTISET;
     } else {
-      return new RegularImmutableSortedMultiset<E>(comparator);
+      return new RegularImmutableSortedMultiset<>(comparator);
     }
   }
 
@@ -408,7 +408,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * @throws NullPointerException if {@code comparator} is null
    */
   public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
-    return new Builder<E>(comparator);
+    return new Builder<>(comparator);
   }
 
   /**
@@ -420,7 +420,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6468354">bug 6468354</a>.
    */
   public static <E extends Comparable<?>> Builder<E> reverseOrder() {
-    return new Builder<E>(Ordering.<E>natural().reverse());
+    return new Builder<>(Ordering.<E>natural().reverse());
   }
 
   /**
@@ -434,7 +434,7 @@ public abstract class ImmutableSortedMultiset<E> extends ImmutableMultiset<E>
    * href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6468354">bug 6468354</a>.
    */
   public static <E extends Comparable<?>> Builder<E> naturalOrder() {
-    return new Builder<E>(Ordering.natural());
+    return new Builder<>(Ordering.natural());
   }
 
   /**

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -90,7 +90,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
           (RegularImmutableSortedSet<E>) RegularImmutableSortedSet.NATURAL_EMPTY_SET;
       return result;
     } else {
-      return new RegularImmutableSortedSet<E>(ImmutableList.<E>of(), comparator);
+      return new RegularImmutableSortedSet<>(ImmutableList.<E>of(), comparator);
     }
   }
 
@@ -106,7 +106,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
 
   /** Returns an immutable sorted set containing a single element. */
   public static <E extends Comparable<? super E>> ImmutableSortedSet<E> of(E element) {
-    return new RegularImmutableSortedSet<E>(ImmutableList.of(element), Ordering.natural());
+    return new RegularImmutableSortedSet<>(ImmutableList.of(element), Ordering.natural());
   }
 
   /**
@@ -350,7 +350,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
     if (list.isEmpty()) {
       return emptySet(comparator);
     } else {
-      return new RegularImmutableSortedSet<E>(list, comparator);
+      return new RegularImmutableSortedSet<>(list, comparator);
     }
   }
 
@@ -381,7 +381,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
       }
     }
     Arrays.fill(contents, uniques, n, null);
-    return new RegularImmutableSortedSet<E>(
+    return new RegularImmutableSortedSet<>(
         ImmutableList.<E>asImmutableList(contents, uniques), comparator);
   }
 
@@ -394,7 +394,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
    * @throws NullPointerException if {@code comparator} is null
    */
   public static <E> Builder<E> orderedBy(Comparator<E> comparator) {
-    return new Builder<E>(comparator);
+    return new Builder<>(comparator);
   }
 
   /**
@@ -402,7 +402,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
    * of their natural ordering.
    */
   public static <E extends Comparable<?>> Builder<E> reverseOrder() {
-    return new Builder<E>(Collections.reverseOrder());
+    return new Builder<>(Collections.reverseOrder());
   }
 
   /**
@@ -412,7 +412,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
    * implement {@link Comparable}.
    */
   public static <E extends Comparable<?>> Builder<E> naturalOrder() {
-    return new Builder<E>(Ordering.natural());
+    return new Builder<>(Ordering.natural());
   }
 
   /**
@@ -580,7 +580,7 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
         return emptySet(comparator);
       } else {
         forceCopy = true;
-        return new RegularImmutableSortedSet<E>(
+        return new RegularImmutableSortedSet<>(
             ImmutableList.asImmutableList(elements, n), comparator);
       }
     }

--- a/guava/src/com/google/common/collect/LinkedHashMultiset.java
+++ b/guava/src/com/google/common/collect/LinkedHashMultiset.java
@@ -46,7 +46,7 @@ public final class LinkedHashMultiset<E extends @Nullable Object>
 
   /** Creates a new, empty {@code LinkedHashMultiset} using the default initial capacity. */
   public static <E extends @Nullable Object> LinkedHashMultiset<E> create() {
-    return new LinkedHashMultiset<E>();
+    return new LinkedHashMultiset<>();
   }
 
   /**
@@ -57,7 +57,7 @@ public final class LinkedHashMultiset<E extends @Nullable Object>
    * @throws IllegalArgumentException if {@code distinctElements} is negative
    */
   public static <E extends @Nullable Object> LinkedHashMultiset<E> create(int distinctElements) {
-    return new LinkedHashMultiset<E>(distinctElements);
+    return new LinkedHashMultiset<>(distinctElements);
   }
 
   /**

--- a/guava/src/com/google/common/collect/MapMakerInternalMap.java
+++ b/guava/src/com/google/common/collect/MapMakerInternalMap.java
@@ -636,7 +636,7 @@ class MapMakerInternalMap<
           MapMakerInternalMap<K, Dummy, StrongKeyDummyValueEntry<K>, StrongKeyDummyValueSegment<K>>
               map,
           int initialCapacity) {
-        return new StrongKeyDummyValueSegment<K>(map, initialCapacity);
+        return new StrongKeyDummyValueSegment<>(map, initialCapacity);
       }
 
       @Override
@@ -1274,7 +1274,7 @@ class MapMakerInternalMap<
     }
 
     AtomicReferenceArray<E> newEntryArray(int size) {
-      return new AtomicReferenceArray<E>(size);
+      return new AtomicReferenceArray<>(size);
     }
 
     void initTable(AtomicReferenceArray<E> newTable) {
@@ -2066,7 +2066,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for strong keys and weak values. */
   static final class StrongKeyWeakValueSegment<K, V>
       extends Segment<K, V, StrongKeyWeakValueEntry<K, V>, StrongKeyWeakValueSegment<K, V>> {
-    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<V>();
+    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<>();
 
     StrongKeyWeakValueSegment(
         MapMakerInternalMap<K, V, StrongKeyWeakValueEntry<K, V>, StrongKeyWeakValueSegment<K, V>>
@@ -2154,7 +2154,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and strong values. */
   static final class WeakKeyStrongValueSegment<K, V>
       extends Segment<K, V, WeakKeyStrongValueEntry<K, V>, WeakKeyStrongValueSegment<K, V>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
 
     WeakKeyStrongValueSegment(
         MapMakerInternalMap<K, V, WeakKeyStrongValueEntry<K, V>, WeakKeyStrongValueSegment<K, V>>
@@ -2193,8 +2193,8 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and weak values. */
   static final class WeakKeyWeakValueSegment<K, V>
       extends Segment<K, V, WeakKeyWeakValueEntry<K, V>, WeakKeyWeakValueSegment<K, V>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
-    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<V>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
+    private final ReferenceQueue<V> queueForValues = new ReferenceQueue<>();
 
     WeakKeyWeakValueSegment(
         MapMakerInternalMap<K, V, WeakKeyWeakValueEntry<K, V>, WeakKeyWeakValueSegment<K, V>> map,
@@ -2264,7 +2264,7 @@ class MapMakerInternalMap<
   /** Concrete implementation of {@link Segment} for weak keys and {@link Dummy} values. */
   static final class WeakKeyDummyValueSegment<K>
       extends Segment<K, Dummy, WeakKeyDummyValueEntry<K>, WeakKeyDummyValueSegment<K>> {
-    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<K>();
+    private final ReferenceQueue<K> queueForKeys = new ReferenceQueue<>();
 
     WeakKeyDummyValueSegment(
         MapMakerInternalMap<K, Dummy, WeakKeyDummyValueEntry<K>, WeakKeyDummyValueSegment<K>> map,
@@ -2303,7 +2303,7 @@ class MapMakerInternalMap<
     final WeakReference<MapMakerInternalMap<?, ?, ?, ?>> mapReference;
 
     public CleanupMapTask(MapMakerInternalMap<?, ?, ?, ?> map) {
-      this.mapReference = new WeakReference<MapMakerInternalMap<?, ?, ?, ?>>(map);
+      this.mapReference = new WeakReference<>(map);
     }
 
     @Override

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -688,7 +688,7 @@ public final class Maps {
 
     static <V extends @Nullable Object> ValueDifference<V> create(
         @ParametricNullness V left, @ParametricNullness V right) {
-      return new ValueDifferenceImpl<V>(left, right);
+      return new ValueDifferenceImpl<>(left, right);
     }
 
     private ValueDifferenceImpl(@ParametricNullness V left, @ParametricNullness V right) {

--- a/guava/src/com/google/common/collect/Multimaps.java
+++ b/guava/src/com/google/common/collect/Multimaps.java
@@ -1223,7 +1223,7 @@ public final class Multimaps {
 
     @Override
     public Set<V> removeAll(@CheckForNull Object key) {
-      Set<V> values = new HashSet<V>(2);
+      Set<V> values = new HashSet<>(2);
       if (!map.containsKey(key)) {
         return values;
       }

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -106,7 +106,7 @@ public final class Multisets {
       Multiset<E> result = (Multiset<E>) multiset;
       return result;
     }
-    return new UnmodifiableMultiset<E>(checkNotNull(multiset));
+    return new UnmodifiableMultiset<>(checkNotNull(multiset));
   }
 
   /**
@@ -237,7 +237,7 @@ public final class Multisets {
   public static <E extends @Nullable Object> SortedMultiset<E> unmodifiableSortedMultiset(
       SortedMultiset<E> sortedMultiset) {
     // it's in its own file so it can be emulated for GWT
-    return new UnmodifiableSortedMultiset<E>(checkNotNull(sortedMultiset));
+    return new UnmodifiableSortedMultiset<>(checkNotNull(sortedMultiset));
   }
 
   /**
@@ -250,7 +250,7 @@ public final class Multisets {
    */
   public static <E extends @Nullable Object> Multiset.Entry<E> immutableEntry(
       @ParametricNullness E e, int n) {
-    return new ImmutableEntry<E>(e, n);
+    return new ImmutableEntry<>(e, n);
   }
 
   static class ImmutableEntry<E extends @Nullable Object> extends AbstractEntry<E>
@@ -315,9 +315,9 @@ public final class Multisets {
       // collection.
       FilteredMultiset<E> filtered = (FilteredMultiset<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredMultiset<E>(filtered.unfiltered, combinedPredicate);
+      return new FilteredMultiset<>(filtered.unfiltered, combinedPredicate);
     }
-    return new FilteredMultiset<E>(unfiltered, predicate);
+    return new FilteredMultiset<>(unfiltered, predicate);
   }
 
   private static final class FilteredMultiset<E extends @Nullable Object> extends ViewMultiset<E> {
@@ -1065,7 +1065,7 @@ public final class Multisets {
 
   /** An implementation of {@link Multiset#iterator}. */
   static <E extends @Nullable Object> Iterator<E> iteratorImpl(Multiset<E> multiset) {
-    return new MultisetIteratorImpl<E>(multiset, multiset.entrySet().iterator());
+    return new MultisetIteratorImpl<>(multiset, multiset.entrySet().iterator());
   }
 
   static final class MultisetIteratorImpl<E extends @Nullable Object> implements Iterator<E> {

--- a/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
+++ b/guava/src/com/google/common/collect/MutableClassToInstanceMap.java
@@ -59,7 +59,7 @@ public final class MutableClassToInstanceMap<B extends @Nullable Object>
    * default initial capacity and load factor.
    */
   public static <B extends @Nullable Object> MutableClassToInstanceMap<B> create() {
-    return new MutableClassToInstanceMap<B>(new HashMap<Class<? extends @NonNull B>, B>());
+    return new MutableClassToInstanceMap<>(new HashMap<Class<? extends @NonNull B>, B>());
   }
 
   /**
@@ -69,7 +69,7 @@ public final class MutableClassToInstanceMap<B extends @Nullable Object>
    */
   public static <B extends @Nullable Object> MutableClassToInstanceMap<B> create(
       Map<Class<? extends @NonNull B>, B> backingMap) {
-    return new MutableClassToInstanceMap<B>(backingMap);
+    return new MutableClassToInstanceMap<>(backingMap);
   }
 
   private final Map<Class<? extends @NonNull B>, B> delegate;

--- a/guava/src/com/google/common/collect/Ordering.java
+++ b/guava/src/com/google/common/collect/Ordering.java
@@ -224,7 +224,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // TODO(kevinb): provide replacement
   @GwtCompatible(serializable = true)
   public static <T> Ordering<T> explicit(List<T> valuesInOrder) {
-    return new ExplicitOrdering<T>(valuesInOrder);
+    return new ExplicitOrdering<>(valuesInOrder);
   }
 
   /**
@@ -411,7 +411,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().reverse();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<S> reverse() {
-    return new ReverseOrdering<S>(this);
+    return new ReverseOrdering<>(this);
   }
 
   /**
@@ -426,7 +426,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().nullsFirst();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<@Nullable S> nullsFirst() {
-    return new NullsFirstOrdering<S>(this);
+    return new NullsFirstOrdering<>(this);
   }
 
   /**
@@ -441,7 +441,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   // Ordering<String> o = Ordering.<String>natural().nullsLast();
   @GwtCompatible(serializable = true)
   public <S extends T> Ordering<@Nullable S> nullsLast() {
-    return new NullsLastOrdering<S>(this);
+    return new NullsLastOrdering<>(this);
   }
 
   /**
@@ -484,7 +484,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
    */
   @GwtCompatible(serializable = true)
   public <U extends T> Ordering<U> compound(Comparator<? super U> secondaryComparator) {
-    return new CompoundOrdering<U>(this, checkNotNull(secondaryComparator));
+    return new CompoundOrdering<>(this, checkNotNull(secondaryComparator));
   }
 
   /**
@@ -511,7 +511,7 @@ public abstract class Ordering<T extends @Nullable Object> implements Comparator
   @GwtCompatible(serializable = true)
   public static <T extends @Nullable Object> Ordering<T> compound(
       Iterable<? extends Comparator<? super T>> comparators) {
-    return new CompoundOrdering<T>(comparators);
+    return new CompoundOrdering<>(comparators);
   }
 
   /**

--- a/guava/src/com/google/common/collect/Queues.java
+++ b/guava/src/com/google/common/collect/Queues.java
@@ -55,7 +55,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // ArrayBlockingQueue
   public static <E> ArrayBlockingQueue<E> newArrayBlockingQueue(int capacity) {
-    return new ArrayBlockingQueue<E>(capacity);
+    return new ArrayBlockingQueue<>(capacity);
   }
 
   // ArrayDeque
@@ -66,7 +66,7 @@ public final class Queues {
    * @since 12.0
    */
   public static <E> ArrayDeque<E> newArrayDeque() {
-    return new ArrayDeque<E>();
+    return new ArrayDeque<>();
   }
 
   /**
@@ -77,9 +77,9 @@ public final class Queues {
    */
   public static <E> ArrayDeque<E> newArrayDeque(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new ArrayDeque<E>((Collection<? extends E>) elements);
+      return new ArrayDeque<>((Collection<? extends E>) elements);
     }
-    ArrayDeque<E> deque = new ArrayDeque<E>();
+    ArrayDeque<E> deque = new ArrayDeque<>();
     Iterables.addAll(deque, elements);
     return deque;
   }
@@ -90,7 +90,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // ConcurrentLinkedQueue
   public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue() {
-    return new ConcurrentLinkedQueue<E>();
+    return new ConcurrentLinkedQueue<>();
   }
 
   /**
@@ -102,9 +102,9 @@ public final class Queues {
   public static <E> ConcurrentLinkedQueue<E> newConcurrentLinkedQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new ConcurrentLinkedQueue<E>((Collection<? extends E>) elements);
+      return new ConcurrentLinkedQueue<>((Collection<? extends E>) elements);
     }
-    ConcurrentLinkedQueue<E> queue = new ConcurrentLinkedQueue<E>();
+    ConcurrentLinkedQueue<E> queue = new ConcurrentLinkedQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -119,7 +119,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque() {
-    return new LinkedBlockingDeque<E>();
+    return new LinkedBlockingDeque<>();
   }
 
   /**
@@ -131,7 +131,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(int capacity) {
-    return new LinkedBlockingDeque<E>(capacity);
+    return new LinkedBlockingDeque<>(capacity);
   }
 
   /**
@@ -145,9 +145,9 @@ public final class Queues {
   @GwtIncompatible // LinkedBlockingDeque
   public static <E> LinkedBlockingDeque<E> newLinkedBlockingDeque(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedBlockingDeque<E>((Collection<? extends E>) elements);
+      return new LinkedBlockingDeque<>((Collection<? extends E>) elements);
     }
-    LinkedBlockingDeque<E> deque = new LinkedBlockingDeque<E>();
+    LinkedBlockingDeque<E> deque = new LinkedBlockingDeque<>();
     Iterables.addAll(deque, elements);
     return deque;
   }
@@ -158,7 +158,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue() {
-    return new LinkedBlockingQueue<E>();
+    return new LinkedBlockingQueue<>();
   }
 
   /**
@@ -169,7 +169,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(int capacity) {
-    return new LinkedBlockingQueue<E>(capacity);
+    return new LinkedBlockingQueue<>(capacity);
   }
 
   /**
@@ -184,9 +184,9 @@ public final class Queues {
   @GwtIncompatible // LinkedBlockingQueue
   public static <E> LinkedBlockingQueue<E> newLinkedBlockingQueue(Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedBlockingQueue<E>((Collection<? extends E>) elements);
+      return new LinkedBlockingQueue<>((Collection<? extends E>) elements);
     }
-    LinkedBlockingQueue<E> queue = new LinkedBlockingQueue<E>();
+    LinkedBlockingQueue<E> queue = new LinkedBlockingQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -206,7 +206,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // PriorityBlockingQueue
   public static <E extends Comparable> PriorityBlockingQueue<E> newPriorityBlockingQueue() {
-    return new PriorityBlockingQueue<E>();
+    return new PriorityBlockingQueue<>();
   }
 
   /**
@@ -224,9 +224,9 @@ public final class Queues {
   public static <E extends Comparable> PriorityBlockingQueue<E> newPriorityBlockingQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new PriorityBlockingQueue<E>((Collection<? extends E>) elements);
+      return new PriorityBlockingQueue<>((Collection<? extends E>) elements);
     }
-    PriorityBlockingQueue<E> queue = new PriorityBlockingQueue<E>();
+    PriorityBlockingQueue<E> queue = new PriorityBlockingQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -242,7 +242,7 @@ public final class Queues {
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> PriorityQueue<E> newPriorityQueue() {
-    return new PriorityQueue<E>();
+    return new PriorityQueue<>();
   }
 
   /**
@@ -258,9 +258,9 @@ public final class Queues {
   public static <E extends Comparable> PriorityQueue<E> newPriorityQueue(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new PriorityQueue<E>((Collection<? extends E>) elements);
+      return new PriorityQueue<>((Collection<? extends E>) elements);
     }
-    PriorityQueue<E> queue = new PriorityQueue<E>();
+    PriorityQueue<E> queue = new PriorityQueue<>();
     Iterables.addAll(queue, elements);
     return queue;
   }
@@ -271,7 +271,7 @@ public final class Queues {
   @J2ktIncompatible
   @GwtIncompatible // SynchronousQueue
   public static <E> SynchronousQueue<E> newSynchronousQueue() {
-    return new SynchronousQueue<E>();
+    return new SynchronousQueue<>();
   }
 
   /**

--- a/guava/src/com/google/common/collect/RegularImmutableMultiset.java
+++ b/guava/src/com/google/common/collect/RegularImmutableMultiset.java
@@ -73,7 +73,7 @@ class RegularImmutableMultiset<E> extends ImmutableMultiset<E> {
         newEntry =
             canReuseEntry ? (ImmutableEntry<E>) entry : new ImmutableEntry<E>(element, count);
       } else {
-        newEntry = new NonTerminalEntry<E>(element, count, bucketHead);
+        newEntry = new NonTerminalEntry<>(element, count, bucketHead);
       }
       hashCode += hash ^ count;
       entryArray[index++] = newEntry;
@@ -184,7 +184,7 @@ class RegularImmutableMultiset<E> extends ImmutableMultiset<E> {
   @Override
   public ImmutableSet<E> elementSet() {
     ImmutableSet<E> result = elementSet;
-    return (result == null) ? elementSet = new ElementSet<E>(Arrays.asList(entries), this) : result;
+    return (result == null) ? elementSet = new ElementSet<>(Arrays.asList(entries), this) : result;
   }
 
   @Override

--- a/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSortedMultiset.java
@@ -125,7 +125,7 @@ final class RegularImmutableSortedMultiset<E> extends ImmutableSortedMultiset<E>
       return this;
     } else {
       RegularImmutableSortedSet<E> subElementSet = elementSet.getSubSet(from, to);
-      return new RegularImmutableSortedMultiset<E>(
+      return new RegularImmutableSortedMultiset<>(
           subElementSet, cumulativeCounts, offset + from, to - from);
     }
   }

--- a/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/RegularImmutableSortedSet.java
@@ -297,7 +297,7 @@ final class RegularImmutableSortedSet<E> extends ImmutableSortedSet<E> {
     if (newFromIndex == 0 && newToIndex == size()) {
       return this;
     } else if (newFromIndex < newToIndex) {
-      return new RegularImmutableSortedSet<E>(
+      return new RegularImmutableSortedSet<>(
           elements.subList(newFromIndex, newToIndex), comparator);
     } else {
       return emptySet(comparator);

--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -180,7 +180,7 @@ public final class Sets {
    * href="http://goo.gl/iz2Wi">"diamond" syntax</a>.
    */
   public static <E extends @Nullable Object> HashSet<E> newHashSet() {
-    return new HashSet<E>();
+    return new HashSet<>();
   }
 
   /**
@@ -259,7 +259,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> HashSet<E> newHashSetWithExpectedSize(
       int expectedSize) {
-    return new HashSet<E>(Maps.capacity(expectedSize));
+    return new HashSet<>(Maps.capacity(expectedSize));
   }
 
   /**
@@ -309,7 +309,7 @@ public final class Sets {
    * @return a new, empty {@code LinkedHashSet}
    */
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSet() {
-    return new LinkedHashSet<E>();
+    return new LinkedHashSet<>();
   }
 
   /**
@@ -330,7 +330,7 @@ public final class Sets {
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSet(
       Iterable<? extends E> elements) {
     if (elements instanceof Collection) {
-      return new LinkedHashSet<E>((Collection<? extends E>) elements);
+      return new LinkedHashSet<>((Collection<? extends E>) elements);
     }
     LinkedHashSet<E> set = newLinkedHashSet();
     Iterables.addAll(set, elements);
@@ -351,7 +351,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(
       int expectedSize) {
-    return new LinkedHashSet<E>(Maps.capacity(expectedSize));
+    return new LinkedHashSet<>(Maps.capacity(expectedSize));
   }
 
   // TreeSet
@@ -370,7 +370,7 @@ public final class Sets {
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> TreeSet<E> newTreeSet() {
-    return new TreeSet<E>();
+    return new TreeSet<>();
   }
 
   /**
@@ -419,7 +419,7 @@ public final class Sets {
    */
   public static <E extends @Nullable Object> TreeSet<E> newTreeSet(
       Comparator<? super E> comparator) {
-    return new TreeSet<E>(checkNotNull(comparator));
+    return new TreeSet<>(checkNotNull(comparator));
   }
 
   /**
@@ -447,7 +447,7 @@ public final class Sets {
   @J2ktIncompatible
   @GwtIncompatible // CopyOnWriteArraySet
   public static <E extends @Nullable Object> CopyOnWriteArraySet<E> newCopyOnWriteArraySet() {
-    return new CopyOnWriteArraySet<E>();
+    return new CopyOnWriteArraySet<>();
   }
 
   /**
@@ -467,7 +467,7 @@ public final class Sets {
         (elements instanceof Collection)
             ? (Collection<? extends E>) elements
             : Lists.newArrayList(elements);
-    return new CopyOnWriteArraySet<E>(elementsCollection);
+    return new CopyOnWriteArraySet<>(elementsCollection);
   }
 
   /**
@@ -1059,10 +1059,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredSet<E>((Set<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredSet<>((Set<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -1096,10 +1096,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredSortedSet<E>((SortedSet<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredSortedSet<>((SortedSet<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredSortedSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredSortedSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   /**
@@ -1134,10 +1134,10 @@ public final class Sets {
       // collection.
       FilteredSet<E> filtered = (FilteredSet<E>) unfiltered;
       Predicate<E> combinedPredicate = Predicates.<E>and(filtered.predicate, predicate);
-      return new FilteredNavigableSet<E>((NavigableSet<E>) filtered.unfiltered, combinedPredicate);
+      return new FilteredNavigableSet<>((NavigableSet<E>) filtered.unfiltered, combinedPredicate);
     }
 
-    return new FilteredNavigableSet<E>(checkNotNull(unfiltered), checkNotNull(predicate));
+    return new FilteredNavigableSet<>(checkNotNull(unfiltered), checkNotNull(predicate));
   }
 
   private static class FilteredSet<E extends @Nullable Object> extends FilteredCollection<E>
@@ -1172,18 +1172,18 @@ public final class Sets {
 
     @Override
     public SortedSet<E> subSet(@ParametricNullness E fromElement, @ParametricNullness E toElement) {
-      return new FilteredSortedSet<E>(
+      return new FilteredSortedSet<>(
           ((SortedSet<E>) unfiltered).subSet(fromElement, toElement), predicate);
     }
 
     @Override
     public SortedSet<E> headSet(@ParametricNullness E toElement) {
-      return new FilteredSortedSet<E>(((SortedSet<E>) unfiltered).headSet(toElement), predicate);
+      return new FilteredSortedSet<>(((SortedSet<E>) unfiltered).headSet(toElement), predicate);
     }
 
     @Override
     public SortedSet<E> tailSet(@ParametricNullness E fromElement) {
-      return new FilteredSortedSet<E>(((SortedSet<E>) unfiltered).tailSet(fromElement), predicate);
+      return new FilteredSortedSet<>(((SortedSet<E>) unfiltered).tailSet(fromElement), predicate);
     }
 
     @Override
@@ -1613,7 +1613,7 @@ public final class Sets {
       return new AbstractIndexedListIterator<Set<E>>(size()) {
         @Override
         protected Set<E> get(final int setBits) {
-          return new SubSet<E>(inputSet, setBits);
+          return new SubSet<>(inputSet, setBits);
         }
       };
     }
@@ -1825,7 +1825,7 @@ public final class Sets {
     if (set instanceof ImmutableCollection || set instanceof UnmodifiableNavigableSet) {
       return set;
     }
-    return new UnmodifiableNavigableSet<E>(set);
+    return new UnmodifiableNavigableSet<>(set);
   }
 
   static final class UnmodifiableNavigableSet<E extends @Nullable Object>
@@ -1907,7 +1907,7 @@ public final class Sets {
     public NavigableSet<E> descendingSet() {
       UnmodifiableNavigableSet<E> result = descendingSet;
       if (result == null) {
-        result = descendingSet = new UnmodifiableNavigableSet<E>(delegate.descendingSet());
+        result = descendingSet = new UnmodifiableNavigableSet<>(delegate.descendingSet());
         result.descendingSet = this;
       }
       return result;

--- a/guava/src/com/google/common/collect/Synchronized.java
+++ b/guava/src/com/google/common/collect/Synchronized.java
@@ -120,7 +120,7 @@ final class Synchronized {
 
   private static <E extends @Nullable Object> Collection<E> collection(
       Collection<E> collection, @CheckForNull Object mutex) {
-    return new SynchronizedCollection<E>(collection, mutex);
+    return new SynchronizedCollection<>(collection, mutex);
   }
 
   @VisibleForTesting
@@ -266,7 +266,7 @@ final class Synchronized {
 
   @VisibleForTesting
   static <E extends @Nullable Object> Set<E> set(Set<E> set, @CheckForNull Object mutex) {
-    return new SynchronizedSet<E>(set, mutex);
+    return new SynchronizedSet<>(set, mutex);
   }
 
   static class SynchronizedSet<E extends @Nullable Object> extends SynchronizedCollection<E>
@@ -303,7 +303,7 @@ final class Synchronized {
 
   private static <E extends @Nullable Object> SortedSet<E> sortedSet(
       SortedSet<E> set, @CheckForNull Object mutex) {
-    return new SynchronizedSortedSet<E>(set, mutex);
+    return new SynchronizedSortedSet<>(set, mutex);
   }
 
   static class SynchronizedSortedSet<E extends @Nullable Object> extends SynchronizedSet<E>
@@ -495,7 +495,7 @@ final class Synchronized {
     if (multiset instanceof SynchronizedMultiset || multiset instanceof ImmutableMultiset) {
       return multiset;
     }
-    return new SynchronizedMultiset<E>(multiset, mutex);
+    return new SynchronizedMultiset<>(multiset, mutex);
   }
 
   static final class SynchronizedMultiset<E extends @Nullable Object>
@@ -1596,7 +1596,7 @@ final class Synchronized {
   @GwtIncompatible // NavigableSet
   static <E extends @Nullable Object> NavigableSet<E> navigableSet(
       NavigableSet<E> navigableSet, @CheckForNull Object mutex) {
-    return new SynchronizedNavigableSet<E>(navigableSet, mutex);
+    return new SynchronizedNavigableSet<>(navigableSet, mutex);
   }
 
   @GwtIncompatible // NavigableSet
@@ -1928,7 +1928,7 @@ final class Synchronized {
   }
 
   static <E extends @Nullable Object> Deque<E> deque(Deque<E> deque, @CheckForNull Object mutex) {
-    return new SynchronizedDeque<E>(deque, mutex);
+    return new SynchronizedDeque<>(deque, mutex);
   }
 
   static final class SynchronizedDeque<E extends @Nullable Object> extends SynchronizedQueue<E>

--- a/guava/src/com/google/common/collect/TopKSelector.java
+++ b/guava/src/com/google/common/collect/TopKSelector.java
@@ -77,7 +77,7 @@ final class TopKSelector<
    */
   public static <T extends @Nullable Object> TopKSelector<T> least(
       int k, Comparator<? super T> comparator) {
-    return new TopKSelector<T>(comparator, k);
+    return new TopKSelector<>(comparator, k);
   }
 
   /**
@@ -99,7 +99,7 @@ final class TopKSelector<
    */
   public static <T extends @Nullable Object> TopKSelector<T> greatest(
       int k, Comparator<? super T> comparator) {
-    return new TopKSelector<T>(Ordering.from(comparator).reverse(), k);
+    return new TopKSelector<>(Ordering.from(comparator).reverse(), k);
   }
 
   private final int k;

--- a/guava/src/com/google/common/collect/TreeMultiset.java
+++ b/guava/src/com/google/common/collect/TreeMultiset.java
@@ -77,7 +77,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
    */
   @SuppressWarnings("rawtypes") // https://github.com/google/guava/issues/989
   public static <E extends Comparable> TreeMultiset<E> create() {
-    return new TreeMultiset<E>(Ordering.natural());
+    return new TreeMultiset<>(Ordering.natural());
   }
 
   /**
@@ -268,7 +268,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     AvlNode<E> root = rootReference.get();
     if (root == null) {
       int unused = comparator().compare(element, element);
-      AvlNode<E> newRoot = new AvlNode<E>(element, occurrences);
+      AvlNode<E> newRoot = new AvlNode<>(element, occurrences);
       successor(header, newRoot, header);
       rootReference.checkAndSet(root, newRoot);
       return 0;
@@ -551,7 +551,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
 
   @Override
   public SortedMultiset<E> headMultiset(@ParametricNullness E upperBound, BoundType boundType) {
-    return new TreeMultiset<E>(
+    return new TreeMultiset<>(
         rootReference,
         range.intersect(GeneralRange.upTo(comparator(), upperBound, boundType)),
         header);
@@ -559,7 +559,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
 
   @Override
   public SortedMultiset<E> tailMultiset(@ParametricNullness E lowerBound, BoundType boundType) {
-    return new TreeMultiset<E>(
+    return new TreeMultiset<>(
         rootReference,
         range.intersect(GeneralRange.downTo(comparator(), lowerBound, boundType)),
         header);
@@ -659,7 +659,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     }
 
     private AvlNode<E> addRightChild(@ParametricNullness E e, int count) {
-      right = new AvlNode<E>(e, count);
+      right = new AvlNode<>(e, count);
       successor(this, right, succ());
       height = Math.max(2, height);
       distinctElements++;
@@ -668,7 +668,7 @@ public final class TreeMultiset<E extends @Nullable Object> extends AbstractSort
     }
 
     private AvlNode<E> addLeftChild(@ParametricNullness E e, int count) {
-      left = new AvlNode<E>(e, count);
+      left = new AvlNode<>(e, count);
       successor(pred(), left, this);
       height = Math.max(2, height);
       distinctElements++;

--- a/guava/src/com/google/common/collect/TreeTraverser.java
+++ b/guava/src/com/google/common/collect/TreeTraverser.java
@@ -240,7 +240,7 @@ public abstract class TreeTraverser<T> {
     }
 
     private PostOrderNode<T> expand(T t) {
-      return new PostOrderNode<T>(t, children(t).iterator());
+      return new PostOrderNode<>(t, children(t).iterator());
     }
   }
 
@@ -270,7 +270,7 @@ public abstract class TreeTraverser<T> {
     private final Queue<T> queue;
 
     BreadthFirstIterator(T root) {
-      this.queue = new ArrayDeque<T>();
+      this.queue = new ArrayDeque<>();
       queue.add(root);
     }
 

--- a/guava/src/com/google/common/graph/Graphs.java
+++ b/guava/src/com/google/common/graph/Graphs.java
@@ -167,7 +167,7 @@ public final class Graphs extends GraphsBridgeMethods {
     } else {
       // An optimization for the undirected case: for every node B reachable from node A,
       // node A and node B have the same reachability set.
-      Set<N> visitedNodes = new HashSet<N>();
+      Set<N> visitedNodes = new HashSet<>();
       for (N node : graph.nodes()) {
         if (!visitedNodes.contains(node)) {
           Set<N> reachableNodes = reachableNodes(graph, node);
@@ -219,7 +219,7 @@ public final class Graphs extends GraphsBridgeMethods {
       return ((TransposedGraph<N>) graph).graph;
     }
 
-    return new TransposedGraph<N>(graph);
+    return new TransposedGraph<>(graph);
   }
 
   /**

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -139,7 +139,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * @since 12.0
    */
   public BloomFilter<T> copy() {
-    return new BloomFilter<T>(bits.copy(), numHashFunctions, funnel, strategy);
+    return new BloomFilter<>(bits.copy(), numHashFunctions, funnel, strategy);
   }
 
   /**
@@ -436,7 +436,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
     long numBits = optimalNumOfBits(expectedInsertions, fpp);
     int numHashFunctions = optimalNumOfHashFunctions(expectedInsertions, numBits);
     try {
-      return new BloomFilter<T>(new LockFreeBitArray(numBits), numHashFunctions, funnel, strategy);
+      return new BloomFilter<>(new LockFreeBitArray(numBits), numHashFunctions, funnel, strategy);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Could not create BloomFilter of " + numBits + " bits", e);
     }
@@ -621,7 +621,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
         dataArray.putData(i, din.readLong());
       }
 
-      return new BloomFilter<T>(dataArray, numHashFunctions, funnel, strategy);
+      return new BloomFilter<>(dataArray, numHashFunctions, funnel, strategy);
     } catch (IOException e) {
       throw e;
     } catch (Exception e) { // sneaky checked exception

--- a/guava/src/com/google/common/util/concurrent/AbstractFuture.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFuture.java
@@ -860,7 +860,7 @@ public abstract class AbstractFuture<V extends @Nullable Object> extends Interna
         }
         return false;
       }
-      SetFuture<V> valueToSet = new SetFuture<V>(this, future);
+      SetFuture<V> valueToSet = new SetFuture<>(this, future);
       if (ATOMIC_HELPER.casValue(this, null, valueToSet)) {
         // the listener is responsible for calling completeWithFuture, directExecutor is appropriate
         // since all we are doing is unpacking a completed future which should be fast.

--- a/guava/src/com/google/common/util/concurrent/AtomicLongMap.java
+++ b/guava/src/com/google/common/util/concurrent/AtomicLongMap.java
@@ -70,7 +70,7 @@ public final class AtomicLongMap<K> implements Serializable {
 
   /** Creates an {@code AtomicLongMap}. */
   public static <K> AtomicLongMap<K> create() {
-    return new AtomicLongMap<K>(new ConcurrentHashMap<>());
+    return new AtomicLongMap<>(new ConcurrentHashMap<>());
   }
 
   /** Creates an {@code AtomicLongMap} with the same mappings as the specified {@code Map}. */

--- a/guava/src/com/google/common/util/concurrent/ClosingFuture.java
+++ b/guava/src/com/google/common/util/concurrent/ClosingFuture.java
@@ -410,7 +410,7 @@ public final class ClosingFuture<V extends @Nullable Object> {
    * when the pipeline is done, use {@link #submit(ClosingCallable, Executor)} instead.
    */
   public static <V extends @Nullable Object> ClosingFuture<V> from(ListenableFuture<V> future) {
-    return new ClosingFuture<V>(future);
+    return new ClosingFuture<>(future);
   }
 
   /**

--- a/guava/src/com/google/common/util/concurrent/Futures.java
+++ b/guava/src/com/google/common/util/concurrent/Futures.java
@@ -163,7 +163,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   public static <V extends @Nullable Object> ListenableFuture<V> immediateFailedFuture(
       Throwable throwable) {
     checkNotNull(throwable);
-    return new ImmediateFailedFuture<V>(throwable);
+    return new ImmediateFailedFuture<>(throwable);
   }
 
   /**
@@ -619,7 +619,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @SafeVarargs
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllComplete(
       ListenableFuture<? extends V>... futures) {
-    return new FutureCombiner<V>(false, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(false, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -632,7 +632,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllComplete(
       Iterable<? extends ListenableFuture<? extends V>> futures) {
-    return new FutureCombiner<V>(false, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(false, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -645,7 +645,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
   @SafeVarargs
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllSucceed(
       ListenableFuture<? extends V>... futures) {
-    return new FutureCombiner<V>(true, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(true, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -657,7 +657,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
    */
   public static <V extends @Nullable Object> FutureCombiner<V> whenAllSucceed(
       Iterable<? extends ListenableFuture<? extends V>> futures) {
-    return new FutureCombiner<V>(true, ImmutableList.copyOf(futures));
+    return new FutureCombiner<>(true, ImmutableList.copyOf(futures));
   }
 
   /**
@@ -719,7 +719,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
      */
     public <C extends @Nullable Object> ListenableFuture<C> callAsync(
         AsyncCallable<C> combiner, Executor executor) {
-      return new CombinedFuture<C>(futures, allMustSucceed, executor, combiner);
+      return new CombinedFuture<>(futures, allMustSucceed, executor, combiner);
     }
 
     /**
@@ -744,7 +744,7 @@ public final class Futures extends GwtFuturesCatchingSpecialization {
      */
     public <C extends @Nullable Object> ListenableFuture<C> call(
         Callable<C> combiner, Executor executor) {
-      return new CombinedFuture<C>(futures, allMustSucceed, executor, combiner);
+      return new CombinedFuture<>(futures, allMustSucceed, executor, combiner);
     }
 
     /**

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -671,7 +671,7 @@ public final class MoreExecutors {
         Callable<V> callable, long delay, TimeUnit unit) {
       TrustedListenableFutureTask<V> task = TrustedListenableFutureTask.create(callable);
       ScheduledFuture<?> scheduled = delegate.schedule(task, delay, unit);
-      return new ListenableScheduledTask<V>(task, scheduled);
+      return new ListenableScheduledTask<>(task, scheduled);
     }
 
     @Override


### PR DESCRIPTION
We propose the fix to violation s2293 The diamond operator ("<>") should be used identified by SonarQube.

Java uses angular brackets (< and >) to provide a specific type (the "type argument") to a generic type. For instance, List is a generic type, so a list containing strings can be declared with List<String>.
Prior to Java 7, the type argument had to be provided explicitly for every occurrence where generics were used. This often caused redundancy, as the type argument would have to be provided both when a field is declared and initialized.
Java 7 introduced the diamond operator (<>) to reduce the code’s verbosity of generics code. The type argument between the angular brackets should be omitted if the compiler can infer it. For instance, instead of having to declare a List's type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type.

This patch has been automatically produced by our java code remediation solution, available free of charge for all open source projects (https://www.indepth.fr).

We believe that this PR can improve the quality of the Guava project code to a certain extent. Your feedback will also be very useful for us to know if our solution produces quality code or if we need to improve the way it works.

Thank you for your feedback.
