### PR TITLE
Document that ImmutableTable comparators affect ordering, not lookup

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableTable.java
+++ b/guava/src/com/google/common/collect/ImmutableTable.java
@@ -199,14 +199,26 @@ public abstract class ImmutableTable<R, C, V> extends AbstractTable<R, C, V>
      */
     public Builder() {}
 
-    /** Specifies the ordering of the generated table's rows. */
+    /**
+     * Specifies the ordering of the generated table's rows.
+     *
+     * <p>The comparator is used only for ordering. Row lookups in the resulting table, including
+     * {@link ImmutableTable#row} and {@link ImmutableTable#rowMap}, still use {@link
+     * Object#equals}.
+     */
     @CanIgnoreReturnValue
     public Builder<R, C, V> orderRowsBy(Comparator<? super R> rowComparator) {
       this.rowComparator = checkNotNull(rowComparator, "rowComparator");
       return this;
     }
 
-    /** Specifies the ordering of the generated table's columns. */
+    /**
+     * Specifies the ordering of the generated table's columns.
+     *
+     * <p>The comparator is used only for ordering. Column lookups in the resulting table, including
+     * {@link ImmutableTable#column} and {@link ImmutableTable#columnMap}, still use {@link
+     * Object#equals}.
+     */
     @CanIgnoreReturnValue
     public Builder<R, C, V> orderColumnsBy(Comparator<? super C> columnComparator) {
       this.columnComparator = checkNotNull(columnComparator, "columnComparator");


### PR DESCRIPTION
Fixes #4010

`ImmutableTable.Builder.orderRowsBy()` and `orderColumnsBy()` accept comparators that control iteration ordering, but row/column lookups in the resulting table still use `Object.equals`. This was undocumented and surprising to users who expected comparator-based lookups (e.g., case-insensitive keys).

This PR adds javadoc to both methods clarifying that comparators affect ordering only, not lookup semantics.

This contribution was developed with AI assistance (Claude Code).