### PR TITLE
fix: computeIfAbsent should not update write timestamp for existing entries

### DIFF
--- a/guava-tests/test/com/google/common/cache/LocalCacheTest.java
+++ b/guava-tests/test/com/google/common/cache/LocalCacheTest.java
@@ -795,6 +795,76 @@ public class LocalCacheTest extends TestCase {
     assertThat(notifications).isEmpty();
   }
 
+  public void testComputeIfAbsent_existingEntryWriteTimeNotChanged() {
+    FakeTicker ticker = new FakeTicker();
+    LocalCache<Object, Object> map =
+        makeLocalCache(
+            createCacheBuilder()
+                .concurrencyLevel(1)
+                .ticker(ticker)
+                .expireAfterWrite(10, NANOSECONDS));
+
+    Object key = new Object();
+    Object value = new Object();
+    map.put(key, value);
+    ReferenceEntry<Object, Object> entry = map.getEntry(key);
+    long originalWriteTime = entry.getWriteTime();
+
+    ticker.advance(5, NANOSECONDS);
+
+    // computeIfAbsent on an existing key should NOT update write time
+    Object result = map.computeIfAbsent(key, k -> new Object());
+    assertThat(result).isSameInstanceAs(value);
+    assertThat(entry.getWriteTime()).isEqualTo(originalWriteTime);
+  }
+
+  public void testComputeIfAbsent_existingEntryExpiresAfterWrite() {
+    FakeTicker ticker = new FakeTicker();
+    LocalCache<Object, Object> map =
+        makeLocalCache(
+            createCacheBuilder()
+                .concurrencyLevel(1)
+                .ticker(ticker)
+                .expireAfterWrite(10, NANOSECONDS));
+
+    Object key = new Object();
+    Object value = new Object();
+    map.put(key, value);
+
+    // Repeatedly call computeIfAbsent before expiry
+    for (int i = 0; i < 5; i++) {
+      ticker.advance(3, NANOSECONDS);
+      map.computeIfAbsent(key, k -> new Object());
+    }
+
+    // After 15ns total (> 10ns expiry), the entry must be expired
+    assertThat(map.get(key)).isNull();
+  }
+
+  public void testCompute_returningNewValueUpdatesWriteTime() {
+    FakeTicker ticker = new FakeTicker();
+    LocalCache<Object, Object> map =
+        makeLocalCache(
+            createCacheBuilder()
+                .concurrencyLevel(1)
+                .ticker(ticker)
+                .expireAfterWrite(10, NANOSECONDS));
+
+    Object key = new Object();
+    Object value = new Object();
+    map.put(key, value);
+    ReferenceEntry<Object, Object> entry = map.getEntry(key);
+    long originalWriteTime = entry.getWriteTime();
+
+    ticker.advance(5, NANOSECONDS);
+
+    // compute() that returns a NEW value SHOULD update write time
+    Object newValue = new Object();
+    Object result = map.compute(key, (k, v) -> newValue);
+    assertThat(result).isSameInstanceAs(newValue);
+    assertThat(entry.getWriteTime()).isGreaterThan(originalWriteTime);
+  }
+
   public void testCopyEntry_computing() {
     CountDownLatch startSignal = new CountDownLatch(1);
     CountDownLatch computingSignal = new CountDownLatch(1);

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -2275,7 +2275,16 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
           if (valueReference != null && newValue == valueReference.get()) {
             computingValueReference.set(newValue);
             e.setValueReference(valueReference);
-            recordWrite(e, 0, now); // no change in weight
+            // The value was not changed, so avoid resetting the write timestamp,
+            // which would incorrectly extend the expireAfterWrite deadline (see
+            // https://github.com/google/guava/issues/3700).
+            // We still need to re-add to both queues since the entry was removed
+            // from them above, and update the access time.
+            if (map.recordsAccess()) {
+              e.setAccessTime(now);
+            }
+            accessQueue.add(e);
+            writeQueue.add(e);
             return newValue;
           }
           try {


### PR DESCRIPTION
## Problem

`LocalCache.computeIfAbsent()` incorrectly resets the write timestamp when called on an existing key, even though the value is not changed. This causes `expireAfterWrite` caches to behave like `expireAfterAccess` caches — entries never expire as long as they are accessed via `computeIfAbsent()` at intervals shorter than the write expiry duration.

This is particularly problematic for Spring Boot applications using `@Cacheable` with synchronized access, which delegates to `computeIfAbsent()` internally.

## Root Cause

`computeIfAbsent()` delegates to `Segment.compute()`. When the computed value is the same reference as the existing value (`newValue == valueReference.get()`), the code path at `LocalCache.java:2278` called `recordWrite(e, 0, now)`, which resets the write timestamp via `entry.setWriteTime(now)`. This incorrectly extends the `expireAfterWrite` deadline.

## Fix

Replaced the `recordWrite(e, 0, now)` call with inline logic that:
- Updates the access time (for `expireAfterAccess` correctness)
- Re-adds the entry to both `accessQueue` and `writeQueue` (required because they were removed earlier in the `compute()` method at lines 2251-2252)
- Does NOT reset the write timestamp, preserving the original `expireAfterWrite` deadline

## Tests Added

| Change Point | Test |
|---|---|
| Do not reset write time when value unchanged | `testComputeIfAbsent_existingEntryWriteTimeNotChanged()` — verifies `getWriteTime()` is unchanged after `computeIfAbsent` on existing key |
| Entry properly expires despite repeated computeIfAbsent | `testComputeIfAbsent_existingEntryExpiresAfterWrite()` — verifies entry expires after write duration even with repeated `computeIfAbsent` calls |
| Regression: compute() with new value still updates write time | `testCompute_returningNewValueUpdatesWriteTime()` — verifies that `compute()` returning a new value still correctly updates write time |

## Impact

Only affects the code path in `Segment.compute()` where the computed value is the same reference as the existing value. This path is exercised by `computeIfAbsent()` on existing keys, and also by `compute()`/`computeIfPresent()`/`merge()` when their function returns the existing value unchanged. The new-value and removal paths are unaffected.

Fixes #3700