### PR TITLE
Add missing param in `JarOutputStream`

### DIFF
--- a/guava-tests/test/com/google/common/reflect/ClassPathTest.java
+++ b/guava-tests/test/com/google/common/reflect/ClassPathTest.java
@@ -604,7 +604,7 @@ public class ClassPathTest extends TestCase {
     Closer closer = Closer.create();
     try {
       FileOutputStream fileOut = closer.register(new FileOutputStream(jarFile));
-      JarOutputStream jarOut = closer.register(new JarOutputStream(fileOut));
+      JarOutputStream jarOut = closer.register(new JarOutputStream(fileOut, manifest));
       for (String entry : entries) {
         jarOut.putNextEntry(new ZipEntry(entry));
         Resources.copy(ClassPathTest.class.getResource(entry), jarOut);


### PR DESCRIPTION
The documentation for [JarOutputStream](https://developer.android.com/reference/java/util/jar/JarOutputStream) lists two constructors : 

- `public JarOutputStream (OutputStream out)`
- `public JarOutputStream (OutputStream out,  Manifest man)`

In the `writeSelfReferencingJarFile` test file, the test creates a manifest but forget to write it because it is calling the wrong version of the constructor.

This PR fixes that.