### PR TITLE
Changed `*.concat()` to throw `IllegalArgumentException` if the input arrays contain too many elements.

### DIFF
--- a/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -130,6 +130,37 @@ public class BooleansTest extends TestCase {
         .isEqualTo(new boolean[] {false, false, true});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    boolean[][] arrays = new boolean[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    boolean[] sharedArray = new boolean[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Booleans.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Booleans.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Booleans.ensureCapacity(ARRAY_FALSE, 0, 1)).isSameInstanceAs(ARRAY_FALSE);

--- a/android/guava-tests/test/com/google/common/primitives/BytesTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/BytesTest.java
@@ -131,6 +131,37 @@ public class BytesTest extends TestCase {
         .isEqualTo(new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    byte[][] arrays = new byte[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    byte[] sharedArray = new byte[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Bytes.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Bytes.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Bytes.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/android/guava-tests/test/com/google/common/primitives/CharsTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/CharsTest.java
@@ -222,6 +222,37 @@ public class CharsTest extends TestCase {
         .isEqualTo(new char[] {(char) 1, (char) 2, (char) 3, (char) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    char[][] arrays = new char[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    char[] sharedArray = new char[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Chars.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @GwtIncompatible // Chars.fromByteArray
   public void testFromByteArray() {
     assertThat(Chars.fromByteArray(new byte[] {0x23, 0x45, (byte) 0xDC})).isEqualTo('\u2345');

--- a/android/guava-tests/test/com/google/common/primitives/DoublesTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/DoublesTest.java
@@ -280,6 +280,37 @@ public class DoublesTest extends TestCase {
         .isEqualTo(new double[] {(double) 1, (double) 2, (double) 3, (double) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    double[][] arrays = new double[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    double[] sharedArray = new double[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Doubles.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Doubles.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Doubles.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/android/guava-tests/test/com/google/common/primitives/FloatsTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/FloatsTest.java
@@ -267,6 +267,37 @@ public class FloatsTest extends TestCase {
         .isEqualTo(new float[] {(float) 1, (float) 2, (float) 3, (float) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    float[][] arrays = new float[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    float[] sharedArray = new float[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Floats.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Floats.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Floats.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/android/guava-tests/test/com/google/common/primitives/IntsTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/IntsTest.java
@@ -224,6 +224,37 @@ public class IntsTest extends TestCase {
         .isEqualTo(new int[] {(int) 1, (int) 2, (int) 3, (int) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    int[][] arrays = new int[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    int[] sharedArray = new int[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Ints.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testToByteArray() {
     assertThat(Ints.toByteArray(0x12131415)).isEqualTo(new byte[] {0x12, 0x13, 0x14, 0x15});
     assertThat(Ints.toByteArray(0xFFEEDDCC))

--- a/android/guava-tests/test/com/google/common/primitives/ShortsTest.java
+++ b/android/guava-tests/test/com/google/common/primitives/ShortsTest.java
@@ -243,6 +243,37 @@ public class ShortsTest extends TestCase {
         .isEqualTo(new short[] {(short) 1, (short) 2, (short) 3, (short) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    short[][] arrays = new short[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    short[] sharedArray = new short[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Shorts.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @GwtIncompatible // Shorts.toByteArray
   public void testToByteArray() {
     assertThat(Shorts.toByteArray((short) 0x2345)).isEqualTo(new byte[] {0x23, 0x45});

--- a/android/guava/src/com/google/common/primitives/Booleans.java
+++ b/android/guava/src/com/google/common/primitives/Booleans.java
@@ -230,19 +230,29 @@ public final class Booleans {
    *
    * @param arrays zero or more {@code boolean} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static boolean[] concat(boolean[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (boolean[] array : arrays) {
       length += array.length;
     }
-    boolean[] result = new boolean[length];
+    boolean[] result = new boolean[checkNoOverflow(length)];
     int pos = 0;
     for (boolean[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Bytes.java
+++ b/android/guava/src/com/google/common/primitives/Bytes.java
@@ -156,19 +156,29 @@ public final class Bytes {
    *
    * @param arrays zero or more {@code byte} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static byte[] concat(byte[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (byte[] array : arrays) {
       length += array.length;
     }
-    byte[] result = new byte[length];
+    byte[] result = new byte[checkNoOverflow(length)];
     int pos = 0;
     for (byte[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Chars.java
+++ b/android/guava/src/com/google/common/primitives/Chars.java
@@ -270,19 +270,29 @@ public final class Chars {
    *
    * @param arrays zero or more {@code char} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static char[] concat(char[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (char[] array : arrays) {
       length += array.length;
     }
-    char[] result = new char[length];
+    char[] result = new char[checkNoOverflow(length)];
     int pos = 0;
     for (char[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Doubles.java
+++ b/android/guava/src/com/google/common/primitives/Doubles.java
@@ -271,19 +271,29 @@ public final class Doubles extends DoublesMethodsForWeb {
    *
    * @param arrays zero or more {@code double} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static double[] concat(double[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (double[] array : arrays) {
       length += array.length;
     }
-    double[] result = new double[length];
+    double[] result = new double[checkNoOverflow(length)];
     int pos = 0;
     for (double[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   private static final class DoubleConverter extends Converter<String, Double>

--- a/android/guava/src/com/google/common/primitives/Floats.java
+++ b/android/guava/src/com/google/common/primitives/Floats.java
@@ -268,19 +268,29 @@ public final class Floats extends FloatsMethodsForWeb {
    *
    * @param arrays zero or more {@code float} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static float[] concat(float[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (float[] array : arrays) {
       length += array.length;
     }
-    float[] result = new float[length];
+    float[] result = new float[checkNoOverflow(length)];
     int pos = 0;
     for (float[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   private static final class FloatConverter extends Converter<String, Float>

--- a/android/guava/src/com/google/common/primitives/Ints.java
+++ b/android/guava/src/com/google/common/primitives/Ints.java
@@ -279,19 +279,29 @@ public final class Ints extends IntsMethodsForWeb {
    *
    * @param arrays zero or more {@code int} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static int[] concat(int[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (int[] array : arrays) {
       length += array.length;
     }
-    int[] result = new int[length];
+    int[] result = new int[checkNoOverflow(length)];
     int pos = 0;
     for (int[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/android/guava/src/com/google/common/primitives/Shorts.java
+++ b/android/guava/src/com/google/common/primitives/Shorts.java
@@ -279,19 +279,29 @@ public final class Shorts extends ShortsMethodsForWeb {
    *
    * @param arrays zero or more {@code short} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static short[] concat(short[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (short[] array : arrays) {
       length += array.length;
     }
-    short[] result = new short[length];
+    short[] result = new short[checkNoOverflow(length)];
     int pos = 0;
     for (short[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/guava-tests/test/com/google/common/primitives/BooleansTest.java
+++ b/guava-tests/test/com/google/common/primitives/BooleansTest.java
@@ -130,6 +130,37 @@ public class BooleansTest extends TestCase {
         .isEqualTo(new boolean[] {false, false, true});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    boolean[][] arrays = new boolean[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    boolean[] sharedArray = new boolean[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Booleans.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Booleans.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Booleans.ensureCapacity(ARRAY_FALSE, 0, 1)).isSameInstanceAs(ARRAY_FALSE);

--- a/guava-tests/test/com/google/common/primitives/BytesTest.java
+++ b/guava-tests/test/com/google/common/primitives/BytesTest.java
@@ -131,6 +131,37 @@ public class BytesTest extends TestCase {
         .isEqualTo(new byte[] {(byte) 1, (byte) 2, (byte) 3, (byte) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    byte[][] arrays = new byte[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    byte[] sharedArray = new byte[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Bytes.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Bytes.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Bytes.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/guava-tests/test/com/google/common/primitives/CharsTest.java
+++ b/guava-tests/test/com/google/common/primitives/CharsTest.java
@@ -222,6 +222,37 @@ public class CharsTest extends TestCase {
         .isEqualTo(new char[] {(char) 1, (char) 2, (char) 3, (char) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    char[][] arrays = new char[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    char[] sharedArray = new char[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Chars.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @GwtIncompatible // Chars.fromByteArray
   public void testFromByteArray() {
     assertThat(Chars.fromByteArray(new byte[] {0x23, 0x45, (byte) 0xDC})).isEqualTo('\u2345');

--- a/guava-tests/test/com/google/common/primitives/DoublesTest.java
+++ b/guava-tests/test/com/google/common/primitives/DoublesTest.java
@@ -280,6 +280,37 @@ public class DoublesTest extends TestCase {
         .isEqualTo(new double[] {(double) 1, (double) 2, (double) 3, (double) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    double[][] arrays = new double[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    double[] sharedArray = new double[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+        Doubles.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Doubles.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Doubles.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/guava-tests/test/com/google/common/primitives/FloatsTest.java
+++ b/guava-tests/test/com/google/common/primitives/FloatsTest.java
@@ -267,6 +267,37 @@ public class FloatsTest extends TestCase {
         .isEqualTo(new float[] {(float) 1, (float) 2, (float) 3, (float) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    float[][] arrays = new float[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    float[] sharedArray = new float[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Floats.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testEnsureCapacity() {
     assertThat(Floats.ensureCapacity(EMPTY, 0, 1)).isSameInstanceAs(EMPTY);
     assertThat(Floats.ensureCapacity(ARRAY1, 0, 1)).isSameInstanceAs(ARRAY1);

--- a/guava-tests/test/com/google/common/primitives/IntsTest.java
+++ b/guava-tests/test/com/google/common/primitives/IntsTest.java
@@ -224,6 +224,37 @@ public class IntsTest extends TestCase {
         .isEqualTo(new int[] {(int) 1, (int) 2, (int) 3, (int) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    int[][] arrays = new int[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    int[] sharedArray = new int[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Ints.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   public void testToByteArray() {
     assertThat(Ints.toByteArray(0x12131415)).isEqualTo(new byte[] {0x12, 0x13, 0x14, 0x15});
     assertThat(Ints.toByteArray(0xFFEEDDCC))

--- a/guava-tests/test/com/google/common/primitives/ShortsTest.java
+++ b/guava-tests/test/com/google/common/primitives/ShortsTest.java
@@ -243,6 +243,37 @@ public class ShortsTest extends TestCase {
         .isEqualTo(new short[] {(short) 1, (short) 2, (short) 3, (short) 4});
   }
 
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_negative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 15;
+    assertThat(dim1 * dim2).isLessThan(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  @GwtIncompatible // different overflow behavior; could probably be made to work by using ~~
+  public void testConcat_overflow_nonNegative() {
+    int dim1 = 1 << 16;
+    int dim2 = 1 << 16;
+    assertThat(dim1 * dim2).isAtLeast(0);
+    testConcat_overflow(dim1, dim2);
+  }
+
+  private static void testConcat_overflow(int arraysDim1, int arraysDim2) {
+    assertThat((long) arraysDim1 * arraysDim2).isNotEqualTo((long) (arraysDim1 * arraysDim2));
+
+    short[][] arrays = new short[arraysDim1][];
+    // it's shared to avoid using too much memory in tests
+    short[] sharedArray = new short[arraysDim2];
+    Arrays.fill(arrays, sharedArray);
+
+    try {
+      Shorts.concat(arrays);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @GwtIncompatible // Shorts.toByteArray
   public void testToByteArray() {
     assertThat(Shorts.toByteArray((short) 0x2345)).isEqualTo(new byte[] {0x23, 0x45});

--- a/guava/src/com/google/common/primitives/Booleans.java
+++ b/guava/src/com/google/common/primitives/Booleans.java
@@ -230,19 +230,29 @@ public final class Booleans {
    *
    * @param arrays zero or more {@code boolean} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static boolean[] concat(boolean[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (boolean[] array : arrays) {
       length += array.length;
     }
-    boolean[] result = new boolean[length];
+    boolean[] result = new boolean[checkNoOverflow(length)];
     int pos = 0;
     for (boolean[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Bytes.java
+++ b/guava/src/com/google/common/primitives/Bytes.java
@@ -156,19 +156,29 @@ public final class Bytes {
    *
    * @param arrays zero or more {@code byte} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static byte[] concat(byte[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (byte[] array : arrays) {
       length += array.length;
     }
-    byte[] result = new byte[length];
+    byte[] result = new byte[checkNoOverflow(length)];
     int pos = 0;
     for (byte[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Chars.java
+++ b/guava/src/com/google/common/primitives/Chars.java
@@ -270,19 +270,29 @@ public final class Chars {
    *
    * @param arrays zero or more {@code char} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static char[] concat(char[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (char[] array : arrays) {
       length += array.length;
     }
-    char[] result = new char[length];
+    char[] result = new char[checkNoOverflow(length)];
     int pos = 0;
     for (char[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Doubles.java
+++ b/guava/src/com/google/common/primitives/Doubles.java
@@ -273,19 +273,29 @@ public final class Doubles extends DoublesMethodsForWeb {
    *
    * @param arrays zero or more {@code double} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static double[] concat(double[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (double[] array : arrays) {
       length += array.length;
     }
-    double[] result = new double[length];
+    double[] result = new double[checkNoOverflow(length)];
     int pos = 0;
     for (double[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   private static final class DoubleConverter extends Converter<String, Double>

--- a/guava/src/com/google/common/primitives/Floats.java
+++ b/guava/src/com/google/common/primitives/Floats.java
@@ -268,19 +268,29 @@ public final class Floats extends FloatsMethodsForWeb {
    *
    * @param arrays zero or more {@code float} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static float[] concat(float[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (float[] array : arrays) {
       length += array.length;
     }
-    float[] result = new float[length];
+    float[] result = new float[checkNoOverflow(length)];
     int pos = 0;
     for (float[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   private static final class FloatConverter extends Converter<String, Float>

--- a/guava/src/com/google/common/primitives/Ints.java
+++ b/guava/src/com/google/common/primitives/Ints.java
@@ -281,19 +281,29 @@ public final class Ints extends IntsMethodsForWeb {
    *
    * @param arrays zero or more {@code int} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static int[] concat(int[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (int[] array : arrays) {
       length += array.length;
     }
-    int[] result = new int[length];
+    int[] result = new int[checkNoOverflow(length)];
     int pos = 0;
     for (int[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**

--- a/guava/src/com/google/common/primitives/Shorts.java
+++ b/guava/src/com/google/common/primitives/Shorts.java
@@ -279,19 +279,29 @@ public final class Shorts extends ShortsMethodsForWeb {
    *
    * @param arrays zero or more {@code short} arrays
    * @return a single array containing all the values from the source arrays, in order
+   * @throws IllegalArgumentException if the total number of elements in {@code arrays} does not fit
+   *     in an {@code int}
    */
   public static short[] concat(short[]... arrays) {
-    int length = 0;
+    long length = 0;
     for (short[] array : arrays) {
       length += array.length;
     }
-    short[] result = new short[length];
+    short[] result = new short[checkNoOverflow(length)];
     int pos = 0;
     for (short[] array : arrays) {
       System.arraycopy(array, 0, result, pos, array.length);
       pos += array.length;
     }
     return result;
+  }
+
+  private static int checkNoOverflow(long result) {
+    checkArgument(
+        result == (int) result,
+        "the total number of elements (%s) in the arrays must fit in an int",
+        result);
+    return (int) result;
   }
 
   /**


### PR DESCRIPTION
This is basically 8720b6bbc20a36ffdc6c6ce397f1308bd7b630d6 but for:
- `Booleans`,
- `Bytes`,
- `Chars`,
- `Doubles`,
- `Floats`,
- `Ints`,
- `Shorts`.

I think it will be fair to credit @ineuwirth as the author of these changes.

Relates to #3303.
