### PR TITLE
Simplified RateLimiter.setRate

### DIFF
--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -255,8 +255,7 @@ public abstract class RateLimiter {
    * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero
    */
   public final void setRate(double permitsPerSecond) {
-    checkArgument(
-        permitsPerSecond > 0.0 && !Double.isNaN(permitsPerSecond), "rate must be positive");
+    checkArgument(permitsPerSecond > 0.0, "rate must be positive");
     synchronized (mutex()) {
       doSetRate(permitsPerSecond, stopwatch.readMicros());
     }


### PR DESCRIPTION
- This is fix for Issue #7255
- Here setRate method takes double as argument so the condition '!Double.isNaN(permitsPerSecond)' is always 'true' when reached and it is redundant check.
- Reference: https://docs.oracle.com/en/java/javase/17/docs//api/java.base/java/lang/Double.html#isNaN(double)

