### PR TITLE
Fix HTTP header injection via unescaped newline in MediaType parameter values

### DIFF
--- a/android/guava/src/com/google/common/net/MediaType.java
+++ b/android/guava/src/com/google/common/net/MediaType.java
@@ -1255,7 +1255,7 @@ public final class MediaType {
     StringBuilder escaped = new StringBuilder(value.length() + 16).append('"');
     for (int i = 0; i < value.length(); i++) {
       char ch = value.charAt(i);
-      if (ch == '\r' || ch == '\\' || ch == '"') {
+      if (ch == '\r' || ch == '\n' || ch == '\\' || ch == '"') {
         escaped.append('\\');
       }
       escaped.append(ch);

--- a/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -494,4 +494,23 @@ public class MediaTypeTest extends TestCase {
             "text/plain; something=\"cr@zy\"; something-else=\"crazy with spaces\";"
                 + " and-another-thing=\"\"; normal-thing=foo");
   }
+
+  public void testEscapeAndQuote_newlineEscaped() {
+    // Newline characters must be escaped in quoted parameter values to prevent
+    // HTTP header injection when MediaType.toString() is used in HTTP headers.
+    MediaType mediaType =
+        MediaType.create("text", "plain").withParameter("param", "value\ninjected");
+    String result = mediaType.toString();
+    // The \n must be backslash-escaped, not present as a raw 0x0A byte
+    assertThat(result).doesNotContain("\n");
+    assertThat(result).isEqualTo("text/plain; param=\"value\\\ninjected\"");
+  }
+
+  public void testEscapeAndQuote_crEscaped() {
+    // Carriage return was already escaped (pre-existing behavior)
+    MediaType mediaType =
+        MediaType.create("text", "plain").withParameter("param", "value\rinjected");
+    String result = mediaType.toString();
+    assertThat(result).doesNotContain("\r");
+  }
 }

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -1255,7 +1255,7 @@ public final class MediaType {
     StringBuilder escaped = new StringBuilder(value.length() + 16).append('"');
     for (int i = 0; i < value.length(); i++) {
       char ch = value.charAt(i);
-      if (ch == '\r' || ch == '\\' || ch == '"') {
+      if (ch == '\r' || ch == '\n' || ch == '\\' || ch == '"') {
         escaped.append('\\');
       }
       escaped.append(ch);


### PR DESCRIPTION
## Summary

`MediaType.escapeAndQuote()` escapes `\r` (0x0D), backslash, and double-quote in quoted parameter values, but does not escape `\n` (0x0A). When `MediaType.toString()` is used to construct HTTP header values (e.g., `Content-Type`), an attacker who controls a parameter value can inject raw newline bytes, enabling HTTP response splitting / header injection.

## Root Cause

In `MediaType.java` line 1258:
```java
if (ch == '\r' || ch == '\\' || ch == '"') {
```

`\n` is missing from the escape set. The `\r` escape demonstrates the developer's awareness of the HTTP header injection threat, but `\n` was omitted — many HTTP servers accept bare `\n` (LF) as a header terminator, not just `\r\n` (CRLF).

## Fix

Add `\n` to the set of characters escaped in `escapeAndQuote()`:
```java
if (ch == '\r' || ch == '\n' || ch == '\\' || ch == '"') {
```

Applied to both `guava/` and `android/guava/` copies.

## Impact

An application that:
1. Accepts user-controlled input for a MediaType parameter (e.g., charset, boundary)
2. Uses `MediaType.withParameter()` with that input
3. Uses `MediaType.toString()` as an HTTP header value

is vulnerable to HTTP response splitting, which can lead to XSS, cache poisoning, or session fixation.

## Test

Added `testEscapeAndQuote_newlineEscaped()` and `testEscapeAndQuote_crEscaped()` to `MediaTypeTest.java`.