### PR TITLE
Fix confusing Javadoc of memoizeWithExpiration

### DIFF
--- a/android/guava/src/com/google/common/base/Suppliers.java
+++ b/android/guava/src/com/google/common/base/Suppliers.java
@@ -221,10 +221,10 @@ public final class Suppliers {
   }
 
   /**
-   * Returns a supplier that caches the instance supplied by the delegate and removes the cached
-   * value after the specified time has passed. Subsequent calls to {@code get()} return the cached
-   * value if the expiration time has not passed. After the expiration time, a new value is
-   * retrieved, cached, and returned. See: <a
+   * Returns a supplier that caches the instance supplied by the delegate. Subsequent calls to
+   * {@code get()} return the cached value if the expiration time has not passed. Once the
+   * expiration time has passed, the next call to {@code get()} will retrieve a new value, cache it,
+   * and return it. See: <a
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the
@@ -250,10 +250,10 @@ public final class Suppliers {
   }
 
   /**
-   * Returns a supplier that caches the instance supplied by the delegate and removes the cached
-   * value after the specified time has passed. Subsequent calls to {@code get()} return the cached
-   * value if the expiration time has not passed. After the expiration time, a new value is
-   * retrieved, cached, and returned. See: <a
+   * Returns a supplier that caches the instance supplied by the delegate. Subsequent calls to
+   * {@code get()} return the cached value if the expiration time has not passed. Once the
+   * expiration time has passed, the next call to {@code get()} will retrieve a new value, cache it,
+   * and return it. See: <a
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the

--- a/guava/src/com/google/common/base/Suppliers.java
+++ b/guava/src/com/google/common/base/Suppliers.java
@@ -221,10 +221,10 @@ public final class Suppliers {
   }
 
   /**
-   * Returns a supplier that caches the instance supplied by the delegate and removes the cached
-   * value after the specified time has passed. Subsequent calls to {@code get()} return the cached
-   * value if the expiration time has not passed. After the expiration time, a new value is
-   * retrieved, cached, and returned. See: <a
+   * Returns a supplier that caches the instance supplied by the delegate. Subsequent calls to
+   * {@code get()} return the cached value if the expiration time has not passed. Once the
+   * expiration time has passed, the next call to {@code get()} will retrieve a new value, cache it,
+   * and return it. See: <a
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the
@@ -250,10 +250,10 @@ public final class Suppliers {
   }
 
   /**
-   * Returns a supplier that caches the instance supplied by the delegate and removes the cached
-   * value after the specified time has passed. Subsequent calls to {@code get()} return the cached
-   * value if the expiration time has not passed. After the expiration time, a new value is
-   * retrieved, cached, and returned. See: <a
+   * Returns a supplier that caches the instance supplied by the delegate. Subsequent calls to
+   * {@code get()} return the cached value if the expiration time has not passed. Once the
+   * expiration time has passed, the next call to {@code get()} will retrieve a new value, cache it,
+   * and return it. See: <a
    * href="http://en.wikipedia.org/wiki/Memoization">memoization</a>
    *
    * <p>The returned supplier is thread-safe. The supplier's serialized form does not contain the


### PR DESCRIPTION
Fixes #5812. Clarifies that the expiration check and value retrieval happen only when get() is called, not automatically in the background.