### PR TITLE
Fix grammar typo in AbstractExecutionThreadService Javadoc

### DIFF
--- a/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
+++ b/guava/src/com/google/common/util/concurrent/AbstractExecutionThreadService.java
@@ -127,7 +127,7 @@ public abstract class AbstractExecutionThreadService implements Service {
    * <p>By default this method does nothing.
    *
    * <p>Currently, this method is invoked while holding a lock. If an implementation of this method
-   * blocks, it can prevent this service from changing state. If you need to performing a blocking
+   * blocks, it can prevent this service from changing state. If you need to perform a blocking
    * operation in order to trigger shutdown, consider instead registering a listener and
    * implementing {@code stopping}. Note, however, that {@code stopping} does not run at exactly the
    * same times as {@code triggerShutdown}.


### PR DESCRIPTION
## Summary

Small Javadoc grammar fix in `AbstractExecutionThreadService#triggerShutdown()`.

After "need to", English requires the infinitive base form ("perform"), not the present participle/gerund ("performing"). This corrects the sentence to read naturally.

## Change

```diff
-   * blocks, it can prevent this service from changing state. If you need to performing a blocking
+   * blocks, it can prevent this service from changing state. If you need to perform a blocking
```

Only the `guava/` copy is modified; per `CONTRIBUTING.md`, the mirrored `android/guava/` copy is updated automatically by Google's internal sync.

## Notes

- Javadoc/comment only — no behavior or API change.
- No new tests required (documentation-only change).
- Follows the precedent of recently merged typo PRs such as #8364 / #8365.

Made with [Cursor](https://cursor.com)