### PR TITLE
Use default error action for malformed input and unmappable characters

### DIFF
--- a/android/guava/src/com/google/common/io/ReaderInputStream.java
+++ b/android/guava/src/com/google/common/io/ReaderInputStream.java
@@ -74,7 +74,7 @@ final class ReaderInputStream extends InputStream {
 
   /**
    * Creates a new input stream that will encode the characters from {@code reader} into bytes using
-   * the given character set. Malformed input and unmappable characters will be replaced.
+   * the given character set.
    *
    * @param reader input source
    * @param charset character set used for encoding chars to bytes
@@ -85,9 +85,7 @@ final class ReaderInputStream extends InputStream {
     this(
         reader,
         charset
-            .newEncoder()
-            .onMalformedInput(CodingErrorAction.REPLACE)
-            .onUnmappableCharacter(CodingErrorAction.REPLACE),
+            .newEncoder(),
         bufferSize);
   }
 


### PR DESCRIPTION
I have to preface this by saying that I'm quite new to this codebase. However, I looked through the issues list and fixing the linked issue seemed trivial enough so I gave it a shot.

Maybe, if things work out and I learn quickly, I might try tackling larger issues.

Fixes #6944