### PR TITLE
Add `application/cbor` to `MediaType`

### DIFF
--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -459,6 +459,15 @@ public final class MediaType {
   public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
   /**
+   * As described in <a href="https://www.rfc-editor.org/rfc/rfc8949.html">RFC 8949</a>, this
+   * constant ({@code application/cbor}) is used for the Concise Binary Object
+   * Representation (CBOR) data format.
+   *
+   * @since NEXT
+   */
+  public static final MediaType CBOR = createConstant(APPLICATION_TYPE, "cbor");
+
+  /**
    * Media type for the <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Format</a>, a
    * geospatial data interchange format based on JSON.
    *

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -459,6 +459,15 @@ public final class MediaType {
   public static final MediaType APPLICATION_BINARY = createConstant(APPLICATION_TYPE, "binary");
 
   /**
+   * As described in <a href="https://www.rfc-editor.org/rfc/rfc8949.html">RFC 8949</a>, this
+   * constant ({@code application/cbor}) is used for the Concise Binary Object
+   * Representation (CBOR) data format.
+   *
+   * @since NEXT
+   */
+  public static final MediaType CBOR = createConstant(APPLICATION_TYPE, "cbor");
+
+  /**
    * Media type for the <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Format</a>, a
    * geospatial data interchange format based on JSON.
    *


### PR DESCRIPTION
Add Concise Binary Object Representation (CBOR) from [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949) as a known media type: `application/cbor`.