### PR TITLE
Document that ImmutableMultimap creation APIs produce ImmutableListMultimap

### DIFF
--- a/guava/src/com/google/common/collect/ImmutableMultimap.java
+++ b/guava/src/com/google/common/collect/ImmutableMultimap.java
@@ -125,6 +125,10 @@ public abstract class ImmutableMultimap<K, V> extends BaseImmutableMultimap<K, V
   /**
    * Returns a new builder. The generated builder is equivalent to the builder created by the {@link
    * Builder} constructor.
+   *
+   * <p>The returned builder always builds an {@link ImmutableListMultimap}. For clarity and to
+   * avoid the pitfalls described in the {@linkplain ImmutableMultimap class documentation}, prefer
+   * {@link ImmutableListMultimap#builder} or {@link ImmutableSetMultimap#builder}.
    */
   public static <K, V> Builder<K, V> builder() {
     return new Builder<>();
@@ -360,7 +364,10 @@ public abstract class ImmutableMultimap<K, V> extends BaseImmutableMultimap<K, V
       return this;
     }
 
-    /** Returns a newly-created immutable multimap. */
+    /**
+     * Returns a newly-created immutable multimap. The returned multimap is an {@link
+     * ImmutableListMultimap}.
+     */
     public ImmutableMultimap<K, V> build() {
       if (builderMap == null) {
         return ImmutableListMultimap.of();


### PR DESCRIPTION
Fixes #5888

`ImmutableMultimap.builder()` and `build()` produce `ImmutableListMultimap` instances, but this was undocumented. Users were confused about which concrete type they would get, especially since the class-level javadoc warns against using `ImmutableMultimap` directly.

This PR:
- Documents on `builder()` that it always produces `ImmutableListMultimap` and recommends using `ImmutableListMultimap.builder()` or `ImmutableSetMultimap.builder()` for clarity
- Documents on `build()` that the returned multimap is an `ImmutableListMultimap`

This contribution was developed with AI assistance (Claude Code).