### PR TITLE
Add basic test for RateLimiter.tryAcquire() burst behavior

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -24,7 +24,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
-
+import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.NullPointerTester;
@@ -563,4 +563,31 @@ public class RateLimiterTest extends TestCase {
           .put(double.class, 1.0)
           .put(TimeUnit.class, SECONDS)
           .build();
+
+  //Added Test for RateLimiter.tryAcquire()
+  @GwtIncompatible
+  @Test
+  public void testTryAcquireMethod(){
+
+    final RateLimiter rateLimiter = RateLimiter.create(1000);
+
+    int allowed = 0;
+    int denied = 0;
+
+    for(int i = 0; i < 20; i++){
+      if(rateLimiter.tryAcquire()){
+        allowed++;
+      }
+
+      else {
+        denied++;
+      }
+    }
+
+    System.out.println("Allowed: " + allowed + ", Denied: " + denied);
+
+    assertTrue("Expected atleast one request is denied" , denied > 0);
+    assertTrue("Expected atleast one request is allowed" , allowed > 0);
+
+  }
 }

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -42,7 +42,7 @@ import org.jspecify.annotations.Nullable;
  * <p>{@code RateLimiter} is safe for concurrent use: It will restrict the total rate of calls from
  * all threads. Note, however, that it does not guarantee fairness.
  *
- * <p>Rate limiters are often used to restrict the rate at which some physical or logical resource
+ * <p>Rate limiters are often used to restrict the rate at which some physical or logical r esource
  * is accessed. This is in contrast to {@link java.util.concurrent.Semaphore} which restricts the
  * number of concurrent accesses instead of the rate (note though that concurrency and rate are
  * closely related, e.g. see <a href="http://en.wikipedia.org/wiki/Little%27s_law">Little's

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -42,7 +42,7 @@ import org.jspecify.annotations.Nullable;
  * <p>{@code RateLimiter} is safe for concurrent use: It will restrict the total rate of calls from
  * all threads. Note, however, that it does not guarantee fairness.
  *
- * <p>Rate limiters are often used to restrict the rate at which some physical or logical r esource
+ * <p>Rate limiters are often used to restrict the rate at which some physical or logical resource
  * is accessed. This is in contrast to {@link java.util.concurrent.Semaphore} which restricts the
  * number of concurrent accesses instead of the rate (note though that concurrency and rate are
  * closely related, e.g. see <a href="http://en.wikipedia.org/wiki/Little%27s_law">Little's


### PR DESCRIPTION
This pull request adds a test case for `RateLimiter.tryAcquire()` to observe its behavior under a short burst of requests.

 What the Test Covers

- Creates a RateLimiter with 1000 permits/second.
- Fires 20 tryAcquire() calls in rapid succession.
- Asserts that:
  - Some requests are allowed initially (due to stored permits).
  - Some requests are denied once the limiter catches up to the rate limit.

 Rationale

Although testImmediateTryAcquire() checks permit exhaustion for two consecutive calls, this test simulates a higher-throughput scenario to validate how  tryAcquire() behaves under short bursts — closer to real-world usage.


Let me know if any revisions are needed!

