### PR TITLE
Update FarmHashFingerprint64.java

### DIFF
--- a/guava/src/com/google/common/hash/FarmHashFingerprint64.java
+++ b/guava/src/com/google/common/hash/FarmHashFingerprint64.java
@@ -120,9 +120,9 @@ final class FarmHashFingerprint64 extends AbstractNonStreamingHashFunction {
       long mul = K2 + length * 2L;
       long a = load64(bytes, offset) + K2;
       long b = load64(bytes, offset + length - 8);
-      long c = rotateRight(b, 37) * mul + a;
-      long d = (rotateRight(a, 25) + b) * mul;
-      return hashLength16(c, d, mul);
+      long c = rotateRight(b, 37) * mul;
+      long d = rotateRight(a, 25) * mul;
+      return hashLength16(c + a, d + b * mul, mul);
     }
     if (length >= 4) {
       long mul = K2 + length * 2;


### PR DESCRIPTION
Remove the data dependency between loads and both the rotates.  

We can rewrite the code in such a way that rotates can start computing as soon as the required loads are present instead of waiting for both the loads to retire.

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
