### PR TITLE
Maps: Avoid double iteration in uniqueIndex for FilteredCollection

### DIFF
--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -1324,7 +1324,12 @@ public final class Maps {
   @CanIgnoreReturnValue
   public static <K, V> ImmutableMap<K, V> uniqueIndex(
       Iterable<V> values, Function<? super V, K> keyFunction) {
-    if (values instanceof Collection) {
+    // Avoid calling size() on FilteredCollection or FilteredMultimapValues, as their size()
+    // methods iterate through all elements, causing double iteration when combined with
+    // the subsequent uniqueIndex iteration.
+    if (values instanceof Collection
+        && !(values instanceof Collections2.FilteredCollection)
+        && !(values instanceof FilteredMultimapValues)) {
       return uniqueIndex(
           values.iterator(),
           keyFunction,


### PR DESCRIPTION
## Summary
- Skip pre-sizing optimization in `Maps.uniqueIndex` when input is `FilteredCollection` or `FilteredMultimapValues`
- Prevents double iteration since these classes have O(n) `size()` methods

## Motivation
`Maps.uniqueIndex` calls `size()` on `Collection` inputs to pre-size the builder. However, `FilteredCollection.size()` and `FilteredMultimapValues.size()` iterate through all elements applying the predicate. This causes the predicate to be evaluated twice:
1. Once during `size()` call
2. Once during iteration to build the map

This fix skips the pre-sizing optimization for these filtered views, avoiding the double iteration.

Fixes #6638

## Testing
- Standalone test verified predicate is called once per element (4 calls), not twice (8 calls)
- Basic functionality verified with normal collections