### PR TITLE
Fix ClassPathTest#testLocationsFrom_idempotentScan flakiness

### DIFF
--- a/guava-tests/pom.xml
+++ b/guava-tests/pom.xml
@@ -84,6 +84,19 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!--
+            Move the reports directory outside of any directory that ends up on
+            java.class.path. By default, Surefire writes reports to
+            target/surefire-reports/ during test execution, and that directory
+            can appear on java.class.path, causing
+            ClassPathTest.testLocationsFrom_idempotentScan to flake: new report
+            files written between the test's two scanResources() calls make the
+            second scan find files the first scan didn't.
+            See: https://github.com/google/guava/issues/8295
+          -->
+          <reportsDirectory>${project.build.directory}/surefire-reports-classpath-safe</reportsDirectory>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -669,21 +669,13 @@ public final class ClassPath {
 
   // TODO(benyu): Try java.nio.file.Paths#get() when Guava drops JDK 6 support.
   @VisibleForTesting
-//  static File toFile(URL url) {
-//    checkArgument(url.getProtocol().equals("file"));
-//    try {
-//      return new File(url.toURI()); // Accepts escaped characters like %20.
-//    } catch (URISyntaxException e) { // URL.toURI() doesn't escape chars.
-//      return new File(url.getPath()); // Accepts non-escaped chars like space.
-//    }
-//  }
   static File toFile(URL url) {
     checkArgument(url.getProtocol().equals("file"));
     try {
-      return new File(url.toURI());
-    } catch (URISyntaxException e) {
-      // Fallback: decode manually
-      return new File(java.net.URLDecoder.decode(url.getPath(), java.nio.charset.StandardCharsets.UTF_8));
+      return new File(url.toURI()); // Accepts escaped characters like %20.
+    } catch (URISyntaxException e) { // URL.toURI() doesn't escape chars.
+      return new File(url.getPath()); // Accepts non-escaped chars like space.
     }
   }
+
 }

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -669,12 +669,21 @@ public final class ClassPath {
 
   // TODO(benyu): Try java.nio.file.Paths#get() when Guava drops JDK 6 support.
   @VisibleForTesting
+//  static File toFile(URL url) {
+//    checkArgument(url.getProtocol().equals("file"));
+//    try {
+//      return new File(url.toURI()); // Accepts escaped characters like %20.
+//    } catch (URISyntaxException e) { // URL.toURI() doesn't escape chars.
+//      return new File(url.getPath()); // Accepts non-escaped chars like space.
+//    }
+//  }
   static File toFile(URL url) {
     checkArgument(url.getProtocol().equals("file"));
     try {
-      return new File(url.toURI()); // Accepts escaped characters like %20.
-    } catch (URISyntaxException e) { // URL.toURI() doesn't escape chars.
-      return new File(url.getPath()); // Accepts non-escaped chars like space.
+      return new File(url.toURI());
+    } catch (URISyntaxException e) {
+      // Fallback: decode manually
+      return new File(java.net.URLDecoder.decode(url.getPath(), java.nio.charset.StandardCharsets.UTF_8));
     }
   }
 }


### PR DESCRIPTION
Fixes #8295

## Problem
`ClassPathTest.testLocationsFrom_idempotentScan` scans classpath resources
twice and asserts both scans return identical results. It was flaking because:

1. Surefire adds `target/surefire-reports/` to `java.class.path`
2. `redirectTestOutputToFile=true` causes Surefire to write `.txt` and `.xml`
   report files into that directory while tests are still running
3. New report files written between the two `scanResources()` calls cause the
   second scan to find files the first scan didn't

## Fix
Override `reportsDirectory` in `guava-tests/pom.xml` to redirect Surefire's
reports to a directory that does not appear on `java.class.path`, so that
files written mid-run are never visible to the classpath scanner.

This is a Maven-side fix with no changes to test logic, as suggested by
@netdpb in the issue.