### PR TITLE
Deprecate MediaType.JSON_UTF_8 per RFC 8259

### DIFF
--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -517,6 +517,15 @@ public final class MediaType {
    */
   public static final MediaType JOSE_JSON = createConstant(APPLICATION_TYPE, "jose+json");
 
+  /**
+   * <a href="https://datatracker.ietf.org/doc/html/rfc8259">RFC 8259</a> (The JavaScript Object
+   * Notation (JSON) Data Interchange Format) does not define a charset parameter for the {@code
+   * application/json} media type. The charset is always UTF-8.
+   *
+   * @deprecated Use {@link #APPLICATION_JSON} or call {@link #withoutParameters()} on an
+   *     {@code application/json} media type instance instead.
+   */
+  @Deprecated
   public static final MediaType JSON_UTF_8 = createConstantUtf8(APPLICATION_TYPE, "json");
 
   /**


### PR DESCRIPTION
## Summary
This PR deprecates the `MediaType.JSON_UTF_8` constant as it violates RFC 8259 specification.

## Background
[RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259#section-11) (The JavaScript Object Notation (JSON) Data Interchange Format) explicitly states that JSON does not define a charset parameter. JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32, with UTF-8 being the default and strongly recommended encoding.

Per RFC 8259, Section 11:
> JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32, with UTF-8 being the default and strongly recommended encoding.

The constant `application/json;charset=utf-8` is therefore incorrect per the RFC specification, as the charset parameter is not defined for JSON.

## Changes
- Added `@Deprecated` annotation to `MediaType.JSON_UTF_8`
- Added comprehensive javadoc with RFC 8259 reference
- Provided migration guidance for users:
  - Use `APPLICATION_JSON` for standard application/json without charset
  - Use `withoutParameters()` on any application/json instance

## Impact
- **Backward Compatible:** Deprecation only, no removal
- **Minimal Change:** 9 lines added (javadoc + annotation)
- **Tests:** All existing tests pass
- **RFC Compliance:** Aligns Guava with RFC 8259 specification

## Migration Path
Users currently using `JSON_UTF_8` can migrate to:
1. `MediaType.APPLICATION_JSON` - standard application/json media type
2. `MediaType.parse("application/json")` - alternative approach
3. Any application/json instance with `withoutParameters()` - removes charset if present

Fixes #6901