### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Cancel any previous runs for the same branch that are still running.
       - name: 'Cancel previous runs'
-        uses: styfle/cancel-workflow-action@3155a141048f8f89c06b4cdae32e7853e97536bc # 0.13.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
       - name: 'Check out repository'


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `styfle/cancel-workflow-action` | [`3155a14`](https://github.com/styfle/cancel-workflow-action/commit/3155a141048f8f89c06b4cdae32e7853e97536bc) | [`d07a454`](https://github.com/styfle/cancel-workflow-action/commit/d07a454dad7609a92316b57b23c9ccfd4f59af66) | [Diff](https://github.com/styfle/cancel-workflow-action/compare/3155a141048f...d07a454dad76) | ci.yml |

## Release Notes

<details>
<summary>Release notes for styfle/cancel-workflow-action</summary>

### [0.13.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.13.1)

### Patches 

- Fix: update Node.js runtime from 20 to 24: #217

</details>

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.

## Validation Warnings

The following issues were detected by [actionlint](https://github.com/rhysd/actionlint):

- `ci.yml: ../../../../../tmp/tmp53a2875e/guava/.github/workflows/ci.yml:54:9: shellcheck reported issue in this script: SC2086:info:1:64: Double quote to prevent globbing and word splitting [shellcheck]`
- `ci.yml: |`
- `ci.yml: 54 |         run: ./mvnw -B -ntp -Dtoolchain.skip install -U -DskipTests=true -f $ROOT_POM`
