### PR TITLE
Expose bitSize method for the BloomFilter classs

### DIFF
--- a/android/guava/src/com/google/common/hash/BloomFilter.java
+++ b/android/guava/src/com/google/common/hash/BloomFilter.java
@@ -213,8 +213,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
   }
 
   /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  public long bitSize() {
     return bits.bitSize();
   }
 

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -214,8 +214,7 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
   }
 
   /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  public long bitSize() {
     return bits.bitSize();
   }
 


### PR DESCRIPTION
This PR exposes the `bitSize` method as part of `BloomFilter`'s API as discussed in #6866.

Closes #6866 
Closes #6923 
Closes #7383 