### PR TITLE
Add ConcurrentMap spliterator checks

### DIFF
--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -74,6 +74,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -4401,6 +4403,12 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
     @Override
     public void clear() {
       LocalCache.this.clear();
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+      return Spliterators.spliteratorUnknownSize(
+          iterator(), Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
     }
   }
 

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -4456,6 +4456,13 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
     public boolean contains(Object o) {
       return LocalCache.this.containsValue(o);
     }
+
+    @Override
+    @IgnoreJRERequirement // used only from APIs with Java 8 types in them
+    public Spliterator<V> spliterator() {
+      return Spliterators.spliteratorUnknownSize(
+          iterator(), Spliterator.CONCURRENT | Spliterator.NONNULL);
+    }
   }
 
   final class EntrySet extends AbstractCacheSet<Entry<K, V>> {

--- a/android/guava/src/com/google/common/cache/LocalCache.java
+++ b/android/guava/src/com/google/common/cache/LocalCache.java
@@ -4406,6 +4406,7 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
     }
 
     @Override
+    @IgnoreJRERequirement // used only from APIs with Java 8 types in them
     public Spliterator<T> spliterator() {
       return Spliterators.spliteratorUnknownSize(
           iterator(), Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);

--- a/guava-testlib/src/com/google/common/collect/testing/ConcurrentMapTestSuiteBuilder.java
+++ b/guava-testlib/src/com/google/common/collect/testing/ConcurrentMapTestSuiteBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.collect.testing.testers.ConcurrentMapPutIfAbsentTester;
 import com.google.common.collect.testing.testers.ConcurrentMapRemoveTester;
 import com.google.common.collect.testing.testers.ConcurrentMapReplaceEntryTester;
 import com.google.common.collect.testing.testers.ConcurrentMapReplaceTester;
+import com.google.common.collect.testing.testers.ConcurrentMapSpliteratorTester;
 import java.util.List;
 
 /**
@@ -44,7 +45,8 @@ public class ConcurrentMapTestSuiteBuilder<K, V> extends MapTestSuiteBuilder<K, 
           ConcurrentMapPutIfAbsentTester.class,
           ConcurrentMapRemoveTester.class,
           ConcurrentMapReplaceTester.class,
-          ConcurrentMapReplaceEntryTester.class);
+          ConcurrentMapReplaceEntryTester.class,
+          ConcurrentMapSpliteratorTester.class);
 
   @SuppressWarnings("rawtypes") // class literals
   @Override

--- a/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapSpliteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapSpliteratorTester.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect.testing.testers;
+
+import com.google.common.annotations.GwtCompatible;
+import com.google.common.collect.testing.AbstractMapTester;
+import java.util.Spliterator;
+import java.util.concurrent.ConcurrentMap;
+import org.jspecify.annotations.NullMarked;
+import org.junit.Ignore;
+
+/**
+ * A generic JUnit test which tests spliterator characteristics on derived views of a concurrent
+ * map. Can't be invoked directly; please see {@link
+ * com.google.common.collect.testing.ConcurrentMapTestSuiteBuilder}.
+ *
+ * @author Louis Wasserman
+ */
+@GwtCompatible
+@Ignore("test runners must not instantiate and run this directly, only via suites we build")
+// @Ignore affects the Android test runner, which respects JUnit 4 annotations on JUnit 3 tests.
+@SuppressWarnings("JUnit4ClassUsedInJUnit3")
+@NullMarked
+public class ConcurrentMapSpliteratorTester<K, V> extends AbstractMapTester<K, V> {
+  @Override
+  protected ConcurrentMap<K, V> getMap() {
+    return (ConcurrentMap<K, V>) super.getMap();
+  }
+
+  public void testKeySetSpliteratorHasConcurrentCharacteristic() {
+    assertTrue(
+        "keySet spliterator should report CONCURRENT",
+        getMap().keySet().spliterator().hasCharacteristics(Spliterator.CONCURRENT));
+  }
+
+  public void testKeySetSpliteratorDoesNotHaveSizedCharacteristic() {
+    assertFalse(
+        "keySet spliterator should not report SIZED",
+        getMap().keySet().spliterator().hasCharacteristics(Spliterator.SIZED));
+  }
+
+  public void testEntrySetSpliteratorHasConcurrentCharacteristic() {
+    assertTrue(
+        "entrySet spliterator should report CONCURRENT",
+        getMap().entrySet().spliterator().hasCharacteristics(Spliterator.CONCURRENT));
+  }
+
+  public void testEntrySetSpliteratorDoesNotHaveSizedCharacteristic() {
+    assertFalse(
+        "entrySet spliterator should not report SIZED",
+        getMap().entrySet().spliterator().hasCharacteristics(Spliterator.SIZED));
+  }
+}

--- a/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapSpliteratorTester.java
+++ b/guava-testlib/src/com/google/common/collect/testing/testers/ConcurrentMapSpliteratorTester.java
@@ -27,8 +27,6 @@ import org.junit.Ignore;
  * A generic JUnit test which tests spliterator characteristics on derived views of a concurrent
  * map. Can't be invoked directly; please see {@link
  * com.google.common.collect.testing.ConcurrentMapTestSuiteBuilder}.
- *
- * @author Louis Wasserman
  */
 @GwtCompatible
 @Ignore("test runners must not instantiate and run this directly, only via suites we build")

--- a/guava-testlib/test/com/google/common/collect/testing/ConcurrentMapTestSuiteBuilderTest.java
+++ b/guava-testlib/test/com/google/common/collect/testing/ConcurrentMapTestSuiteBuilderTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect.testing;
+
+import com.google.common.collect.ForwardingConcurrentMap;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestFailure;
+import junit.framework.TestResult;
+
+/** Tests for {@link ConcurrentMapTestSuiteBuilder}. */
+@AndroidIncompatible // test-suite builders
+public final class ConcurrentMapTestSuiteBuilderTest extends TestCase {
+  public void testConcurrentHashMapDerivedSetSpliteratorsPass() {
+    TestResult result = runSuite(new ConcurrentHashMapGenerator(), "ConcurrentHashMap");
+
+    assertEquals(0, result.errorCount());
+    assertEquals(0, result.failureCount());
+  }
+
+  public void testConcurrentMapDerivedSetSpliteratorTestsCatchWrongCharacteristics() {
+    TestResult result = runSuite(new BadSpliteratorConcurrentMapGenerator(), "BadConcurrentMap");
+
+    assertEquals(0, result.errorCount());
+
+    List<String> failedTests = failedTests(result);
+    assertTrue(failedTests.toString(), failedTests.size() >= 4);
+    assertContainsFailure(
+        failedTests, "testKeySetSpliteratorHasConcurrentCharacteristic");
+    assertContainsFailure(
+        failedTests, "testKeySetSpliteratorDoesNotHaveSizedCharacteristic");
+    assertContainsFailure(
+        failedTests, "testEntrySetSpliteratorHasConcurrentCharacteristic");
+    assertContainsFailure(
+        failedTests, "testEntrySetSpliteratorDoesNotHaveSizedCharacteristic");
+  }
+
+  private static TestResult runSuite(TestStringMapGenerator generator, String name) {
+    Test suite =
+        ConcurrentMapTestSuiteBuilder.using(generator)
+            .named(name)
+            .withFeatures(
+                MapFeature.GENERAL_PURPOSE,
+                CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                CollectionSize.ONE)
+            .suppressing(new OpenJdk6MapTests().suppressForConcurrentHashMap())
+            .createTestSuite();
+    TestResult result = new TestResult();
+    suite.run(result);
+    return result;
+  }
+
+  private static List<String> failedTests(TestResult result) {
+    List<String> failedTests = new ArrayList<>();
+    for (java.util.Enumeration<TestFailure> failures = result.failures();
+        failures.hasMoreElements(); ) {
+      failedTests.add(failures.nextElement().failedTest().toString());
+    }
+    return failedTests;
+  }
+
+  private static void assertContainsFailure(List<String> failedTests, String testName) {
+    for (String failedTest : failedTests) {
+      if (failedTest.contains(testName)) {
+        return;
+      }
+    }
+    fail("Expected failure for " + testName + " in " + failedTests);
+  }
+
+  private static final class ConcurrentHashMapGenerator extends TestStringMapGenerator {
+    @Override
+    protected Map<String, String> create(Entry<String, String>[] entries) {
+      ConcurrentMap<String, String> map = new ConcurrentHashMap<>();
+      for (Entry<String, String> entry : entries) {
+        map.put(entry.getKey(), entry.getValue());
+      }
+      return map;
+    }
+  }
+
+  private static final class BadSpliteratorConcurrentMapGenerator extends TestStringMapGenerator {
+    @Override
+    protected Map<String, String> create(Entry<String, String>[] entries) {
+      BadSpliteratorConcurrentMap map = new BadSpliteratorConcurrentMap();
+      for (Entry<String, String> entry : entries) {
+        map.put(entry.getKey(), entry.getValue());
+      }
+      return map;
+    }
+  }
+
+  private static final class BadSpliteratorConcurrentMap
+      extends ForwardingConcurrentMap<String, String> {
+    private final ConcurrentMap<String, String> delegate = new ConcurrentHashMap<>();
+
+    @Override
+    protected ConcurrentMap<String, String> delegate() {
+      return delegate;
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return new BadSpliteratorSet<>(delegate.keySet());
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+      return new BadSpliteratorSet<>(delegate.entrySet());
+    }
+  }
+
+  private static final class BadSpliteratorSet<E> extends AbstractSet<E> {
+    private final Set<E> delegate;
+
+    BadSpliteratorSet(Set<E> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+      return delegate.iterator();
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return delegate.contains(o);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      return delegate.remove(o);
+    }
+
+    @Override
+    public void clear() {
+      delegate.clear();
+    }
+
+    @Override
+    public Spliterator<E> spliterator() {
+      return Spliterators.spliterator(iterator(), size(), Spliterator.DISTINCT);
+    }
+  }
+}

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -74,6 +74,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -4545,6 +4547,12 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
     @Override
     public void clear() {
       LocalCache.this.clear();
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+      return Spliterators.spliteratorUnknownSize(
+          iterator(), Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.NONNULL);
     }
   }
 

--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -4622,6 +4622,12 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
     public boolean contains(Object o) {
       return LocalCache.this.containsValue(o);
     }
+
+    @Override
+    public Spliterator<V> spliterator() {
+      return Spliterators.spliteratorUnknownSize(
+          iterator(), Spliterator.CONCURRENT | Spliterator.NONNULL);
+    }
   }
 
   final class EntrySet extends AbstractCacheSet<Entry<K, V>> {


### PR DESCRIPTION
Adds ConcurrentMap-specific testlib coverage for derived keySet and entrySet spliterators, and updates LocalCache to satisfy it in both the JRE and Android source trees.

Fixes #7855

Implementation:
- add a new ConcurrentMapSpliteratorTester that checks keySet() and entrySet() spliterators report CONCURRENT and do not report SIZED
- wire that tester into ConcurrentMapTestSuiteBuilder so ConcurrentMap suites pick it up automatically
- add a focused ConcurrentMapTestSuiteBuilder self-test that verifies both the passing and failing cases
- override LocalCache derived-set spliterators in both JRE and Android variants to use concurrent unknown-size spliterators

Process:
- read and followed the repository guidance and matched the surrounding testlib and cache code style
- kept the scope to the issue and added regression coverage for the new behavior

Validation:
- direct junit.textui.TestRunner execution of com.google.common.collect.testing.ConcurrentMapTestSuiteBuilderTest passed
- direct javac compilation of the changed testlib and LocalCache sources passed
- full Maven test execution was not possible in this environment because Maven project loading failed on unresolved build extensions during local verification