### PR TITLE
fix: EvictingQueue.add() returns false when maxSize is zero

### DIFF
--- a/guava-tests/test/com/google/common/collect/EvictingQueueTest.java
+++ b/guava-tests/test/com/google/common/collect/EvictingQueueTest.java
@@ -47,10 +47,10 @@ public class EvictingQueueTest extends TestCase {
     EvictingQueue<String> queue = EvictingQueue.create(0);
     assertEquals(0, queue.size());
 
-    assertTrue(queue.add("hi"));
+    assertFalse(queue.add("hi"));
     assertEquals(0, queue.size());
 
-    assertTrue(queue.offer("hi"));
+    assertFalse(queue.offer("hi"));
     assertEquals(0, queue.size());
 
     assertFalse(queue.remove("hi"));

--- a/guava/src/com/google/common/collect/EvictingQueue.java
+++ b/guava/src/com/google/common/collect/EvictingQueue.java
@@ -86,7 +86,8 @@ public final class EvictingQueue<E> extends ForwardingQueue<E> implements Serial
    * Adds the given element to this queue. If the queue is currently full, the element at the head
    * of the queue is evicted to make room.
    *
-   * @return {@code true} always
+   * @return {@code true} if the queue was modified as a result of this call, which is always the
+   *     case unless {@code maxSize} is zero
    */
   @Override
   @CanIgnoreReturnValue
@@ -98,14 +99,15 @@ public final class EvictingQueue<E> extends ForwardingQueue<E> implements Serial
    * Adds the given element to this queue. If the queue is currently full, the element at the head
    * of the queue is evicted to make room.
    *
-   * @return {@code true} always
+   * @return {@code true} if the queue was modified as a result of this call, which is always the
+   *     case unless {@code maxSize} is zero
    */
   @Override
   @CanIgnoreReturnValue
   public boolean add(E e) {
     checkNotNull(e); // check before removing
     if (maxSize == 0) {
-      return true;
+      return false;
     }
     if (size() == maxSize) {
       delegate.remove();


### PR DESCRIPTION
## Problem

When `maxSize == 0`, `EvictingQueue.add()` and `offer()` return `true` even though the element is never added to the queue. This violates the `Collection.add()` contract:

> Returns `true` if this collection changed as a result of the call.

**Reproducer:**
```java
EvictingQueue<String> q = EvictingQueue.create(0);
boolean result = q.add("hello"); // returns true (wrong!)
q.contains("hello");              // returns false
```

## Fix

Return `false` from `add()` and `offer()` when `maxSize == 0`, since the collection never changes in that case. Updated the Javadoc and the existing `testCreateWithZeroSize` test to reflect the correct behavior.

Fixes #8243