### PR TITLE
Semgrep Rule Fix

### DIFF
--- a/android/guava-tests/benchmark/com/google/common/base/EnumsBenchmark.java
+++ b/android/guava-tests/benchmark/com/google/common/base/EnumsBenchmark.java
@@ -45,6 +45,11 @@ public class EnumsBenchmark {
   void setUp() throws ClassNotFoundException {
     Preconditions.checkArgument(hitRate >= 0 && hitRate <= 1, "hitRate must be in the range [0,1]");
 
+    // Validate enumSize to prevent unsafe reflection
+    if (!"Small".equals(enumSize) && !"Medium".equals(enumSize) && !"Large".equals(enumSize)) {
+      throw new IllegalArgumentException("enumSize must be one of: Small, Medium, Large");
+    }
+
     enumType =
         Class.forName(EnumsBenchmark.class.getCanonicalName() + "$" + enumSize + "Enum")
             .asSubclass(Enum.class);

--- a/guava-tests/benchmark/com/google/common/base/EnumsBenchmark.java
+++ b/guava-tests/benchmark/com/google/common/base/EnumsBenchmark.java
@@ -45,6 +45,11 @@ public class EnumsBenchmark {
   void setUp() throws ClassNotFoundException {
     Preconditions.checkArgument(hitRate >= 0 && hitRate <= 1, "hitRate must be in the range [0,1]");
 
+    // Validate enumSize to prevent unsafe reflection
+    if (!"Small".equals(enumSize) && !"Medium".equals(enumSize) && !"Large".equals(enumSize)) {
+      throw new IllegalArgumentException("enumSize must be one of: Small, Medium, Large");
+    }
+
     enumType =
         Class.forName(EnumsBenchmark.class.getCanonicalName() + "$" + enumSize + "Enum")
             .asSubclass(Enum.class);


### PR DESCRIPTION

We have used our AI-Guardian product to identify and remediate a Semgrep rule violation

  ```
  Rule ID: unsafe-reflection
    Rule Message: If an attacker can supply values that the application then uses to determine which class to instantiate or which method to invoke, the potential exists for the attacker to create control flow paths through the application that were not intended by the application developers. This attack vector may allow the attacker to bypass authentication or access control checks or otherwise cause the application to behave in an unexpected manner.
    File Path: /tools/scanResult/unzipped-271687943/android/guava-tests/benchmark/com/google/common/base/EnumsBenchmark.java
    Line: 49
```


<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
