### PR TITLE
jpms: add 'require static' entries for annotation processing

### DIFF
--- a/guava/src/module-info.java
+++ b/guava/src/module-info.java
@@ -17,6 +17,9 @@
 /** Google Guava */
 module com.google.common {
   requires static jdk.unsupported;
+  requires static com.google.errorprone.annotations;
+  requires static com.google.j2objc.annotations;
+  requires static org.jspecify;
   requires java.logging;
   requires com.google.common.util.concurrent.internal;
 


### PR DESCRIPTION
Follow up to: #2970

The annotation libraries that provide annotations used on public API should be declared as `require static`. Otherwise, compiling with `-Xlint:all` and `-Werror` fails because all annotations that are visited need to be accessible from the context of the module they are used in.

Example error:

```
guava-33.4.5-jre.jar(/com/google/common/util/concurrent/ListenableFuture.class): warning: Cannot find annotation method 'value()' in type 'DoNotMock': class file for com.google.errorprone.annotations.DoNotMock not found
guava-33.4.5-jre.jar(/com/google/common/util/concurrent/ListenableFuture.class): warning: Cannot find annotation method 'value()' in type 'DoNotMock': class file for com.google.errorprone.annotations.DoNotMock not found
error: warnings found and -Werror specified
1 error
2 warnings
```

https://scans.gradle.com/s/ose6lkdbtogww/console-log/task/:hedera-protobuf-java-api:compileJava?anchor=5&page=1

For more details see also this similar issue in Log4j2: https://github.com/apache/logging-log4j2/issues/3437

I believe Guava's own build would fail without this at compilation time if annotation processing would be done on the module path (`--process-module-path`).
Unfortunately, that's a bit complex to configure currently: https://issues.apache.org/jira/browse/MCOMPILER-412 
