### PR TITLE
BloomFilter - bitSize exposed as public API

### DIFF
--- a/android/guava/src/com/google/common/hash/BloomFilter.java
+++ b/android/guava/src/com/google/common/hash/BloomFilter.java
@@ -213,8 +213,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
   }
 
   /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  public long bitSize() {
     return bits.bitSize();
   }
 

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -214,8 +214,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
   }
 
   /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  public long bitSize() {
     return bits.bitSize();
   }
 


### PR DESCRIPTION
Exposed the bitSize as public #6866 
- 
- Removed @VisibleForTesting 