### PR TITLE
Reduce allocations in TypeToken#getRawType

### DIFF
--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -191,10 +191,19 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
    * </ul>
    */
   public final Class<? super T> getRawType() {
-    // For wildcard or type variable, the first bound determines the runtime type.
-    Class<?> rawType = getRawTypes().iterator().next();
-    @SuppressWarnings("unchecked") // raw type is |T|
-    Class<? super T> result = (Class<? super T>) rawType;
+    final Class<? super T> result;
+    if (runtimeType instanceof Class) {
+      @SuppressWarnings("unchecked") // raw type is |T|
+      Class<? super T> rawType = (Class<? super T>) runtimeType;
+      result = rawType;
+    } else if (runtimeType instanceof ParameterizedType) {
+      @SuppressWarnings("unchecked") // raw type is |T|
+      Class<? super T> rawType = (Class<? super T>) ((ParameterizedType) runtimeType).getRawType();
+      result = rawType;
+    } else {
+      // For wildcard or type variable, the first bound determines the runtime type.
+      result = getRawTypes().iterator().next();
+    }
     return result;
   }
 


### PR DESCRIPTION
Special case Class and ParameterizedType handling in getRawType to avoid allocating for the trivial / common case. Fixes #7957.