### PR TITLE
Make BloomFilter.bitSize() public

### DIFF
--- a/android/guava-tests/test/com/google/common/hash/BloomFilterTest.java
+++ b/android/guava-tests/test/com/google/common/hash/BloomFilterTest.java
@@ -353,6 +353,47 @@ public class BloomFilterTest extends TestCase {
     }
   }
 
+  /**
+   * Tests that bitSize() can be used to predict the serialization size produced by writeTo().
+   *
+   * <p>The serialization format consists of a 6-byte header (1 byte strategy, 1 byte hash
+   * functions, 4 bytes array length) followed by the bit array data (bitSize / 8 bytes).
+   */
+  public void testBitSizeMatchesSerializationSize() throws Exception {
+    int[] expectedInsertionValues = {1, 10, 100, 1000, 10000};
+    double[] fppValues = {0.01, 0.03, 0.1};
+
+    for (int expectedInsertions : expectedInsertionValues) {
+      for (double fpp : fppValues) {
+        BloomFilter<String> bf =
+            BloomFilter.create(Funnels.unencodedCharsFunnel(), expectedInsertions, fpp);
+
+        // Add some elements
+        for (int i = 0; i < expectedInsertions / 2; i++) {
+          bf.put("element" + i);
+        }
+
+        // Calculate expected size based on bitSize()
+        // Header: 1 byte (strategy) + 1 byte (hash functions) + 4 bytes (array length) = 6 bytes
+        // Data: bitSize / 8 bytes
+        long predictedSize = bf.bitSize() / 8 + 6;
+
+        // Serialize and measure actual size
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        bf.writeTo(out);
+        int actualSize = out.size();
+
+        assertEquals(
+            "Serialization size mismatch for expectedInsertions="
+                + expectedInsertions
+                + " fpp="
+                + fpp,
+            predictedSize,
+            actualSize);
+      }
+    }
+  }
+
   public void testApproximateElementCount() {
     int numInsertions = 1000;
     BloomFilter<Integer> bf = BloomFilter.create(Funnels.integerFunnel(), numInsertions);

--- a/android/guava/src/com/google/common/hash/BloomFilter.java
+++ b/android/guava/src/com/google/common/hash/BloomFilter.java
@@ -220,9 +220,17 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
         -Math.log1p(-fractionOfBitsSet) * bitSize / numHashFunctions, RoundingMode.HALF_UP);
   }
 
-  /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  /**
+   * Returns the number of bits in the underlying bit array.
+   *
+   * <p>This can be useful when pre-allocating space for serialization. The number of bytes written
+   * by {@link #writeTo(OutputStream)} is {@code bitSize() / 8 + 6} (6 bytes for the header: 1 byte
+   * for the strategy, 1 byte for the number of hash functions, and 4 bytes for the array length).
+   *
+   * @return the number of bits in this Bloom filter's underlying bit array
+   * @since 35.0
+   */
+  public long bitSize() {
     return bits.bitSize();
   }
 

--- a/guava-tests/test/com/google/common/hash/BloomFilterTest.java
+++ b/guava-tests/test/com/google/common/hash/BloomFilterTest.java
@@ -355,6 +355,47 @@ public class BloomFilterTest extends TestCase {
     }
   }
 
+  /**
+   * Tests that bitSize() can be used to predict the serialization size produced by writeTo().
+   *
+   * <p>The serialization format consists of a 6-byte header (1 byte strategy, 1 byte hash
+   * functions, 4 bytes array length) followed by the bit array data (bitSize / 8 bytes).
+   */
+  public void testBitSizeMatchesSerializationSize() throws Exception {
+    int[] expectedInsertionValues = {1, 10, 100, 1000, 10000};
+    double[] fppValues = {0.01, 0.03, 0.1};
+
+    for (int expectedInsertions : expectedInsertionValues) {
+      for (double fpp : fppValues) {
+        BloomFilter<String> bf =
+            BloomFilter.create(Funnels.unencodedCharsFunnel(), expectedInsertions, fpp);
+
+        // Add some elements
+        for (int i = 0; i < expectedInsertions / 2; i++) {
+          bf.put("element" + i);
+        }
+
+        // Calculate expected size based on bitSize()
+        // Header: 1 byte (strategy) + 1 byte (hash functions) + 4 bytes (array length) = 6 bytes
+        // Data: bitSize / 8 bytes
+        long predictedSize = bf.bitSize() / 8 + 6;
+
+        // Serialize and measure actual size
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        bf.writeTo(out);
+        int actualSize = out.size();
+
+        assertEquals(
+            "Serialization size mismatch for expectedInsertions="
+                + expectedInsertions
+                + " fpp="
+                + fpp,
+            predictedSize,
+            actualSize);
+      }
+    }
+  }
+
   public void testApproximateElementCount() {
     int numInsertions = 1000;
     BloomFilter<Integer> bf = BloomFilter.create(Funnels.integerFunnel(), numInsertions);

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -232,9 +232,17 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
         -Math.log1p(-fractionOfBitsSet) * bitSize / numHashFunctions, RoundingMode.HALF_UP);
   }
 
-  /** Returns the number of bits in the underlying bit array. */
-  @VisibleForTesting
-  long bitSize() {
+  /**
+   * Returns the number of bits in the underlying bit array.
+   *
+   * <p>This can be useful when pre-allocating space for serialization. The number of bytes written
+   * by {@link #writeTo(OutputStream)} is {@code bitSize() / 8 + 6} (6 bytes for the header: 1 byte
+   * for the strategy, 1 byte for the number of hash functions, and 4 bytes for the array length).
+   *
+   * @return the number of bits in this Bloom filter's underlying bit array
+   * @since 35.0
+   */
+  public long bitSize() {
     return bits.bitSize();
   }
 


### PR DESCRIPTION
## Summary

This PR makes the existing `bitSize()` method in `BloomFilter` public. Previously it was package-private with `@VisibleForTesting`.

### Motivation

Users who embed Bloom filters in custom file formats need to know the serialization size before writing to pre-allocate space (e.g., for memory-mapped files or fixed-size records). Currently the only way to determine the size is to actually serialize the filter, which is inefficient.

### Changes

- Changed `bitSize()` visibility from package-private to `public`
- Removed `@VisibleForTesting` annotation
- Added comprehensive Javadoc explaining:
  - The method's purpose
  - How to calculate serialization size: `bitSize() / 8 + 6` bytes
  - The 6-byte header breakdown (1 byte strategy, 1 byte hash functions, 4 bytes array length)
- Added `@since 35.0` annotation
- Applied changes to both JRE and Android flavors

### Tests

Added `testBitSizeMatchesSerializationSize()` test that verifies `bitSize()` correctly predicts the `writeTo()` output size across various configurations.

## Test plan

- [x] New test `testBitSizeMatchesSerializationSize()` validates the size calculation formula
- [x] Existing `testBitSize()` test continues to pass (now testing public API)
- [ ] Run full Guava test suite

Fixes #6866