### PR TITLE
AbstractFutureTest adding clinit test

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -43,8 +43,13 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.annotations.GwtIncompatible;
 import com.google.common.annotations.J2ktIncompatible;
 import com.google.common.collect.Range;
+import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.internal.InternalFutureFailureAccess;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -87,13 +92,29 @@ public class AbstractFutureTest extends TestCase {
         .isEqualTo(value);
   }
 
-    public void testAssertNoClinit() {
-        java.lang.reflect.Method[] abstractFutureMethods = AbstractFuture.class.getDeclaredMethods();
-        for (java.lang.reflect.Method abstractFutureMethod : abstractFutureMethods) {
-            if (abstractFutureMethod.getName().equals("<clinit>")) {
-                fail("Abstract future method has a static initalizer method");
+    @SuppressWarnings("Java8ApiChecker")
+    public void testAssertNoClinit() throws Exception {
+        byte[] bytes;
+        boolean hasClinit = false;
+        String abstractFuturePath = AbstractFuture.class.getName().replace('.', '/') + ".class";
+
+        try (InputStream stream = AbstractFuture.class.getClassLoader().getResourceAsStream(abstractFuturePath)) {
+            assertNotNull(stream);
+            bytes = ByteStreams.toByteArray(stream);
+            ClassModel classModel = ClassFile.of().parse(bytes);
+
+            for (MethodModel method: classModel.methods()){
+                if (method.methodName().stringValue().equals("<clinit>")) {
+                    hasClinit = true;
+                    break;
+                }
             }
         }
+
+        assertWithMessage("AbstractFuture should not have a static initializer (<clinit>) "
+                + "to prevent potential class-loading deadlocks.")
+                .that(hasClinit)
+                .isFalse();
     }
 
   @J2ktIncompatible // J2KT ExecutionException differs in stack trace

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -599,6 +599,16 @@ public class AbstractFutureTest extends TestCase {
     executor.shutdown();
   }
 
+  // Made the test concerning cpovirk test request in AbstractFuture
+  public void testAssertNoClinit() {
+      java.lang.reflect.Method[] abstractFutureMethods = AbstractFuture.class.getDeclaredMethods();
+      for (java.lang.reflect.Method abstractFutureMethod : abstractFutureMethods) {
+          if (abstractFutureMethod.getName().equals("<clinit>")) {
+              fail("Abstract future method has a static initalizer method");
+          }
+      }
+  }
+
   // setFuture and cancel() interact in more complicated ways than the other setters.
   @J2ktIncompatible
   public void testSetFutureCancelBash() {

--- a/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/AbstractFutureTest.java
@@ -87,6 +87,15 @@ public class AbstractFutureTest extends TestCase {
         .isEqualTo(value);
   }
 
+    public void testAssertNoClinit() {
+        java.lang.reflect.Method[] abstractFutureMethods = AbstractFuture.class.getDeclaredMethods();
+        for (java.lang.reflect.Method abstractFutureMethod : abstractFutureMethods) {
+            if (abstractFutureMethod.getName().equals("<clinit>")) {
+                fail("Abstract future method has a static initalizer method");
+            }
+        }
+    }
+
   @J2ktIncompatible // J2KT ExecutionException differs in stack trace
   public void testException() throws InterruptedException {
     Throwable failure = new Throwable();
@@ -597,16 +606,6 @@ public class AbstractFutureTest extends TestCase {
       finalResults.clear();
     }
     executor.shutdown();
-  }
-
-  // Made the test concerning cpovirk test request in AbstractFuture
-  public void testAssertNoClinit() {
-      java.lang.reflect.Method[] abstractFutureMethods = AbstractFuture.class.getDeclaredMethods();
-      for (java.lang.reflect.Method abstractFutureMethod : abstractFutureMethods) {
-          if (abstractFutureMethod.getName().equals("<clinit>")) {
-              fail("Abstract future method has a static initalizer method");
-          }
-      }
   }
 
   // setFuture and cancel() interact in more complicated ways than the other setters.


### PR DESCRIPTION
<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->

### Summary:
Added a test case "testAssertNoClinit()" inside AbstractFutureTest.java which gathers the stream of "AbstractFuture".class and coverts into Bytes then parsed. Later loops all methods to find if class used does not contain a static initializer <clinit>. This test uses java.lang.classfile API (JDK 25). Ensuring AbstractFutureTest.java can be loaded without effects from static block and reducing potential deadlocks.

Note: Included @SuppressWarnings("Java8ApiChecker") to allow the use of modern APIs within the Java 8-aligned test suite.


@imports
```
import com.google.common.io.ByteStreams;
import java.lang.classfile.ClassFile;
import java.lang.classfile.ClassModel;
import java.lang.classfile.MethodModel;
```

### References
I used this link for reference for the test case:
https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/classfile/package-summary.html


