### PR TITLE
just one file/update: use `string.isEmpty()` replace to `string.length == 0`

### DIFF
--- a/guava/src/com/google/common/primitives/ParseRequest.java
+++ b/guava/src/com/google/common/primitives/ParseRequest.java
@@ -28,7 +28,7 @@ final class ParseRequest {
   }
 
   static ParseRequest fromString(String stringValue) {
-    if (stringValue.length() == 0) {
+    if (stringValue.isEmpty()) {
       throw new NumberFormatException("empty string");
     }
 


### PR DESCRIPTION
Hi guys,

I've noticed that Guava consistently uses `string.length() == 0` instead of `string.isEmpty()`. I'm curious about the reasoning behind this coding style.

After doing some research, I've gathered a few potential reasons:

1. **Android Compatibility**: Guava needs to maintain support for older Android versions while staying on a Java 8 baseline.
2. **Performance**: `length() == 0` might be a more direct property check in some older environments.
3. **No-churn Policy**: The team generally discourages "refactoring for style only" to avoid unnecessary code churn.

However, I'm wondering if there are other factors, such as limited time or bandwidth for such updates. If that’s the case, I’d be happy to help with some minor cleanups—not a massive refactor, just small, focused improvements.

Also, I saw this [line](https://github.com/google/guava/blob/fb062c0da22c2f38ff0c6f411df8683d8ee144f6/guava/src/com/google/common/base/Splitter.java#L167), I understand that don't need replacing it with `!separator.isEmpty()`

```
checkArgument(separator.length() != 0, "xxxxxxx");
```

I apologize if this has been discussed before (I couldn't find the exact issue). I would love to hear your thoughts on this.

Thanks in advance!