### PR TITLE
Skip testCreateParentDirectories_noPermission when running as root

### DIFF
--- a/guava-tests/test/com/google/common/io/MoreFilesTest.java
+++ b/guava-tests/test/com/google/common/io/MoreFilesTest.java
@@ -300,6 +300,9 @@ public class MoreFilesTest extends TestCase {
     if (isWindows()) {
       return; // TODO: b/136041958 - Create/find a directory that we don't have permissions on?
     }
+    if ("root".equals(System.getProperty("user.name"))) {
+      return; // Root bypasses filesystem permission checks, so the test expectation doesn't hold.
+    }
     Path file = root().resolve("parent/nonexistent.file");
     Path parent = file.getParent();
     assertFalse(Files.exists(parent));


### PR DESCRIPTION
Fixes #7328

`MoreFilesTest.testCreateParentDirectories_noPermission` expects `MoreFiles.createParentDirectories` to throw `IOException` when the parent directory cannot be created due to permissions. However, when running as root, filesystem permission checks are bypassed, so the operation succeeds and the test fails.

This PR adds a root user check that skips the test, matching the existing pattern used for Windows.

This contribution was developed with AI assistance (Claude Code).