### PR TITLE
Optimize getFileExtension by scanning string directly

### DIFF
--- a/guava/src/com/google/common/io/Files.java
+++ b/guava/src/com/google/common/io/Files.java
@@ -794,9 +794,16 @@ public final class Files {
    */
   public static String getFileExtension(String fullName) {
     checkNotNull(fullName);
-    String fileName = new File(fullName).getName();
-    int dotIndex = fileName.lastIndexOf('.');
-    return (dotIndex == -1) ? "" : fileName.substring(dotIndex + 1);
+    for (int i = fullName.length() - 1; i>= 0; i--) {
+      char c = fullName.charAt(i);
+      if (c == '/' || c == '\\') {
+        break;
+      }
+      if (c == '.') {
+        return fullName.substring(i + 1);
+      }
+    }
+    return "";
   }
 
   /**


### PR DESCRIPTION
Avoid creating File object and temporary file name string.
Scan from the end of the path to locate the extension before any path separator.