### PR TITLE
Add test for containsKey(keyForNullValue)

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/testers/MapContainsKeyTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/MapContainsKeyTester.java
@@ -19,6 +19,7 @@ package com.google.common.collect.testing.testers;
 import static com.google.common.collect.testing.features.CollectionSize.ZERO;
 import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEYS;
 import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_KEY_QUERIES;
+import static com.google.common.collect.testing.features.MapFeature.ALLOWS_NULL_VALUES;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.collect.testing.AbstractMapTester;
@@ -69,6 +70,13 @@ public class MapContainsKeyTester<K, V> extends AbstractMapTester<K, V> {
   public void testContains_nullContained() {
     initMapWithNullKey();
     assertTrue("containsKey(null) should return true", getMap().containsKey(null));
+  }
+
+  @MapFeature.Require(ALLOWS_NULL_VALUES)
+  @CollectionSize.Require(absent = ZERO)
+  public void testContains_keyWithNullValueContained() {
+    initMapWithNullValue();
+    assertFalse("containsKey(keyForNullValue) should return true", getMap().containsKey(getKeyForNullValue()));
   }
 
   public void testContains_wrongType() {


### PR DESCRIPTION
A buggy `Map.containsKey` implementation could be like `return get(key) != null`, however, such an implementation is not valid as it would return `false` if the value is `null`.

WDYT?