### PR TITLE
collect: Return null from Spliterator.getComparator() for natural ordering

### DIFF
--- a/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.Spliterator;
 import java.util.TreeSet;
 import java.util.function.BiPredicate;
 import java.util.stream.Collector;
@@ -1224,5 +1225,34 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     ImmutableSortedSet<Integer> unused = builder.build();
     assertThat(compares[0]).isAtMost(10000);
     // hopefully something quadratic would have more digits
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testSpliteratorComparator_naturalOrdering() {
+    // Per Spliterator.getComparator() contract, null indicates natural ordering
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.of(1, 2, 3);
+    Spliterator<Integer> spliterator = set.spliterator();
+    assertThat(spliterator.hasCharacteristics(Spliterator.SORTED)).isTrue();
+    assertThat(spliterator.getComparator()).isNull();
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testSpliteratorComparator_customComparator() {
+    // Custom comparator should be returned from getComparator()
+    Comparator<Integer> comparator = Comparator.reverseOrder();
+    ImmutableSortedSet<Integer> set =
+        ImmutableSortedSet.orderedBy(comparator).add(1, 2, 3).build();
+    Spliterator<Integer> spliterator = set.spliterator();
+    assertThat(spliterator.hasCharacteristics(Spliterator.SORTED)).isTrue();
+    assertThat(spliterator.getComparator()).isEqualTo(comparator);
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testAsListSpliteratorComparator_naturalOrdering() {
+    // asList().spliterator() should also return null for natural ordering
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.of(1, 2, 3);
+    Spliterator<Integer> spliterator = set.asList().spliterator();
+    assertThat(spliterator.hasCharacteristics(Spliterator.SORTED)).isTrue();
+    assertThat(spliterator.getComparator()).isNull();
   }
 }

--- a/guava/src/com/google/common/collect/CollectSpliterators.java
+++ b/guava/src/com/google/common/collect/CollectSpliterators.java
@@ -53,6 +53,11 @@ final class CollectSpliterators {
     if (comparator != null) {
       checkArgument((extraCharacteristics & Spliterator.SORTED) != 0);
     }
+    // Per Spliterator.getComparator() contract, return null for natural ordering
+    @Nullable Comparator<? super T> spliteratorComparator =
+        (comparator == Ordering.natural() || comparator == Comparator.naturalOrder())
+            ? null
+            : comparator;
     final class WithCharacteristics implements Spliterator<T> {
       private final Spliterator.OfInt delegate;
 
@@ -92,7 +97,7 @@ final class CollectSpliterators {
       @Override
       public @Nullable Comparator<? super T> getComparator() {
         if (hasCharacteristics(Spliterator.SORTED)) {
-          return comparator;
+          return spliteratorComparator;
         } else {
           throw new IllegalStateException();
         }

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -833,6 +833,9 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
 
       @Override
       public Comparator<? super E> getComparator() {
+        if (comparator == Ordering.natural() || comparator == Comparator.naturalOrder()) {
+          return null;
+        }
         return comparator;
       }
     };


### PR DESCRIPTION
## Summary
- Return `null` from `Spliterator.getComparator()` when comparator is natural ordering
- Check for both `Ordering.natural()` and `Comparator.naturalOrder()` (both singletons)
- Apply fix to `ImmutableSortedSet.spliterator()` and `CollectSpliterators.indexed()`
- Add unit tests for the new behavior

## Motivation
Per the [Spliterator.getComparator() contract](https://docs.oracle.com/javase/8/docs/api/java/util/Spliterator.html#getComparator--), `null` should be returned to indicate natural ordering. The JDK stream implementation [clears the SORTED flag](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/stream/StreamOpFlag.java#L751-L755) when `getComparator()` returns non-null, which [prevents the sorted() optimization](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/stream/SortedOps.java#L136-L139).

This causes unnecessary sorting when calling `stream().sorted()` on naturally-ordered `ImmutableSortedSet`:

```java
ImmutableSortedSet<Integer> sortedSet = ImmutableSortedSet.of(1, 2, 3, 4);
// sorted() should be a no-op, but wasn't because getComparator() returned Ordering.natural()
sortedSet.stream().sorted().collect(Collectors.toList());
```

Fixes #6187

## Testing
Added 3 unit tests to `ImmutableSortedSetTest`:
- `testSpliteratorComparator_naturalOrdering` - verifies `getComparator()` returns null for natural ordering
- `testSpliteratorComparator_customComparator` - verifies custom comparator is returned
- `testAsListSpliteratorComparator_naturalOrdering` - verifies `asList().spliterator()` also returns null

Also verified locally that stream sorted() optimization now works correctly.