### PR TITLE
Fix typos

### DIFF
--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
@@ -187,7 +187,7 @@ public abstract class ImmutableList<E> extends ImmutableCollection<E>
    *
    * <p>The array must be internally created.
    */
-  @SuppressWarnings("unchecked") // caller is reponsible for getting this right
+  @SuppressWarnings("unchecked") // caller is responsible for getting this right
   static <E> ImmutableList<E> asImmutableList(Object[] elements) {
     return unsafeDelegateList((List) Arrays.asList(elements));
   }

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableSortedMap.java
@@ -417,7 +417,7 @@ public final class ImmutableSortedMap<K, V> extends ForwardingImmutableMap<K, V>
 
   @Override
   ImmutableSortedSet<K> createKeySet() {
-    // the keySet() of the delegate is only a Set and TreeMap.navigatableKeySet
+    // the keySet() of the delegate is only a Set and TreeMap.navigableKeySet
     // is not available in GWT yet.  To keep the code simple and code size more,
     // we make a copy here, instead of creating a view of it.
     //

--- a/guava/src/com/google/common/net/HttpHeaders.java
+++ b/guava/src/com/google/common/net/HttpHeaders.java
@@ -395,7 +395,7 @@ public final class HttpHeaders {
 
   /**
    * The HTTP <a href="https://github.com/WICG/nav-speculation/blob/main/no-vary-search.md">{@code
-   * No-Vary-Seearch}</a> header field name.
+   * No-Vary-Search}</a> header field name.
    *
    * @since 32.0.0
    */

--- a/guava/src/com/google/common/util/concurrent/AbstractFutureState.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractFutureState.java
@@ -403,7 +403,7 @@ abstract class AbstractFutureState<V extends @Nullable Object> extends InternalF
    *
    * Additionally, it seems that nestmates do not help with runtime reflection under *Android*, even
    * when we use a newer -source and -target. That doesn't normally matter for AbstractFutureState,
-   * since Android should normally succed in using UnsafeAtomicHelper and thus never even try the
+   * since Android should normally succeed in using UnsafeAtomicHelper and thus never even try the
    * problematic AtomicReferenceFieldUpdaterAtomicHelper code path. However, the same problem *does*
    * matter with AggregateFutureState, which does not have an Unsafe-based helper.
    *

--- a/guava/src/com/google/common/util/concurrent/InterruptibleTask.java
+++ b/guava/src/com/google/common/util/concurrent/InterruptibleTask.java
@@ -214,7 +214,7 @@ abstract class InterruptibleTask<T extends @Nullable Object>
 
   /**
    * Using this as the blocker object allows introspection and debugging tools to see that the
-   * currentRunner thread is blocked on the progress of the interruptor thread, which can help
+   * currentRunner thread is blocked on the progress of the interrupter thread, which can help
    * identify deadlocks.
    */
   @VisibleForTesting


### PR DESCRIPTION
It was done by a script I wrote to find typos based on statistical analysis and when I double checked them, I applied the fixes. I know it's not a big change, just fixing some small things. I hope it's fine.
