### PR TITLE
MoreObjects: Document requireNonNullElseGet in firstNonNull Javadoc

### DIFF
--- a/guava/src/com/google/common/base/MoreObjects.java
+++ b/guava/src/com/google/common/base/MoreObjects.java
@@ -54,7 +54,8 @@ public final class MoreObjects {
    * first.or(supplier)}.
    *
    * <p><b>Java 9 users:</b> use {@code java.util.Objects.requireNonNullElse(first, second)}
-   * instead.
+   * instead. For lazy evaluation of the fallback, use {@code
+   * java.util.Objects.requireNonNullElseGet(first, supplier)}.
    *
    * @return {@code first} if it is non-null; otherwise {@code second} if it is non-null
    * @throws NullPointerException if both {@code first} and {@code second} are null


### PR DESCRIPTION
## Summary
- Add mention of `java.util.Objects.requireNonNullElseGet` as the lazy evaluation alternative for Java 9+ users in `MoreObjects.firstNonNull` Javadoc

## Motivation
The current Javadoc mentions `requireNonNullElse` for Java 9 users but doesn't mention the lazy `Supplier`-based variant `requireNonNullElseGet`. Per maintainer comment on the issue, this should be documented.

Fixes #6283

## Testing
- Javadoc-only change, compilation verified