### PR TITLE
Fix inconsistent weigher() javadoc in CacheBuilder

### DIFF
--- a/android/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/android/guava/src/com/google/common/cache/CacheBuilder.java
@@ -549,10 +549,10 @@ public final class CacheBuilder<K, V> {
 
   /**
    * Specifies the weigher to use in determining the weight of entries. Entry weight is taken into
-   * consideration by {@link #maximumWeight(long)} when determining which entries to evict, and use
-   * of this method requires a corresponding call to {@link #maximumWeight(long)} prior to calling
-   * {@link #build}. Weights are measured and recorded when entries are inserted into the cache, and
-   * are thus effectively static during the lifetime of a cache entry.
+   * consideration by {@link #maximumWeight(long)} when determining whether the cache is over
+   * capacity, and use of this method requires a corresponding call to {@link #maximumWeight(long)}
+   * prior to calling {@link #build}. Weights are measured and recorded when entries are inserted
+   * into the cache, and are thus effectively static during the lifetime of a cache entry.
    *
    * <p>When the weight of an entry is zero it will not be considered for size-based eviction
    * (though it still may be evicted by other means).

--- a/guava/src/com/google/common/cache/CacheBuilder.java
+++ b/guava/src/com/google/common/cache/CacheBuilder.java
@@ -549,10 +549,10 @@ public final class CacheBuilder<K, V> {
 
   /**
    * Specifies the weigher to use in determining the weight of entries. Entry weight is taken into
-   * consideration by {@link #maximumWeight(long)} when determining which entries to evict, and use
-   * of this method requires a corresponding call to {@link #maximumWeight(long)} prior to calling
-   * {@link #build}. Weights are measured and recorded when entries are inserted into the cache, and
-   * are thus effectively static during the lifetime of a cache entry.
+   * consideration by {@link #maximumWeight(long)} when determining whether the cache is over
+   * capacity, and use of this method requires a corresponding call to {@link #maximumWeight(long)}
+   * prior to calling {@link #build}. Weights are measured and recorded when entries are inserted
+   * into the cache, and are thus effectively static during the lifetime of a cache entry.
    *
    * <p>When the weight of an entry is zero it will not be considered for size-based eviction
    * (though it still may be evicted by other means).


### PR DESCRIPTION
## Problem

The `weigher()` javadoc in `CacheBuilder` states that entry weight is used "when determining which entries to evict", contradicting the `maximumWeight()` javadoc which correctly states that "weight is only used to determine whether the cache is over capacity; it has no effect on selecting which entry should be evicted next."

## Root Cause

The `weigher()` javadoc was written with imprecise wording. The implementation in `LocalCache.Segment.getNextEvictable()` confirms that eviction candidate selection is based on access recency (LRU via the `accessQueue`), not entry weight. Weight only affects whether the total capacity threshold has been exceeded, triggering eviction.

## Fix

- Updated the `weigher()` javadoc to say weight is used "when determining whether the cache is over capacity" instead of "when determining which entries to evict"
- Applied the same fix to both JRE and Android variants

## Impact

Javadoc-only change. No behavioral change. Resolves the documented inconsistency between `weigher()` and `maximumWeight()` javadoc.

Fixes #1690