### PR TITLE
Customize redirect template to preserve the URL anchor.

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ page.redirect.to }}">
+  <script>location="{{ page.redirect.to }}"+location.hash</script>
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
Extracted the default redirect HTML via `wget guava.dev/api` and replaced the destination URL with `{{ page.redirect.to }}` and just added `+location.hash` to the JavaScript redirect URL.

See https://github.com/jekyll/jekyll-redirect-from#customizing-the-redirect-template.

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
