### PR TITLE
Fix AbstractLoadingCache class Javadoc to describe its own behavior

### DIFF
--- a/android/guava/src/com/google/common/cache/AbstractLoadingCache.java
+++ b/android/guava/src/com/google/common/cache/AbstractLoadingCache.java
@@ -21,20 +21,18 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 /**
- * This class provides a skeletal implementation of the {@code Cache} interface to minimize the
- * effort required to implement this interface.
+ * This class provides a skeletal implementation of the {@code LoadingCache} interface to minimize
+ * the effort required to implement this interface.
  *
- * <p>To implement a cache, the programmer needs only to extend this class and provide an
+ * <p>To implement a loading cache, the programmer needs only to extend this class and provide an
  * implementation for the {@link #get(Object)} and {@link #getIfPresent} methods. {@link
- * #getUnchecked}, {@link #get(Object, Callable)}, and {@link #getAll} are implemented in terms of
- * {@code get}; {@link #getAllPresent} is implemented in terms of {@code getIfPresent}; {@link
- * #putAll} is implemented in terms of {@link #put}, {@link #invalidateAll(Iterable)} is implemented
- * in terms of {@link #invalidate}. The method {@link #cleanUp} is a no-op. All other methods throw
- * an {@link UnsupportedOperationException}.
+ * #getUnchecked} and {@link #getAll} are implemented in terms of {@code get}; {@link #apply} is
+ * implemented in terms of {@code getUnchecked}. The method {@link #refresh} throws an {@link
+ * UnsupportedOperationException}; for the methods inherited from {@link AbstractCache}, see that
+ * class's documentation.
  *
  * @author Charles Fry
  * @since 11.0

--- a/guava/src/com/google/common/cache/AbstractLoadingCache.java
+++ b/guava/src/com/google/common/cache/AbstractLoadingCache.java
@@ -21,20 +21,18 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 /**
- * This class provides a skeletal implementation of the {@code Cache} interface to minimize the
- * effort required to implement this interface.
+ * This class provides a skeletal implementation of the {@code LoadingCache} interface to minimize
+ * the effort required to implement this interface.
  *
- * <p>To implement a cache, the programmer needs only to extend this class and provide an
+ * <p>To implement a loading cache, the programmer needs only to extend this class and provide an
  * implementation for the {@link #get(Object)} and {@link #getIfPresent} methods. {@link
- * #getUnchecked}, {@link #get(Object, Callable)}, and {@link #getAll} are implemented in terms of
- * {@code get}; {@link #getAllPresent} is implemented in terms of {@code getIfPresent}; {@link
- * #putAll} is implemented in terms of {@link #put}, {@link #invalidateAll(Iterable)} is implemented
- * in terms of {@link #invalidate}. The method {@link #cleanUp} is a no-op. All other methods throw
- * an {@link UnsupportedOperationException}.
+ * #getUnchecked} and {@link #getAll} are implemented in terms of {@code get}; {@link #apply} is
+ * implemented in terms of {@code getUnchecked}. The method {@link #refresh} throws an {@link
+ * UnsupportedOperationException}; for the methods inherited from {@link AbstractCache}, see that
+ * class's documentation.
  *
  * @author Charles Fry
  * @since 11.0


### PR DESCRIPTION
## Problem
`AbstractLoadingCache`'s class-level Javadoc is a near-verbatim copy of `AbstractCache`'s and describes methods that `AbstractLoadingCache` does not actually contribute. For example, it claims that `getAllPresent`, `putAll`, `invalidateAll(Iterable)`, `cleanUp` are pre-implemented here, and that `get(Object, Callable)` is implemented in terms of `get`. None of those statements are accurate for this class:
- `getAllPresent`, `putAll`, `invalidateAll(Iterable)`, and `cleanUp` are inherited unchanged from `AbstractCache`.
- `get(Object, Callable)` is inherited from `AbstractCache` where it throws `UnsupportedOperationException` -- it is not implemented in terms of `get`.

This was already noted in #1871 (now closed) and is the subject of #2862.

## Root Cause
When `AbstractLoadingCache` was added, the class-level Javadoc appears to have been copied from `AbstractCache` without being adapted to describe the loading-cache-specific surface that this class adds.

## Fix
Rewrite the class Javadoc so it talks about `LoadingCache` and only the methods this class actually defines:
- `getUnchecked` and `getAll` are implemented in terms of `get`.
- `apply` is implemented in terms of `getUnchecked`.
- `refresh` throws `UnsupportedOperationException`.
- For everything inherited (`getAllPresent`, `putAll`, `invalidateAll(Iterable)`, `cleanUp`, `put`, `invalidate`, `size`, `stats`, `asMap`, `get(K, Callable)`), the doc points the reader to `AbstractCache`.

The same Javadoc lives in both `guava/` and `android/guava/`; both copies are updated and remain identical.

The now-unused `java.util.concurrent.Callable` import (referenced only by the old Javadoc) is removed.

No behavior change; documentation only.

Closes #2862