### PR TITLE
Replace deprecated Throwables.propagate with throwIfUnchecked and direct exception throwing in SubscriberRegistry, MoreExecutors

### DIFF
--- a/guava/src/com/google/common/eventbus/SubscriberRegistry.java
+++ b/guava/src/com/google/common/eventbus/SubscriberRegistry.java
@@ -239,7 +239,8 @@ final class SubscriberRegistry {
     try {
       return flattenHierarchyCache.getUnchecked(concreteClass);
     } catch (UncheckedExecutionException e) {
-      throw Throwables.propagate(e.getCause());
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e.getCause());
     }
   }
 

--- a/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+++ b/guava/src/com/google/common/util/concurrent/MoreExecutors.java
@@ -808,7 +808,8 @@ public final class MoreExecutors {
     } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
       throw new RuntimeException("Couldn't invoke ThreadManager.currentRequestThreadFactory", e);
     } catch (InvocationTargetException e) {
-      throw Throwables.propagate(e.getCause());
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e.getCause());
     }
   }
 


### PR DESCRIPTION
The suggestion here is to change the use of the deprecated `Throwables.propagate()` in the `SubscriberRegistry.java`, `MoreExecutors.java` classes to the alternative that is recommended in the documentation for this method: 

```
Throwables.throwIfUnchecked(e);
throw new RuntimeException(e.getCause());
```