### PR TITLE
Fix grammar in Wildcard lower-bound precondition message

### DIFF
--- a/android/guava/src/com/google/common/reflect/Types.java
+++ b/android/guava/src/com/google/common/reflect/Types.java
@@ -63,7 +63,7 @@ final class Types {
     if (componentType instanceof WildcardType) {
       WildcardType wildcard = (WildcardType) componentType;
       Type[] lowerBounds = wildcard.getLowerBounds();
-      checkArgument(lowerBounds.length <= 1, "Wildcard cannot have more than one lower bounds.");
+      checkArgument(lowerBounds.length <= 1, "Wildcard cannot have more than one lower bound.");
       if (lowerBounds.length == 1) {
         return supertypeOf(newArrayType(lowerBounds[0]));
       } else {

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -63,7 +63,7 @@ final class Types {
     if (componentType instanceof WildcardType) {
       WildcardType wildcard = (WildcardType) componentType;
       Type[] lowerBounds = wildcard.getLowerBounds();
-      checkArgument(lowerBounds.length <= 1, "Wildcard cannot have more than one lower bounds.");
+      checkArgument(lowerBounds.length <= 1, "Wildcard cannot have more than one lower bound.");
       if (lowerBounds.length == 1) {
         return supertypeOf(newArrayType(lowerBounds[0]));
       } else {


### PR DESCRIPTION

**Repo:** google/guava (⭐ 49000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Corrects a minor grammatical error in a `checkArgument` precondition message in `Types.newArrayType`. The message read "Wildcard cannot have more than one lower bounds." — "one" requires a singular noun. Changed to "Wildcard cannot have more than one lower bound." in both the `guava` and `android/guava` copies of `com.google.common.reflect.Types`.

## Why
The adjacent precondition for upper bounds already uses the singular form ("Wildcard should have only one upper bound."), so the two sibling messages are now consistent. The message is user-visible via `IllegalArgumentException` when callers pass a malformed `WildcardType` to `Types.newArrayType`, so it benefits from correct grammar.

## Testing
No behavior change — the text of a precondition message has no functional effect. Tests that assert on this exact string (none found via grep in `guava-tests/` or `android/guava-tests/`) would need an update; none exist.

## Risk
Low — string-only change to a precondition message, both mainline and Android variants updated in lockstep.
