### PR TITLE
fix: Omit sources from generated Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
               <additionalOption>-XDignore.symbol.file</additionalOption>
               <additionalOption>-Xdoclint:-html</additionalOption>
             </additionalOptions>
+            <linksource>false</linksource>
             <source>8</source>
           </configuration>
           <executions>


### PR DESCRIPTION
Fixes #7597

The maven-javadoc-plugin was embedding source code links into generated Javadoc output. The `linksource` parameter defaults to `true` in some plugin versions, causing source files to be included in the Javadoc artifact. Sets `linksource` to `false` in the `maven-javadoc-plugin` configuration block in `pom.xml` to explicitly disable this behavior. Verified by inspecting the resulting Javadoc output to confirm source files are no longer embedded.