### PR TITLE
Fix foreach test assertion to handle HashSet's unordered iteration

### DIFF
--- a/guava-tests/test/com/google/common/collect/FilteredCollectionsTestUtil.java
+++ b/guava-tests/test/com/google/common/collect/FilteredCollectionsTestUtil.java
@@ -106,7 +106,7 @@ public final class FilteredCollectionsTestUtil {
               assertTrue("Unexpected element: " + i, EVEN.apply(i));
               foundElements.add(i);
             });
-        assertEquals(ImmutableList.copyOf(filtered), foundElements);
+        assertThat(foundElements).containsExactlyElementsIn(filtered);
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?
This PR is fixing the ```testForEach()``` test failing caused by HashSet's unordered iteration. The original test compared the list directly, which assumed a consistent iteration order.

However, since the underlying collection was backed by a HashSet, the order of elements was not guaranteed. This caused the assertion to fail even though the correct elements were present.

###  Reproduce Test:
To reproduce the failing test, Nondex can be used.
```
mvn -pl guava-tests edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.google.common.collect.SetsFilterHashSetTest#testForEach -DnondexMode=FULL
```
The test fails in ```FULL``` mode because the two lists can be iterating over the same collection but with different internal orders, exposing the nondeterminism.

### The Fix:
This update changes the assertion to verify that all expected elements are present, without assuming any particular order.

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
