### PR TITLE
Prevent newline (`\n`) in MediaType.parse() quoted parameters (header safety)

### DIFF
--- a/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -379,6 +379,7 @@ public class MediaTypeTest extends TestCase {
     assertThrows(IllegalArgumentException.class, () -> MediaType.parse("text/plain; a=1; b"));
     assertThrows(IllegalArgumentException.class, () -> MediaType.parse("text/plain; a=1; b="));
     assertThrows(IllegalArgumentException.class, () -> MediaType.parse("text/plain; a=\u2025"));
+    assertThrows(IllegalArgumentException.class, () -> MediaType.parse("text/plain; a=\"\n\""));
   }
 
   // https://github.com/google/guava/issues/6663

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -85,7 +85,7 @@ public final class MediaType {
           .and(CharMatcher.isNot(' '))
           .and(CharMatcher.noneOf("()<>@,;:\\\"/[]?="));
 
-  private static final CharMatcher QUOTED_TEXT_MATCHER = ascii().and(CharMatcher.noneOf("\"\\\r"));
+  private static final CharMatcher QUOTED_TEXT_MATCHER = ascii().and(CharMatcher.noneOf("\"\\\r\n"));
 
   /*
    * This matches the same characters as linear-white-space from RFC 822, but we make no effort to


### PR DESCRIPTION
This PR addresses an issue in `MediaType.parse()` where bare line feed (`\n`) characters were permitted within quoted parameter values (e.g., `charset="utf-8\n"`).

While carriage return (`\r`) was already excluded, line feed (`\n`) was not covered by `QUOTED_TEXT_MATCHER`. In scenarios where parsed `MediaType` values are incorporated into HTTP headers without proper sanitization, this behavior could contribute to HTTP header injection risks.

This change updates `QUOTED_TEXT_MATCHER` to also reject `\n`, aligning with safe header construction practices.

Tests have been extended to assert that inputs containing bare `\n` now result in `IllegalArgumentException`.