### PR TITLE
Update BloomFilterStrategies.java

### DIFF
--- a/guava/src/com/google/common/hash/BloomFilterStrategies.java
+++ b/guava/src/com/google/common/hash/BloomFilterStrategies.java
@@ -57,13 +57,13 @@ enum BloomFilterStrategies implements BloomFilter.Strategy {
       int hash2 = (int) (hash64 >>> 32);
 
       boolean bitsChanged = false;
+      int signedCombinedHash = 0;
+      int combinedHash = hash1;
       for (int i = 1; i <= numHashFunctions; i++) {
-        int combinedHash = hash1 + (i * hash2);
+        combinedHash += hash2;
         // Flip all the bits if it's negative (guaranteed positive number)
-        if (combinedHash < 0) {
-          combinedHash = ~combinedHash;
-        }
-        bitsChanged |= bits.set(combinedHash % bitSize);
+        signedCombinedHash = (combinedHash < 0) ? ~combinedHash : combinedHash;
+        bitsChanged |= bits.set(signedCombinedHash % bitSize);
       }
       return bitsChanged;
     }
@@ -79,13 +79,13 @@ enum BloomFilterStrategies implements BloomFilter.Strategy {
       int hash1 = (int) hash64;
       int hash2 = (int) (hash64 >>> 32);
 
+      int signedCombinedHash = 0;
+      int combinedHash = hash1;
       for (int i = 1; i <= numHashFunctions; i++) {
-        int combinedHash = hash1 + (i * hash2);
+        combinedHash += hash2;
         // Flip all the bits if it's negative (guaranteed positive number)
-        if (combinedHash < 0) {
-          combinedHash = ~combinedHash;
-        }
-        if (!bits.get(combinedHash % bitSize)) {
+        signedCombinedHash = (combinedHash < 0) ? ~combinedHash : combinedHash;
+        if (!bits.get(signedCombinedHash % bitSize)) {
           return false;
         }
       }


### PR DESCRIPTION
Remove imul instruction from murmur operations of 32bit hash functions -- reduces the number of instructions by 1 CPU cycle.

Before -- https://godbolt.org/z/GWvnEoPa3
After -- https://godbolt.org/z/4zEoM5G1W