### PR TITLE
Clarify InetAddresses.forString() IPv4-mapped IPv6 behavior

### DIFF
--- a/guava/src/com/google/common/net/InetAddresses.java
+++ b/guava/src/com/google/common/net/InetAddresses.java
@@ -137,6 +137,10 @@ public final class InetAddresses {
    *
    * <p>This deliberately avoids all nameservice lookups (e.g. no DNS).
    *
+   * <p>IPv4-mapped IPv6 addresses (e.g. {@code "::ffff:192.168.0.1"}) are returned as {@link
+   * Inet4Address} objects, not {@link Inet6Address}. This is consistent with the behavior of
+   * {@link InetAddress}. 
+   * 
    * <p>This method accepts non-ASCII digits, for example {@code "１９２.１６８.０.１"} (those are fullwidth
    * characters). That is consistent with {@link InetAddress}, but not with various RFCs. If you
    * want to accept ASCII digits only, you can use something like {@code


### PR DESCRIPTION
Explicitly state in the Javadoc that IPv4-mapped IPv6 addresses (e.g., "::ffff:192.168.0.1") are returned as Inet4Address instances. This aligns with the behavior of java.net.InetAddress but is a common source of confusion for users expecting Inet6Address.

Fixes #8158

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
