### PR TITLE
Fix typo: TreeMap.navigatbleKeySet -> TreeMap.navigableKeySet

### DIFF
--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableSortedMap.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableSortedMap.java
@@ -422,7 +422,7 @@ public final class ImmutableSortedMap<K, V> extends ForwardingImmutableMap<K, V>
     // we make a copy here, instead of creating a view of it.
     //
     // TODO: revisit if it's unbearably slow or when GWT supports
-    // TreeMap.navigatbleKeySet().
+    // TreeMap.navigableKeySet().
     return ImmutableSortedSet.copyOf(comparator, sortedDelegate.keySet());
   }
 


### PR DESCRIPTION
## Summary

Tiny follow-up to the recently merged typo-fix PR [#8364](https://github.com/google/guava/pull/8364) (synced as #8365).

That PR fixed `TreeMap.navigatableKeySet` on one line of a comment in `guava-gwt`'s `ImmutableSortedMap`, but missed the same typo (`navigatbleKeySet`) in the TODO just two lines below it.

## Change

```diff
     // TODO: revisit if it's unbearably slow or when GWT supports
-    // TreeMap.navigatbleKeySet().
+    // TreeMap.navigableKeySet().
```

File: `guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableSortedMap.java`

## Notes

- Comment-only — no behavior or API change.
- No test impact (GWT super-source comment).
- Follows the precedent of PR #8364.

Made with [Cursor](https://cursor.com)