### PR TITLE
Promote Traverser from beta to not a beta anymore

### DIFF
--- a/guava/src/com/google/common/graph/Traverser.java
+++ b/guava/src/com/google/common/graph/Traverser.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.Beta;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.DoNotMock;
@@ -60,7 +59,6 @@ import org.jspecify.annotations.Nullable;
  * @param <N> Node parameter type
  * @since 23.1
  */
-@Beta
 @DoNotMock(
     "Call forGraph or forTree, passing a lambda or a Graph with the desired edges (built with"
         + " GraphBuilder)")


### PR DESCRIPTION
The Traverser has been around for eight years already, and your IDE still complains you're using a Beta API.

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
