### PR TITLE
Add explicit writeUTF/readUTF javadoc to LittleEndian stream classes

### DIFF
--- a/android/guava/src/com/google/common/io/LittleEndianDataInputStream.java
+++ b/android/guava/src/com/google/common/io/LittleEndianDataInputStream.java
@@ -173,6 +173,16 @@ public final class LittleEndianDataInputStream extends FilterInputStream impleme
     return Double.longBitsToDouble(readLong());
   }
 
+  /**
+   * Reads a string as specified by {@link DataInputStream#readUTF()}.
+   *
+   * <p>The UTF-8 encoded string is prefixed by a 2-byte length in <b>big-endian</b> byte order,
+   * not little-endian. This matches the behavior of {@link DataInputStream} and is not affected by
+   * the little-endian byte order used by other read methods in this class.
+   *
+   * @return the string read from the input stream
+   * @throws IOException if an I/O error occurs
+   */
   @CanIgnoreReturnValue // to skip a field
   @Override
   public String readUTF() throws IOException {

--- a/android/guava/src/com/google/common/io/LittleEndianDataOutputStream.java
+++ b/android/guava/src/com/google/common/io/LittleEndianDataOutputStream.java
@@ -156,6 +156,15 @@ public final class LittleEndianDataOutputStream extends FilterOutputStream imple
     out.write(0xFF & (v >> 8));
   }
 
+  /**
+   * Writes a string as specified by {@link DataOutputStream#writeUTF(String)}.
+   *
+   * <p>The UTF-8 encoded string is prefixed by a 2-byte length in <b>big-endian</b> byte order,
+   * not little-endian. This matches the behavior of {@link DataOutputStream} and is not affected by
+   * the little-endian byte order used by other write methods in this class.
+   *
+   * @throws IOException if an I/O error occurs
+   */
   @Override
   public void writeUTF(String str) throws IOException {
     ((DataOutputStream) out).writeUTF(str);

--- a/guava/src/com/google/common/io/LittleEndianDataInputStream.java
+++ b/guava/src/com/google/common/io/LittleEndianDataInputStream.java
@@ -173,6 +173,16 @@ public final class LittleEndianDataInputStream extends FilterInputStream impleme
     return Double.longBitsToDouble(readLong());
   }
 
+  /**
+   * Reads a string as specified by {@link DataInputStream#readUTF()}.
+   *
+   * <p>The UTF-8 encoded string is prefixed by a 2-byte length in <b>big-endian</b> byte order,
+   * not little-endian. This matches the behavior of {@link DataInputStream} and is not affected by
+   * the little-endian byte order used by other read methods in this class.
+   *
+   * @return the string read from the input stream
+   * @throws IOException if an I/O error occurs
+   */
   @CanIgnoreReturnValue // to skip a field
   @Override
   public String readUTF() throws IOException {

--- a/guava/src/com/google/common/io/LittleEndianDataOutputStream.java
+++ b/guava/src/com/google/common/io/LittleEndianDataOutputStream.java
@@ -156,6 +156,15 @@ public final class LittleEndianDataOutputStream extends FilterOutputStream imple
     out.write(0xFF & (v >> 8));
   }
 
+  /**
+   * Writes a string as specified by {@link DataOutputStream#writeUTF(String)}.
+   *
+   * <p>The UTF-8 encoded string is prefixed by a 2-byte length in <b>big-endian</b> byte order,
+   * not little-endian. This matches the behavior of {@link DataOutputStream} and is not affected by
+   * the little-endian byte order used by other write methods in this class.
+   *
+   * @throws IOException if an I/O error occurs
+   */
   @Override
   public void writeUTF(String str) throws IOException {
     ((DataOutputStream) out).writeUTF(str);


### PR DESCRIPTION
## Problem

`LittleEndianDataOutputStream.writeUTF()` and `LittleEndianDataInputStream.readUTF()` inherit their javadoc from `DataOutput` and `DataInput`. The inherited documentation references `writeShort` and `readUnsignedShort` for the UTF string length prefix encoding, which in these classes use little-endian byte order. However, the actual implementations delegate to standard `DataOutputStream.writeUTF()` and `DataInputStream.readUTF()`, which encode the length prefix in big-endian byte order.

## Root Cause

These methods had no explicit javadoc, so they inherited documentation that became misleading in the context of little-endian stream classes.

## Fix

- Added explicit javadoc to `writeUTF()` in `LittleEndianDataOutputStream` clarifying the big-endian length prefix
- Added explicit javadoc to `readUTF()` in `LittleEndianDataInputStream` clarifying the big-endian length prefix
- Applied to both JRE and Android variants

## Impact

Javadoc-only change. No behavioral change. Prevents users from incorrectly assuming the UTF length prefix is little-endian.

Fixes #1659