### PR TITLE
Return null from Spliterator.getComparator() for natural ordering (fixes #6187)

### DIFF
--- a/guava-tests/test/com/google/common/collect/CollectSpliteratorsTest.java
+++ b/guava-tests/test/com/google/common/collect/CollectSpliteratorsTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.Ascii;
 import com.google.common.collect.testing.SpliteratorTester;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.stream.DoubleStream;
@@ -110,5 +111,50 @@ public class CollectSpliteratorsTest extends TestCase {
     List<String> actualValues = new ArrayList<>();
     multiset.spliterator().forEachRemaining(actualValues::add);
     assertThat(multiset).containsExactly("a", "a", "a", "b", "c", "c").inOrder();
+  }
+
+  // Regression tests for https://github.com/google/guava/issues/6187.
+
+  public void testIsNaturalOrder_null() {
+    assertThat(CollectSpliterators.isNaturalOrder(null)).isTrue();
+  }
+
+  public void testIsNaturalOrder_orderingNatural() {
+    assertThat(CollectSpliterators.isNaturalOrder(Ordering.natural())).isTrue();
+  }
+
+  public void testIsNaturalOrder_comparatorNaturalOrder() {
+    assertThat(CollectSpliterators.isNaturalOrder(Comparator.naturalOrder())).isTrue();
+  }
+
+  public void testIsNaturalOrder_reverseOrder_false() {
+    assertThat(CollectSpliterators.isNaturalOrder(Comparator.reverseOrder())).isFalse();
+    assertThat(CollectSpliterators.isNaturalOrder(Ordering.natural().reverse())).isFalse();
+  }
+
+  public void testIsNaturalOrder_customComparator_false() {
+    Comparator<Integer> custom = (a, b) -> a - b;
+    assertThat(CollectSpliterators.isNaturalOrder(custom)).isFalse();
+  }
+
+  public void testIndexedSortedSpliterator_naturalOrderReturnsNull() {
+    Spliterator<Integer> spliterator =
+        CollectSpliterators.indexed(
+            3, Spliterator.SORTED, i -> i + 1, Ordering.<Integer>natural());
+    assertThat(spliterator.getComparator()).isNull();
+    assertThat(spliterator.hasCharacteristics(Spliterator.SORTED)).isTrue();
+  }
+
+  public void testIndexedSortedSpliterator_comparatorNaturalOrderReturnsNull() {
+    Spliterator<Integer> spliterator =
+        CollectSpliterators.indexed(3, Spliterator.SORTED, i -> i + 1, Comparator.naturalOrder());
+    assertThat(spliterator.getComparator()).isNull();
+  }
+
+  public void testIndexedSortedSpliterator_customComparatorIsPreserved() {
+    Comparator<Integer> reverse = Comparator.reverseOrder();
+    Spliterator<Integer> spliterator =
+        CollectSpliterators.indexed(3, Spliterator.SORTED, i -> 3 - i, reverse);
+    assertThat(spliterator.getComparator()).isEqualTo(reverse);
   }
 }

--- a/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
+++ b/guava-tests/test/com/google/common/collect/ImmutableSortedSetTest.java
@@ -57,6 +57,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.Spliterator;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
@@ -1219,6 +1220,43 @@ public class ImmutableSortedSetTest extends AbstractImmutableSetTest {
     ImmutableSortedSet<Integer> unused = builder.build();
     assertThat(compares[0]).isAtMost(10000);
     // hopefully something quadratic would have more digits
+  }
+
+  // Regression tests for https://github.com/google/guava/issues/6187:
+  // Spliterator.getComparator() must return null for naturally-ordered sources so that
+  // stream optimizations (e.g. Stream.sorted() as a no-op) kick in.
+
+  public void testSpliteratorGetComparator_naturalOrdering_returnsNull() {
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.of(1, 2, 3, 4);
+    assertThat(set.spliterator().getComparator()).isNull();
+  }
+
+  public void testSpliteratorGetComparator_comparatorNaturalOrder_returnsNull() {
+    ImmutableSortedSet<Integer> set =
+        ImmutableSortedSet.copyOf(Comparator.<Integer>naturalOrder(), asList(1, 2, 3, 4));
+    assertThat(set.spliterator().getComparator()).isNull();
+  }
+
+  public void testSpliteratorGetComparator_customOrdering_returnsComparator() {
+    Comparator<Integer> reverse = Comparator.reverseOrder();
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.copyOf(reverse, asList(1, 2, 3, 4));
+    assertThat(set.spliterator().getComparator()).isEqualTo(reverse);
+  }
+
+  public void testSpliteratorHasSortedCharacteristic() {
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.of(1, 2, 3, 4);
+    assertThat(set.spliterator().hasCharacteristics(Spliterator.SORTED)).isTrue();
+  }
+
+  public void testAsListSpliteratorGetComparator_naturalOrdering_returnsNull() {
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.of(1, 2, 3, 4);
+    assertThat(set.asList().spliterator().getComparator()).isNull();
+  }
+
+  public void testAsListSpliteratorGetComparator_customOrdering_returnsComparator() {
+    Comparator<Integer> reverse = Comparator.reverseOrder();
+    ImmutableSortedSet<Integer> set = ImmutableSortedSet.copyOf(reverse, asList(1, 2, 3, 4));
+    assertThat(set.asList().spliterator().getComparator()).isEqualTo(reverse);
   }
 
   private static <E extends @Nullable Object> SortedSet<E> newTreeSetWithComparator(

--- a/guava/src/com/google/common/collect/CollectSpliterators.java
+++ b/guava/src/com/google/common/collect/CollectSpliterators.java
@@ -40,6 +40,20 @@ import org.jspecify.annotations.Nullable;
 final class CollectSpliterators {
   private CollectSpliterators() {}
 
+  /**
+   * Returns whether {@code comparator} represents the natural ordering of its elements.
+   *
+   * <p>Recognizes the two well-known natural-ordering singletons: {@link Ordering#natural()} and
+   * {@link Comparator#naturalOrder()}.  Any comparator that compares equal to one of these (via
+   * {@link Object#equals}) is treated as natural order so that {@link Spliterator#getComparator()}
+   * can return {@code null} as required by its contract.
+   */
+  static boolean isNaturalOrder(@Nullable Comparator<?> comparator) {
+    return comparator == null
+        || Ordering.natural().equals(comparator)
+        || Comparator.naturalOrder().equals(comparator);
+  }
+
   static <T extends @Nullable Object> Spliterator<T> indexed(
       int size, int extraCharacteristics, IntFunction<T> function) {
     return indexed(size, extraCharacteristics, function, null);
@@ -92,7 +106,10 @@ final class CollectSpliterators {
       @Override
       public @Nullable Comparator<? super T> getComparator() {
         if (hasCharacteristics(Spliterator.SORTED)) {
-          return comparator;
+          // Per Spliterator.getComparator()'s contract, null signals that the source is
+          // sorted in natural order.  Normalizing natural-ordering singletons to null allows
+          // Stream.sorted() to short-circuit instead of re-sorting already-sorted data.
+          return isNaturalOrder(comparator) ? null : comparator;
         } else {
           throw new IllegalStateException();
         }

--- a/guava/src/com/google/common/collect/ImmutableSortedSet.java
+++ b/guava/src/com/google/common/collect/ImmutableSortedSet.java
@@ -832,8 +832,11 @@ public abstract class ImmutableSortedSet<E> extends ImmutableSet.CachingAsList<E
       }
 
       @Override
-      public Comparator<? super E> getComparator() {
-        return comparator;
+      public @Nullable Comparator<? super E> getComparator() {
+        // Per Spliterator.getComparator()'s contract, null signals that the source is sorted in
+        // natural order.  Normalizing natural-ordering singletons to null allows Stream.sorted()
+        // to short-circuit instead of re-sorting already-sorted data.
+        return CollectSpliterators.isNaturalOrder(comparator) ? null : comparator;
       }
     };
   }


### PR DESCRIPTION
Fixes #6187.

## Problem

Per the [`Spliterator.getComparator()` contract](https://docs.oracle.com/javase/8/docs/api/java/util/Spliterator.html#getComparator--), implementations whose source is sorted in natural order must return `null`. The JDK uses this signal to clear the `SORTED` characteristic when the comparator is non-null ([StreamOpFlag line 751-755](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/stream/StreamOpFlag.java#L751-L755)), which in turn disables [`Stream.sorted()`'s short-circuit optimization](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/stream/SortedOps.java#L136-L139), causing unnecessary re-sorting of already-sorted data.

`ImmutableSortedSet.spliterator()` and `CollectSpliterators.indexed()` (used by `ImmutableSortedAsList.spliterator()`, which in turn backs `RegularImmutableSortedSet.spliterator()` and its subset views) returned `Ordering.natural()` instead of `null` for naturally-ordered sources, so code like:

```java
ImmutableSortedSet.of(1, 2, 3, 4).stream().sorted().collect(toList());
```

incurred a full re-sort rather than the documented no-op.

## Fix

- Added `CollectSpliterators.isNaturalOrder(Comparator)`, a shared helper that recognizes the two well-known natural-ordering singletons (`Ordering.natural()` and `Comparator.naturalOrder()`) as well as `null`.
- `CollectSpliterators.indexed()` and `ImmutableSortedSet.spliterator()` now normalize natural-ordering comparators to `null` at the `getComparator()` boundary. Custom and reverse-order comparators are preserved unchanged, so `DescendingImmutableSortedSet` and user-supplied comparators are unaffected.

@kevinb9n called out special-casing `Comparator.naturalOrder()` in addition to `Ordering.natural()` on [#6188](https://github.com/google/guava/pull/6188) (the earlier, stale attempt by @kilink); this PR honors that and adds the test coverage that was missing from both #6188 and the withdrawn #8174.

## Tests

Added regression tests at two levels:

**`CollectSpliteratorsTest`**
- `testIsNaturalOrder_null`, `_orderingNatural`, `_comparatorNaturalOrder` — helper returns `true` for each natural-ordering form
- `testIsNaturalOrder_reverseOrder_false`, `_customComparator_false` — non-natural comparators are rejected
- `testIndexedSortedSpliterator_naturalOrderReturnsNull`, `_comparatorNaturalOrderReturnsNull` — indexed spliterator surfaces `null` for natural ordering and keeps `SORTED`
- `testIndexedSortedSpliterator_customComparatorIsPreserved` — custom comparator round-trips unchanged

**`ImmutableSortedSetTest`**
- `testSpliteratorGetComparator_naturalOrdering_returnsNull`
- `testSpliteratorGetComparator_comparatorNaturalOrder_returnsNull`
- `testSpliteratorGetComparator_customOrdering_returnsComparator`
- `testSpliteratorHasSortedCharacteristic`
- `testAsListSpliteratorGetComparator_naturalOrdering_returnsNull` (covers the `ImmutableSortedAsList` path used by `RegularImmutableSortedSet`)
- `testAsListSpliteratorGetComparator_customOrdering_returnsComparator`

## Test plan

- [x] `./mvnw -pl guava -am install -DskipTests` — builds clean
- [x] `./mvnw -pl guava-tests test -Dtest='CollectSpliteratorsTest,ImmutableSortedSetTest'` — 17,293 tests, 0 failures
- [x] Broader sweep: `./mvnw -pl guava-tests test -Dtest='*SortedSet*,*SortedMap*,*SortedMultiset*,*Collect*Test,ImmutableListTest,ImmutableSetTest,StreamsTest'` — 455,720 tests, 0 failures

Per `CONTRIBUTING.md`, the `android/` tree is left to the automatic mirror script.
