### PR TITLE
testlib: add tests for Map.entrySet().stream() and Spliterator charac…

### DIFF
--- a/guava-testlib/test/com/google/common/collect/testing/EntrySetStreamTest.java
+++ b/guava-testlib/test/com/google/common/collect/testing/EntrySetStreamTest.java
@@ -1,0 +1,52 @@
+package com.google.common.collect.testing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import junit.framework.TestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+
+public class EntrySetStreamTest extends TestCase {
+
+    public void testEntrySetStreamToList_BasicImmutableMap() {
+        Map<String, Integer> map = ImmutableMap.of("a", 1, "b", 2);
+
+        assertThat(map.entrySet().stream().collect(Collectors.toList()))
+                .containsExactlyElementsIn(map.entrySet())
+                .inOrder();
+    }
+
+    public void testEntrySetStreamToList_WithNullValueInHashMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("x", null);
+        map.put("y", "yes");
+
+        assertThat(map.entrySet().stream().collect(Collectors.toList()))
+                .containsExactlyElementsIn(map.entrySet())
+                .inOrder();
+    }
+
+    public void testSpliteratorCharacteristics_ImmutableMap() {
+        Map<String, String> map = ImmutableMap.of("a", "1", "b", "2");
+
+        Spliterator<Map.Entry<String, String>> spliterator = map.entrySet().spliterator();
+
+        // NONNULL should be set since ImmutableMap does not allow nulls
+        assertTrue((spliterator.characteristics() & Spliterator.NONNULL) != 0);
+    }
+
+    public void testSpliteratorCharacteristics_HashMapWithNullValue() {
+        Map<String, String> map = new HashMap<>();
+        map.put("a", "1");
+        map.put("b", null);
+
+        Spliterator<Map.Entry<String, String>> spliterator = map.entrySet().spliterator();
+
+        // NONNULL should NOT be set because value is null
+        assertFalse((spliterator.characteristics() & Spliterator.NONNULL) != 0);
+    }
+}


### PR DESCRIPTION
Adds tests for 'Map.entrySet().stream()' and its associated 'Spliterator' characteristics as requested in issue #7855.

Validates that:
- 'map.entrySet().stream().toList()' returns exactly the same entries as the original map.
- For maps that allow null values (e.g., HashMap), the 'Spliterator.NONNULL' characteristic is not present if nulls exist.
- For maps that disallow nulls (e.g., ImmutableMap), the 'Spliterator.NONNULL' characteristic is present.

Test coverage includes:
- Basic map entries streaming validation.
- Validation for Spliterator characteristics with and without nulls.

These tests help ensure compliance with Java 8+ stream semantics and provide regression protection for future implementations.

Fixes #7855.
