### PR TITLE
fix flaky test testToStringWithNullValue and testToString_formatting

### DIFF
--- a/android/guava-testlib/src/com/google/common/collect/testing/google/MultimapToStringTester.java
+++ b/android/guava-testlib/src/com/google/common/collect/testing/google/MultimapToStringTester.java
@@ -14,18 +14,21 @@
 
 package com.google.common.collect.testing.google;
 
-import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
-import static com.google.common.collect.testing.features.CollectionSize.ONE;
-import static com.google.common.collect.testing.features.CollectionSize.ZERO;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.junit.Ignore;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.testing.features.CollectionFeature;
+import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
 import com.google.common.collect.testing.features.CollectionSize;
+import static com.google.common.collect.testing.features.CollectionSize.ONE;
+import static com.google.common.collect.testing.features.CollectionSize.ZERO;
 import com.google.common.collect.testing.features.MapFeature;
-import org.junit.Ignore;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
 
 /**
  * Tester for {@code Multimap.toString()}.
@@ -66,6 +69,14 @@ public class MultimapToStringTester<K, V> extends AbstractMultimapTester<K, V, M
 
   @CollectionFeature.Require(absent = NON_STANDARD_TOSTRING)
   public void testToStringMatchesAsMap() {
-    assertEquals(multimap().asMap().toString(), multimap().toString());
+    assertEquals(sortedToString(multimap().asMap().toString()), sortedToString(multimap().toString()));
+  }
+
+  private String sortedToString(String mapToString) {
+    String content = mapToString.substring(1, mapToString.length() - 1);
+    Pattern pattern = Pattern.compile(", (?![^\\{]*\\})");
+    String[] entries = pattern.split(content);
+    Arrays.sort(entries);
+    return "{" + String.join(", ", entries) + "}";
   }
 }

--- a/guava-testlib/src/com/google/common/collect/testing/testers/MapToStringTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/MapToStringTester.java
@@ -14,22 +14,25 @@
 
 package com.google.common.collect.testing.testers;
 
-import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
-import static com.google.common.collect.testing.features.CollectionSize.ONE;
-import static com.google.common.collect.testing.features.CollectionSize.ZERO;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
-import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
-
-import com.google.common.annotations.GwtCompatible;
-import com.google.common.collect.testing.AbstractMapTester;
-import com.google.common.collect.testing.features.CollectionFeature;
-import com.google.common.collect.testing.features.CollectionSize;
-import com.google.common.collect.testing.features.MapFeature;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Pattern;
+
 import org.junit.Ignore;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.collect.testing.AbstractMapTester;
+import com.google.common.collect.testing.features.CollectionFeature;
+import static com.google.common.collect.testing.features.CollectionFeature.NON_STANDARD_TOSTRING;
+import com.google.common.collect.testing.features.CollectionSize;
+import static com.google.common.collect.testing.features.CollectionSize.ONE;
+import static com.google.common.collect.testing.features.CollectionSize.ZERO;
+import com.google.common.collect.testing.features.MapFeature;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
 
 /**
  * A generic JUnit test which tests {@code toString()} operations on a map. Can't be invoked
@@ -77,7 +80,7 @@ public class MapToStringTester<K, V> extends AbstractMapTester<K, V> {
   @CollectionFeature.Require(absent = NON_STANDARD_TOSTRING)
   public void testToString_formatting() {
     assertEquals(
-        "map.toString() incorrect", expectedToString(getMap().entrySet()), getMap().toString());
+        "map.toString() incorrect", expectedToString(getMap().entrySet()), sortedToString(getMap().toString()));
   }
 
   private String expectedToString(Set<Entry<K, V>> entries) {
@@ -85,6 +88,14 @@ public class MapToStringTester<K, V> extends AbstractMapTester<K, V> {
     for (Entry<K, V> entry : entries) {
       reference.put(entry.getKey(), entry.getValue());
     }
-    return reference.toString();
+    return sortedToString(reference.toString());
+  }
+
+  private String sortedToString(String mapToString) {
+    String content = mapToString.substring(1, mapToString.length() - 1);
+    Pattern pattern = Pattern.compile(", (?![^\\{]*\\})");
+    String[] entries = pattern.split(content);
+    Arrays.sort(entries);
+    return "{" + String.join(", ", entries) + "}";
   }
 }


### PR DESCRIPTION
This PR is a further discussion based on the previous flaky test PR: [https://github.com/google/guava/pull/7387](https://github.com/google/guava/pull/7387)
The two flaky tests are also detected by running with Nondex:
`mvn -pl ./guava-tests nondex:nondex -Dtest=com.google.common.collect.MultimapsCollectionTest -DnondexRuns=10`
The issue arises because the order of keys in a HashMap entry set is not fixed, leading to variations in the toString() output depending on the seed, which causes test failures.

To address this, I’ve explored three potential solutions:
1. Use a different data structure, such as TreeMap, to guarantee key order.
2. Sort the toString() output to achieve a consistent order.
3. Use a comparison method other than assertEquals() for evaluating the results.、

Since these tests are intended to verify the toString() output specifically for HashMap, changing the data structure may alter the test's intent. With efficiency in mind, my proposed solution is to sort the toString() output to ensure consistency.

I would appreciate any feedback on this approach or other suggestions for addressing these flaky tests. Thank you!
