### PR TITLE
Fix resource leak in FakeTickerTest (Issue #8152)

### DIFF
--- a/guava-testlib/test/com/google/common/testing/FakeTickerTest.java
+++ b/guava-testlib/test/com/google/common/testing/FakeTickerTest.java
@@ -164,8 +164,7 @@ public class FakeTickerTest extends TestCase {
   @GwtIncompatible // concurrency
   private void runConcurrentTest(int numberOfThreads, Callable<@Nullable Void> callable)
           throws Exception {
-    ExecutorService executorService = newFixedThreadPool(numberOfThreads);
-    try { //   1.  <---try
+    try (ExecutorService executorService = newFixedThreadPool(numberOfThreads)) {
       CountDownLatch startLatch = new CountDownLatch(numberOfThreads);
       CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
       for (int i = numberOfThreads; i > 0; i--) {
@@ -184,8 +183,6 @@ public class FakeTickerTest extends TestCase {
                         });
       }
       doneLatch.await();
-    } finally {     // 2.  <---finally
-      executorService.shutdown();
     }
   }
 }


### PR DESCRIPTION
**Description**
As discussed in Issue #8152, the `ExecutorService` in `FakeTickerTest` was created but never shut down, leading to potential thread leaks.

**Changes**
- Wrapped the test execution logic in a `try-finally` block.
- Added `executorService.shutdown()` in the `finally` block to ensure threads are released even if the test fails.

**Link to Issue**
Fixes #8152