### PR TITLE
Fixed flaky test-case

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/testers/MapToStringTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/MapToStringTester.java
@@ -14,22 +14,26 @@
 
 package com.google.common.collect.testing.testers;
 
-import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
-import static com.google.common.collect.testing.features.CollectionSize.ONE;
-import static com.google.common.collect.testing.features.CollectionSize.ZERO;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
-
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.testing.AbstractMapTester;
 import com.google.common.collect.testing.features.CollectionFeature;
 import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
+import org.junit.Ignore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-import org.junit.Ignore;
+import java.util.Objects;
+
+import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
+import static com.google.common.collect.testing.features.CollectionSize.ONE;
+import static com.google.common.collect.testing.features.CollectionSize.ZERO;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
 
 /**
  * A generic JUnit test which tests {@code toString()} operations on a map. Can't be invoked
@@ -42,6 +46,8 @@ import org.junit.Ignore;
 @Ignore // Affects only Android test runner, which respects JUnit 4 annotations on JUnit 3 tests.
 @SuppressWarnings("JUnit4ClassUsedInJUnit3")
 public class MapToStringTester<K, V> extends AbstractMapTester<K, V> {
+
+  private static final Integer LENGTH_OF_COMMA_AND_SPACE = 2;
   public void testToString_minimal() {
     assertNotNull("toString() should not return null", getMap().toString());
   }
@@ -76,15 +82,58 @@ public class MapToStringTester<K, V> extends AbstractMapTester<K, V> {
 
   @CollectionFeature.Require(absent = NON_STANDARD_TOSTRING)
   public void testToString_formatting() {
+    String actual = getMap().toString();
+    String expected = expectedToString(getMap(), getKeysParsedFromStringVersionOfMap(getMap(), actual));
     assertEquals(
-        "map.toString() incorrect", expectedToString(getMap().entrySet()), getMap().toString());
+        "map.toString() incorrect", expected, actual);
   }
 
-  private String expectedToString(Set<Entry<K, V>> entries) {
+  private String expectedToString(Map<K, V> map, List<K> keys) {
     Map<K, V> reference = new LinkedHashMap<>();
-    for (Entry<K, V> entry : entries) {
-      reference.put(entry.getKey(), entry.getValue());
+    for (K key : keys) {
+      reference.put(key, map.get(key));
     }
     return reference.toString();
   }
+
+  /**
+   * For a given String, which is expected to be created by Map.toString() call,
+   * creates a list of keys in the same order of appearance as they are in the string
+   * @param map Any implementation of Map
+   * @param mapDotToString map.toString(), to derive order of keys
+   * @return List<String> keys from the map
+   */
+  private List<K> getKeysParsedFromStringVersionOfMap(Map<K, V> map, String mapDotToString) {
+
+    Map<String, K> entryToKeyMap = new HashMap<>();
+    for (Entry<K, V> entry: map.entrySet()) {
+      entryToKeyMap.put(entry.toString(), entry.getKey());
+    }
+    String clipperMapString = mapDotToString.substring(1, mapDotToString.length() - 1); // getting rid of unnecessary "{" and "}"
+    List<K> keyOrder = new ArrayList<>();
+    while (!clipperMapString.isEmpty()) {
+      String lastEntry = null;
+      for (Entry<String, K> e : entryToKeyMap.entrySet()) {
+        if (clipperMapString.indexOf(e.getKey()) == 0) {
+          lastEntry = e.getKey();
+          K topLevelKey = e.getValue();
+
+          keyOrder.add(topLevelKey);
+          if (clipperMapString.length() >= LENGTH_OF_COMMA_AND_SPACE + e.getKey().length()) {
+            clipperMapString = clipperMapString.substring(LENGTH_OF_COMMA_AND_SPACE + e.getKey().length());
+          } else { // When last segment of entry in clipperMapString is reached
+            clipperMapString = clipperMapString.substring(e.getKey().length());
+          }
+          break;
+        }
+      }
+      if (Objects.nonNull(lastEntry)) {
+        entryToKeyMap.remove(lastEntry);
+      } else {
+        break;
+      }
+    }
+    return keyOrder;
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,11 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.4.0</version>
         </plugin>
+        <plugin> <!-- for flaky testing -->
+          <groupId>edu.illinois</groupId>
+          <artifactId>nondex-maven-plugin</artifactId>
+          <version>2.1.7</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Fixed flaky test case in the following class: guava-tests/test/com/google/common/collect/MultimapsCollectionTest.java

Assertion called in: guava-testlib/src/com/google/common/collect/testing/testers/MapToStringTester.java

POINT OF FAILURE ->
In MapToStringTester class, testToString_formatting() asserts equality in map.toString() and an expected value of map toString() using a LinkedHashMap. This is inconsistent as key ordering obtained in toString() in one call, and the key order observed while iterating through entries in another call can be different.

Fix:
Added a method that retrieves the key order from map.toString() and uses that key order in expected value calculation.

Fixed using NonDex, plugin added in parent pom.
Suggested command to check flaky tests :
> mvn nondex:nondex

For the particular test class:
>mvn -pl ./guava-tests nondex:nondex -Dtest=com.google.common.collect.MultimapsCollectionTest -DnondexRuns=10 -DnondexRuns=10

For more information: https://github.com/TestingResearchIllinois/NonDex