### PR TITLE
ImmutableBiMap: Mark GWT inverse field as transient for GWT-RPC

### DIFF
--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/RegularImmutableBiMap.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/RegularImmutableBiMap.java
@@ -29,7 +29,7 @@ final class RegularImmutableBiMap<K, V> extends ImmutableBiMap<K, V> {
   static final RegularImmutableBiMap<Object, Object> EMPTY =
       new RegularImmutableBiMap<Object, Object>();
 
-  private final ImmutableBiMap<V, K> inverse;
+  private final transient ImmutableBiMap<V, K> inverse;
 
   @SuppressWarnings("unchecked") // used only for the empty map, which works for any types
   RegularImmutableBiMap() {


### PR DESCRIPTION
## Summary
- Marked the `inverse` field in GWT's `RegularImmutableBiMap` as `transient`
- Aligns GWT version with main guava and android versions (which already have `transient`)
- Eliminates GWT-RPC serialization warnings about circular references

## Motivation
GWT-RPC generates warnings when a Map is used in an RPC service interface because the `inverse` field creates a circular reference that GWT-RPC attempts to serialize. The field should be marked `transient` since:
1. It's a circular reference to the inverse bimap
2. It can be reconstructed when accessed via `inverse()`
3. Main guava and android versions already use `transient` for this field

Fixes #8168

## Testing
- Standalone serialization tests passed
- Verified alignment with main guava and android implementations
- Checked that no other GWT BiMap implementations need similar fixes