### PR TITLE
Add Gradle capability declarations to detect duplicate Guava artifacts

### DIFF
--- a/guava/module.json
+++ b/guava/module.json
@@ -78,6 +78,31 @@
           "group": "com.google.collections",
           "name": "google-collections",
           "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-base",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-jdk5",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.sonatype.sisu",
+          "name": "sisu-guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.hudsonci.lib.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.apache.servicemix.bundles",
+          "name": "org.apache.servicemix.bundles.guava",
+          "version": "${pom.version}"
         }
       ]
     },
@@ -143,6 +168,31 @@
         {
           "group": "com.google.collections",
           "name": "google-collections",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-base",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-jdk5",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.sonatype.sisu",
+          "name": "sisu-guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.hudsonci.lib.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.apache.servicemix.bundles",
+          "name": "org.apache.servicemix.bundles.guava",
           "version": "${pom.version}"
         }
       ]
@@ -210,6 +260,31 @@
           "group": "com.google.collections",
           "name": "google-collections",
           "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-base",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-jdk5",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.sonatype.sisu",
+          "name": "sisu-guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.hudsonci.lib.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.apache.servicemix.bundles",
+          "name": "org.apache.servicemix.bundles.guava",
+          "version": "${pom.version}"
         }
       ]
     },
@@ -275,6 +350,31 @@
         {
           "group": "com.google.collections",
           "name": "google-collections",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-base",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.guava",
+          "name": "guava-jdk5",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.sonatype.sisu",
+          "name": "sisu-guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.hudsonci.lib.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "org.apache.servicemix.bundles",
+          "name": "org.apache.servicemix.bundles.guava",
           "version": "${pom.version}"
         }
       ]

--- a/guava/module.json
+++ b/guava/module.json
@@ -98,11 +98,6 @@
           "group": "org.hudsonci.lib.guava",
           "name": "guava",
           "version": "${pom.version}"
-        },
-        {
-          "group": "org.apache.servicemix.bundles",
-          "name": "org.apache.servicemix.bundles.guava",
-          "version": "${pom.version}"
         }
       ]
     },
@@ -188,11 +183,6 @@
         {
           "group": "org.hudsonci.lib.guava",
           "name": "guava",
-          "version": "${pom.version}"
-        },
-        {
-          "group": "org.apache.servicemix.bundles",
-          "name": "org.apache.servicemix.bundles.guava",
           "version": "${pom.version}"
         }
       ]
@@ -280,11 +270,6 @@
           "group": "org.hudsonci.lib.guava",
           "name": "guava",
           "version": "${pom.version}"
-        },
-        {
-          "group": "org.apache.servicemix.bundles",
-          "name": "org.apache.servicemix.bundles.guava",
-          "version": "${pom.version}"
         }
       ]
     },
@@ -370,11 +355,6 @@
         {
           "group": "org.hudsonci.lib.guava",
           "name": "guava",
-          "version": "${pom.version}"
-        },
-        {
-          "group": "org.apache.servicemix.bundles",
-          "name": "org.apache.servicemix.bundles.guava",
           "version": "${pom.version}"
         }
       ]

--- a/integration-tests/gradle/build.gradle.kts
+++ b/integration-tests/gradle/build.gradle.kts
@@ -123,6 +123,52 @@ subprojects {
             }
             ?.apply { select(this) }
         }
+        withCapability("com.google.guava:listenablefuture") {
+          candidates
+            .find {
+              val idField =
+                it.javaClass.getDeclaredMethod("getId")
+              (idField.invoke(it) as ModuleComponentIdentifier).module == "guava"
+            }
+            ?.apply { select(this) }
+        }
+        // Resolution strategies for the 4 new capability declarations from PR 7990
+        withCapability("com.google.guava:guava-base") {
+          candidates
+            .find {
+              val idField =
+                it.javaClass.getDeclaredMethod("getId")
+              (idField.invoke(it) as ModuleComponentIdentifier).module == "guava"
+            }
+            ?.apply { select(this) }
+        }
+        withCapability("com.google.guava:guava-jdk5") {
+          candidates
+            .find {
+              val idField =
+                it.javaClass.getDeclaredMethod("getId")
+              (idField.invoke(it) as ModuleComponentIdentifier).module == "guava"
+            }
+            ?.apply { select(this) }
+        }
+        withCapability("org.sonatype.sisu:sisu-guava") {
+          candidates
+            .find {
+              val idField =
+                it.javaClass.getDeclaredMethod("getId")
+              (idField.invoke(it) as ModuleComponentIdentifier).module == "guava"
+            }
+            ?.apply { select(this) }
+        }
+        withCapability("org.hudsonci.lib.guava:guava") {
+          candidates
+            .find {
+              val idField =
+                it.javaClass.getDeclaredMethod("getId")
+              (idField.invoke(it) as ModuleComponentIdentifier).module == "guava"
+            }
+            ?.apply { select(this) }
+        }
       }
     }
 


### PR DESCRIPTION
fixes #6666

## Problem

Users can accidentally include duplicate Guava artifacts (guava-jdk5, guava-base, sisu-guava, etc.) alongside the main Guava library, causing classpath conflicts and runtime issues that are difficult to debug.

## Solution
Declare that Guava provides the capabilities of known duplicate artifacts in module.json, following the existing google-collections pattern. This enables Gradle to detect and report conflicts at build time.

## Changes
- Added capability declarations for 4 duplicate Guava artifacts in all 4 variant sections of module.json:
  - com.google.guava:guava-base
  - com.google.guava:guava-jdk5
  - org.sonatype.sisu:sisu-guava
  - org.hudsonci.lib.guava:guava

Note: The servicemix capability was removed after testing revealed it caused conflicts between Gradle variants.

## Testing
```bash
# Build and install locally with module metadata
./mvnw install -pl guava -DskipTests -q

# Verify module metadata contains capability declarations
grep -E "(guava-base|guava-jdk5|sisu-guava|hudsonci)" \
  ~/.m2/repository/com/google/guava/guava/999.0.0-HEAD-jre-SNAPSHOT/guava-999.0.0-HEAD-jre-SNAPSHOT.module
# Expected: 20 lines (3 artifacts × 4 = 12, hudsonci × 4 = 4, total = 16 capability lines + 4 group lines)

# For Gradle users - test conflict detection after release
# Note: This will only show conflicts once the changes are in a released version
# The SNAPSHOT version may not resolve correctly from mavenLocal()
mkdir test-guava-conflict && cd test-guava-conflict
cat > build.gradle << 'EOF'
plugins { id 'java' }
repositories { mavenCentral() }
dependencies {
    implementation 'com.google.guava:guava:NEXT_RELEASE_VERSION'
    implementation 'com.google.guava:guava-jdk5:17.0'
}
EOF
gradle dependencies --configuration compileClasspath
# Expected after release: Capability conflict error
# Current behavior (without these changes): Both dependencies resolve without conflict
```

## Breaking Changes
Builds that currently (incorrectly) include both Guava and duplicate artifacts will now fail with a capability conflict error. Users must resolve by excluding the duplicate artifact or using Gradle's capability resolution.

**Why this breaking change is necessary:**
- Prevents silent runtime failures (NoSuchMethodError, ClassNotFoundException)
- Having duplicate Guava classes leads to unpredictable classloading behavior
- Build-time failure is preferable to production runtime failure
- Follows the established pattern already used for google-collections
- Simple fix: exclude the duplicate or explicitly choose which one to use
- "Fail fast, fail loud, fail at build time - not in production"