### PR TITLE
Add test for putIfAbsent to catch implementations that incorrectly ignore null values

### DIFF
--- a/guava-testlib/src/com/google/common/collect/testing/testers/MapPutIfAbsentTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/MapPutIfAbsentTester.java
@@ -125,4 +125,18 @@ public class MapPutIfAbsentTester<K, V> extends AbstractMapTester<K, V> {
         getMap().putIfAbsent(nullValueEntry.getKey(), nullValueEntry.getValue()));
     expectAdded(nullValueEntry);
   }
+
+  @MapFeature.Require({SUPPORTS_PUT, ALLOWS_NULL_VALUES})
+  @CollectionSize.Require(absent = ZERO)
+  public void testPutIfAbsent_replacesNullValue() {
+    // First, put a null value for an existing key
+    getMap().put(k0(), null);
+    assertEquals("Map should contain null value", null, getMap().get(k0()));
+
+    // putIfAbsent should replace the null value with the new value
+    assertNull(
+        "putIfAbsent(existingKeyWithNullValue, value) should return null",
+        getMap().putIfAbsent(k0(), v3()));
+    assertEquals("Map should now contain the new value", v3(), getMap().get(k0()));
+  }
 }


### PR DESCRIPTION

Fixes #6217

## Problem

Multiple map implementations (e.g., fastutils' `Object2ObjectOpenHashMap`) incorrectly pass Guava's testlib suite despite not properly implementing `Map.putIfAbsent` behavior with null values. The JavaDoc specifies that putIfAbsent should replace a null value, but the testlib doesn't verify this edge case, allowing non-compliant implementations to pass.

## Solution

Add `testPutIfAbsent_replacesNullValue()` to verify that `putIfAbsent` correctly replaces existing null values with new values, returning null as specified in the Map interface documentation.

## Changes

- Added new test method in `MapPutIfAbsentTester.java` that:
  - Sets an existing key's value to null
  - Calls putIfAbsent with a new value
  - Verifies it returns null (the old value)
  - Confirms the key now maps to the new value

## Testing

```bash
# Compile the testlib
./mvnw compile -pl guava-testlib

# Run tests that exercise MapPutIfAbsentTester with null-supporting maps
./mvnw test -Dtest=OpenJdk6MapTests -pl guava-testlib
./mvnw test -Dtest=HashMapTest -pl guava-tests
./mvnw test -Dtest=LinkedHashMapTest -pl guava-tests
```

## Breaking Changes

None. This only adds a new test case to catch non-compliant Map implementations.