### PR TITLE
Modify the equals method and do not call the size method

### DIFF
--- a/guava/src/com/google/common/collect/Sets.java
+++ b/guava/src/com/google/common/collect/Sets.java
@@ -967,6 +967,23 @@ public final class Sets {
       }
 
       @Override
+      public boolean equals(Object o) {
+        if (o == this)
+          return true;
+
+        if (!(o instanceof Set))
+          return false;
+        Collection<?> c = (Collection<?>) o;
+        try {
+          return containsAll(c) && c.containsAll(this);
+        } catch (ClassCastException unused)   {
+          return false;
+        } catch (NullPointerException unused) {
+          return false;
+        }
+      }
+
+      @Override
       public int size() {
         int size = 0;
         for (E e : set1) {


### PR DESCRIPTION

For the difference method of Sets, which returns a SetView that inherits AbstractSet, I want to override its equals method to reduce the running time of this method. The main operation is to delete the call to the size method.