### PR TITLE
Document ArrayStoreException in ObjectArrays.concat methods

### DIFF
--- a/android/guava-tests/test/com/google/common/collect/ObjectArraysTest.java
+++ b/android/guava-tests/test/com/google/common/collect/ObjectArraysTest.java
@@ -197,6 +197,24 @@ public class ObjectArraysTest extends TestCase {
     assertThat(result).asList().containsExactly("foo", "bar", "baz").inOrder();
   }
 
+  public void testPrependIncompatibleType_throwsArrayStoreException() {
+    try {
+      Object[] unused = ObjectArrays.concat(0, new String[] {"foo"});
+      fail("Expected ArrayStoreException");
+    } catch (ArrayStoreException expected) {
+      // Expected behavior: cannot store Integer in String[]
+    }
+  }
+
+  public void testAppendIncompatibleType_throwsArrayStoreException() {
+    try {
+      Object[] unused = ObjectArrays.concat(new String[] {"foo"}, 0);
+      fail("Expected ArrayStoreException");
+    } catch (ArrayStoreException expected) {
+      // Expected behavior: cannot store Integer in String[]
+    }
+  }
+
   public void testEmptyArrayToEmpty() {
     doTestNewArrayEquals(new Object[0], 0);
   }

--- a/android/guava/src/com/google/common/collect/ObjectArrays.java
+++ b/android/guava/src/com/google/common/collect/ObjectArrays.java
@@ -85,6 +85,8 @@ public final class ObjectArrays {
    * @param array the array of elements to append
    * @return an array whose size is one larger than {@code array}, with {@code element} occupying
    *     the first position, and the elements of {@code array} occupying the remaining elements.
+   * @throws ArrayStoreException if {@code element} is not of a runtime type that can be stored in
+   *     an array of type {@code T[]}
    */
   public static <T extends @Nullable Object> T[] concat(@ParametricNullness T element, T[] array) {
     T[] result = newArray(array, array.length + 1);
@@ -100,6 +102,8 @@ public final class ObjectArrays {
    * @param element the element to append to the end
    * @return an array whose size is one larger than {@code array}, with the same contents as {@code
    *     array}, plus {@code element} occupying the last position.
+   * @throws ArrayStoreException if {@code element} is not of a runtime type that can be stored in
+   *     an array of type {@code T[]}
    */
   public static <T extends @Nullable Object> T[] concat(T[] array, @ParametricNullness T element) {
     T[] result = Arrays.copyOf(array, array.length + 1);

--- a/guava-tests/test/com/google/common/collect/ObjectArraysTest.java
+++ b/guava-tests/test/com/google/common/collect/ObjectArraysTest.java
@@ -197,6 +197,24 @@ public class ObjectArraysTest extends TestCase {
     assertThat(result).asList().containsExactly("foo", "bar", "baz").inOrder();
   }
 
+  public void testPrependIncompatibleType_throwsArrayStoreException() {
+    try {
+      Object[] unused = ObjectArrays.concat(0, new String[] {"foo"});
+      fail("Expected ArrayStoreException");
+    } catch (ArrayStoreException expected) {
+      // Expected behavior: cannot store Integer in String[]
+    }
+  }
+
+  public void testAppendIncompatibleType_throwsArrayStoreException() {
+    try {
+      Object[] unused = ObjectArrays.concat(new String[] {"foo"}, 0);
+      fail("Expected ArrayStoreException");
+    } catch (ArrayStoreException expected) {
+      // Expected behavior: cannot store Integer in String[]
+    }
+  }
+
   public void testEmptyArrayToEmpty() {
     doTestNewArrayEquals(new Object[0], 0);
   }

--- a/guava/src/com/google/common/collect/ObjectArrays.java
+++ b/guava/src/com/google/common/collect/ObjectArrays.java
@@ -85,6 +85,8 @@ public final class ObjectArrays {
    * @param array the array of elements to append
    * @return an array whose size is one larger than {@code array}, with {@code element} occupying
    *     the first position, and the elements of {@code array} occupying the remaining elements.
+   * @throws ArrayStoreException if {@code element} is not of a runtime type that can be stored in
+   *     an array of type {@code T[]}
    */
   public static <T extends @Nullable Object> T[] concat(@ParametricNullness T element, T[] array) {
     T[] result = newArray(array, array.length + 1);
@@ -100,6 +102,8 @@ public final class ObjectArrays {
    * @param element the element to append to the end
    * @return an array whose size is one larger than {@code array}, with the same contents as {@code
    *     array}, plus {@code element} occupying the last position.
+   * @throws ArrayStoreException if {@code element} is not of a runtime type that can be stored in
+   *     an array of type {@code T[]}
    */
   public static <T extends @Nullable Object> T[] concat(T[] array, @ParametricNullness T element) {
     T[] result = Arrays.copyOf(array, array.length + 1);


### PR DESCRIPTION
## Summary
- Adds `@throws ArrayStoreException` documentation to `concat(T, T[])` and `concat(T[], T)` methods
- Adds test cases demonstrating when ArrayStoreException occurs
- Updates both JRE and Android versions for consistency

## Motivation
Addresses issue #3768 - these methods can throw `ArrayStoreException` at runtime when incompatible types are passed, but this behavior was not documented in the Javadoc.

## Changes
- **Documentation**: Added `@throws` tags explaining when ArrayStoreException occurs
- **Tests**: Added `testPrependIncompatibleType_throwsArrayStoreException()` and `testAppendIncompatibleType_throwsArrayStoreException()` to verify and document the behavior
- **Scope**: Updated all 4 files (JRE + Android source and tests)

## Related Issue
Closes #3768