### PR TITLE
Expose primitive iterators in immutable array list wrappers

### DIFF
--- a/guava-tests/test/com/google/common/primitives/ImmutableDoubleArrayTest.java
+++ b/guava-tests/test/com/google/common/primitives/ImmutableDoubleArrayTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.DoubleStream;
@@ -91,6 +92,16 @@ public class ImmutableDoubleArrayTest extends TestCase {
     assertThat(ImmutableDoubleArray.of(0, 1, 3, 6, 10, 15, 21).asList())
         .containsExactly(0.0, 1.0, 3.0, 6.0, 10.0, 15.0, 21.0)
         .inOrder();
+  }
+
+  public void testAsListIterator() {
+    Iterator<Double> iterator = ImmutableDoubleArray.of(1.0, 2.0, 3.0).asList().iterator();
+    assertThat(iterator).isInstanceOf(PrimitiveIterator.OfDouble.class);
+    PrimitiveIterator.OfDouble doubleIterator = (PrimitiveIterator.OfDouble) iterator;
+    assertThat(doubleIterator.nextDouble()).isEqualTo(1.0);
+    assertThat(doubleIterator.nextDouble()).isEqualTo(2.0);
+    assertThat(doubleIterator.nextDouble()).isEqualTo(3.0);
+    assertThat(doubleIterator.hasNext()).isFalse();
   }
 
   public void testCopyOf_array_empty() {

--- a/guava-tests/test/com/google/common/primitives/ImmutableIntArrayTest.java
+++ b/guava-tests/test/com/google/common/primitives/ImmutableIntArrayTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -89,6 +90,17 @@ public class ImmutableIntArrayTest extends TestCase {
     assertThat(ImmutableIntArray.of(0, 1, 3, 6, 10, 15, 21).asList())
         .containsExactly(0, 1, 3, 6, 10, 15, 21)
         .inOrder();
+  }
+
+  public void testAsListIterator() {
+      Iterator<Integer> iterator = ImmutableIntArray.of(1, 2, 3).asList().iterator();
+      assertThat(iterator).isInstanceOf(PrimitiveIterator.OfInt.class);
+      PrimitiveIterator.OfInt intIterator = (PrimitiveIterator.OfInt) iterator;
+      assertThat(intIterator);
+      assertThat(intIterator.nextInt()).isEqualTo(1);
+      assertThat(intIterator.nextInt()).isEqualTo(2);
+      assertThat(intIterator.nextInt()).isEqualTo(3);
+      assertThat(intIterator.hasNext()).isFalse();
   }
 
   public void testCopyOf_array_empty() {

--- a/guava-tests/test/com/google/common/primitives/ImmutableLongArrayTest.java
+++ b/guava-tests/test/com/google/common/primitives/ImmutableLongArrayTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.LongStream;
@@ -91,6 +92,16 @@ public class ImmutableLongArrayTest extends TestCase {
     assertThat(ImmutableLongArray.of(0, 1, 3, 6, 10, 15, 21).asList())
         .containsExactly(0L, 1L, 3L, 6L, 10L, 15L, 21L)
         .inOrder();
+  }
+
+  public void testAsListIterator() {
+    Iterator<Long> iterator = ImmutableLongArray.of(1, 2, 3).asList().iterator();
+    assertThat(iterator).isInstanceOf(PrimitiveIterator.OfLong.class);
+    PrimitiveIterator.OfLong longIterator = (PrimitiveIterator.OfLong) iterator;
+    assertThat(longIterator.nextLong()).isEqualTo(1);
+    assertThat(longIterator.nextLong()).isEqualTo(2);
+    assertThat(longIterator.nextLong()).isEqualTo(3);
+    assertThat(longIterator.hasNext()).isFalse();
   }
 
   public void testCopyOf_array_empty() {

--- a/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableDoubleArray.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.RandomAccess;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -524,8 +526,13 @@ public final class ImmutableDoubleArray implements Serializable {
 
     // The default List spliterator is not efficiently splittable
     @Override
-    public Spliterator<Double> spliterator() {
+    public Spliterator.OfDouble spliterator() {
       return parent.spliterator();
+    }
+
+    @Override
+    public PrimitiveIterator.OfDouble iterator() {
+      return Spliterators.iterator(spliterator());
     }
 
     @Override

--- a/guava/src/com/google/common/primitives/ImmutableIntArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableIntArray.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.RandomAccess;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -519,8 +521,13 @@ public final class ImmutableIntArray implements Serializable {
 
     // The default List spliterator is not efficiently splittable
     @Override
-    public Spliterator<Integer> spliterator() {
+    public Spliterator.OfInt spliterator() {
       return parent.spliterator();
+    }
+
+    @Override
+    public PrimitiveIterator.OfInt iterator() {
+      return Spliterators.iterator(spliterator());
     }
 
     @Override

--- a/guava/src/com/google/common/primitives/ImmutableLongArray.java
+++ b/guava/src/com/google/common/primitives/ImmutableLongArray.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.RandomAccess;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -521,8 +523,13 @@ public final class ImmutableLongArray implements Serializable {
 
     // The default List spliterator is not efficiently splittable
     @Override
-    public Spliterator<Long> spliterator() {
+    public Spliterator.OfLong spliterator() {
       return parent.spliterator();
+    }
+
+    @Override
+    public PrimitiveIterator.OfLong iterator() {
+      return Spliterators.iterator(spliterator());
     }
 
     @Override


### PR DESCRIPTION
Override the default iterator method for the AsList wrappers to return the corresponding PrimitiveIterator for ImmutableIntArray, ImmutableLongArray, and ImmutableDoubleArray.

Resolves #8108