### PR TITLE
Add RateLimiter.create(double, double) for pre-filled burst capacity

### DIFF
--- a/android/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/android/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -144,6 +144,59 @@ public class RateLimiterTest extends TestCase {
         "R0.20");
   }
 
+  public void testCreateWithMaxBurstSeconds_prefillsBucket() {
+    // Bucket starts full: burst of 5*2=10 permits available immediately (no prior sleep).
+    RateLimiter limiter = RateLimiter.create(5.0, 2.0, stopwatch);
+    limiter.acquire(1); // R0.00, from pre-filled bucket
+    limiter.acquire(1); // R0.00, from pre-filled bucket
+    limiter.acquire(3); // R0.00, from pre-filled bucket
+    limiter.acquire(5); // R0.00, drains remaining 5 permits from pre-filled bucket
+    limiter.acquire(); // R0.20, bucket exhausted
+    assertEvents("R0.00", "R0.00", "R0.00", "R0.00", "R0.20");
+  }
+
+  public void testCreateWithMaxBurstSeconds_vsCreateWithoutPrefill() {
+    // create(5.0) starts empty: first acquire is free but burst requires sleeping first.
+    RateLimiter empty = RateLimiter.create(5.0, stopwatch);
+    empty.acquire(5); // R0.00, first acquire always free
+    empty.acquire(1); // R1.00, must wait for 5 permits' debt
+    assertEvents("R0.00", "R1.00");
+
+    // create(5.0, 1.0) starts full: can serve 5-permit burst without any sleep.
+    RateLimiter prefilled = RateLimiter.create(5.0, 1.0, stopwatch);
+    prefilled.acquire(5); // R0.00, consumed from pre-filled bucket
+    prefilled.acquire(1); // R1.00, must wait after draining bucket
+    assertEvents("R0.00", "R1.00");
+  }
+
+  public void testCreateWithMaxBurstSeconds_rateAfterBurstIsStable() {
+    RateLimiter limiter = RateLimiter.create(5.0, 1.0, stopwatch);
+    limiter.acquire(5); // R0.00, drains the pre-filled bucket
+    limiter.acquire(); // R1.00, now at stable rate
+    limiter.acquire(); // R0.20
+    limiter.acquire(); // R0.20
+    assertEvents("R0.00", "R1.00", "R0.20", "R0.20");
+  }
+
+  public void testCreateWithMaxBurstSeconds_accumulatesAfterIdle() {
+    RateLimiter limiter = RateLimiter.create(5.0, 2.0, stopwatch);
+    limiter.acquire(10); // R0.00, drains pre-filled bucket (10 permits)
+    limiter.acquire();   // R2.00, repays 10-permit debt
+    stopwatch.sleepMillis(2000); // idle: accumulates up to 10 permits again
+    limiter.acquire(10); // R0.00, burst from re-accumulated permits
+    limiter.acquire();   // R2.00
+    assertEvents("R0.00", "R2.00", "U2.00", "R0.00", "R2.00");
+  }
+
+  public void testCreateWithMaxBurstSeconds_parameterValidation() {
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(1.0, 0.0, stopwatch));
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(1.0, -1.0, stopwatch));
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(0.0, 1.0, stopwatch));
+  }
+
   public void testCreateWarmupParameterValidation() {
     RateLimiter unused;
     unused = RateLimiter.create(1.0, 1, NANOSECONDS);

--- a/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -141,6 +141,37 @@ public abstract class RateLimiter {
   }
 
   /**
+   * Creates a {@code RateLimiter} with the specified stable throughput and a pre-filled burst
+   * capacity. Unlike {@link #create(double)}, the returned {@code RateLimiter} starts with a full
+   * token bucket holding up to {@code maxBurstSeconds} seconds' worth of permits, enabling it to
+   * absorb an initial traffic surge immediately without throttling.
+   *
+   * <p>The returned {@code RateLimiter} ensures that on average no more than {@code
+   * permitsPerSecond} are issued during any given second. When unused, permits accumulate up to a
+   * maximum of {@code maxBurstSeconds * permitsPerSecond}.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
+   *     permits become available per second
+   * @param maxBurstSeconds the maximum number of seconds' worth of permits that can be saved up;
+   *     the token bucket is pre-filled to this capacity on creation
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero, or if
+   *     {@code maxBurstSeconds} is negative or zero
+   */
+  public static RateLimiter create(double permitsPerSecond, double maxBurstSeconds) {
+    return create(permitsPerSecond, maxBurstSeconds, SleepingStopwatch.createFromSystemTimer());
+  }
+
+  @VisibleForTesting
+  static RateLimiter create(
+      double permitsPerSecond, double maxBurstSeconds, SleepingStopwatch stopwatch) {
+    checkArgument(maxBurstSeconds > 0.0, "maxBurstSeconds must be positive");
+    SmoothBursty rateLimiter = new SmoothBursty(stopwatch, maxBurstSeconds);
+    rateLimiter.setRate(permitsPerSecond);
+    rateLimiter.prefillStoredPermits();
+    return rateLimiter;
+  }
+
+  /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
    * second" (commonly referred to as <i>QPS</i>, queries per second), and a <i>warmup period</i>,
    * during which the {@code RateLimiter} smoothly ramps up its rate, until it reaches its maximum

--- a/android/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/android/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -300,6 +300,10 @@ abstract class SmoothRateLimiter extends RateLimiter {
       }
     }
 
+    void prefillStoredPermits() {
+      storedPermits = maxPermits;
+    }
+
     @Override
     long storedPermitsToWaitTime(double storedPermits, double permitsToTake) {
       return 0L;

--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -144,6 +144,59 @@ public class RateLimiterTest extends TestCase {
         "R0.20");
   }
 
+  public void testCreateWithMaxBurstSeconds_prefillsBucket() {
+    // Bucket starts full: burst of 5*2=10 permits available immediately (no prior sleep).
+    RateLimiter limiter = RateLimiter.create(5.0, 2.0, stopwatch);
+    limiter.acquire(1); // R0.00, from pre-filled bucket
+    limiter.acquire(1); // R0.00, from pre-filled bucket
+    limiter.acquire(3); // R0.00, from pre-filled bucket
+    limiter.acquire(5); // R0.00, drains remaining 5 permits from pre-filled bucket
+    limiter.acquire(); // R0.20, bucket exhausted
+    assertEvents("R0.00", "R0.00", "R0.00", "R0.00", "R0.20");
+  }
+
+  public void testCreateWithMaxBurstSeconds_vsCreateWithoutPrefill() {
+    // create(5.0) starts empty: first acquire is free but burst requires sleeping first.
+    RateLimiter empty = RateLimiter.create(5.0, stopwatch);
+    empty.acquire(5); // R0.00, first acquire always free
+    empty.acquire(1); // R1.00, must wait for 5 permits' debt
+    assertEvents("R0.00", "R1.00");
+
+    // create(5.0, 1.0) starts full: can serve 5-permit burst without any sleep.
+    RateLimiter prefilled = RateLimiter.create(5.0, 1.0, stopwatch);
+    prefilled.acquire(5); // R0.00, consumed from pre-filled bucket
+    prefilled.acquire(1); // R1.00, must wait after draining bucket
+    assertEvents("R0.00", "R1.00");
+  }
+
+  public void testCreateWithMaxBurstSeconds_rateAfterBurstIsStable() {
+    RateLimiter limiter = RateLimiter.create(5.0, 1.0, stopwatch);
+    limiter.acquire(5); // R0.00, drains the pre-filled bucket
+    limiter.acquire(); // R1.00, now at stable rate
+    limiter.acquire(); // R0.20
+    limiter.acquire(); // R0.20
+    assertEvents("R0.00", "R1.00", "R0.20", "R0.20");
+  }
+
+  public void testCreateWithMaxBurstSeconds_accumulatesAfterIdle() {
+    RateLimiter limiter = RateLimiter.create(5.0, 2.0, stopwatch);
+    limiter.acquire(10); // R0.00, drains pre-filled bucket (10 permits)
+    limiter.acquire();   // R2.00, repays 10-permit debt
+    stopwatch.sleepMillis(2000); // idle: accumulates up to 10 permits again
+    limiter.acquire(10); // R0.00, burst from re-accumulated permits
+    limiter.acquire();   // R2.00
+    assertEvents("R0.00", "R2.00", "U2.00", "R0.00", "R2.00");
+  }
+
+  public void testCreateWithMaxBurstSeconds_parameterValidation() {
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(1.0, 0.0, stopwatch));
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(1.0, -1.0, stopwatch));
+    assertThrows(
+        IllegalArgumentException.class, () -> RateLimiter.create(0.0, 1.0, stopwatch));
+  }
+
   public void testCreateWarmupParameterValidation() {
     RateLimiter unused;
     unused = RateLimiter.create(1.0, 1, NANOSECONDS);

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -141,6 +141,37 @@ public abstract class RateLimiter {
   }
 
   /**
+   * Creates a {@code RateLimiter} with the specified stable throughput and a pre-filled burst
+   * capacity. Unlike {@link #create(double)}, the returned {@code RateLimiter} starts with a full
+   * token bucket holding up to {@code maxBurstSeconds} seconds' worth of permits, enabling it to
+   * absorb an initial traffic surge immediately without throttling.
+   *
+   * <p>The returned {@code RateLimiter} ensures that on average no more than {@code
+   * permitsPerSecond} are issued during any given second. When unused, permits accumulate up to a
+   * maximum of {@code maxBurstSeconds * permitsPerSecond}.
+   *
+   * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
+   *     permits become available per second
+   * @param maxBurstSeconds the maximum number of seconds' worth of permits that can be saved up;
+   *     the token bucket is pre-filled to this capacity on creation
+   * @throws IllegalArgumentException if {@code permitsPerSecond} is negative or zero, or if
+   *     {@code maxBurstSeconds} is negative or zero
+   */
+  public static RateLimiter create(double permitsPerSecond, double maxBurstSeconds) {
+    return create(permitsPerSecond, maxBurstSeconds, SleepingStopwatch.createFromSystemTimer());
+  }
+
+  @VisibleForTesting
+  static RateLimiter create(
+      double permitsPerSecond, double maxBurstSeconds, SleepingStopwatch stopwatch) {
+    checkArgument(maxBurstSeconds > 0.0, "maxBurstSeconds must be positive");
+    SmoothBursty rateLimiter = new SmoothBursty(stopwatch, maxBurstSeconds);
+    rateLimiter.setRate(permitsPerSecond);
+    rateLimiter.prefillStoredPermits();
+    return rateLimiter;
+  }
+
+  /**
    * Creates a {@code RateLimiter} with the specified stable throughput, given as "permits per
    * second" (commonly referred to as <i>QPS</i>, queries per second), and a <i>warmup period</i>,
    * during which the {@code RateLimiter} smoothly ramps up its rate, until it reaches its maximum

--- a/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/SmoothRateLimiter.java
@@ -300,6 +300,10 @@ abstract class SmoothRateLimiter extends RateLimiter {
       }
     }
 
+    void prefillStoredPermits() {
+      storedPermits = maxPermits;
+    }
+
     @Override
     long storedPermitsToWaitTime(double storedPermits, double permitsToTake) {
       return 0L;


### PR DESCRIPTION
## Summary

This PR adds a new factory method `RateLimiter.create(double permitsPerSecond, double maxBurstSeconds)` that creates a `SmoothBursty` `RateLimiter` with its token bucket **pre-filled to capacity** at creation time.

## Motivation

The existing `RateLimiter.create(double)` always starts with an empty token bucket that fills up gradually over time (capped at 1 second of permits). This means that on startup or after a long idle period, the first batch of requests cannot immediately use the full burst capacity — they must wait for the bucket to fill.

The new overload solves the "cold start" problem: callers that know they will face an initial traffic surge (e.g., application startup, cache warming) can pre-fill the bucket so the first wave of requests is served without throttling.

## Changes

- `RateLimiter.java` (JRE + Android): adds `public static RateLimiter create(double permitsPerSecond, double maxBurstSeconds)` and a `@VisibleForTesting` package-private overload that accepts a `SleepingStopwatch`.
- `SmoothRateLimiter.java` (JRE + Android): adds `void prefillStoredPermits()` on `SmoothBursty`, which sets `storedPermits = maxPermits`. No new fields are introduced.
- `RateLimiterTest.java` (JRE + Android): adds tests covering pre-filled bucket behavior, comparison with the unfilled variant, stable rate after burst, accumulation after idle, and parameter validation.

## API

```java
// Creates a bursty RateLimiter at 5 permits/sec with a 2-second pre-filled burst bucket (10 permits).
RateLimiter limiter = RateLimiter.create(5.0, 2.0);
```

The returned `RateLimiter` behaves identically to the result of `create(double)` after the initial burst is consumed.

## Testing

All existing `RateLimiterTest` cases continue to pass. New test methods added:
- `testCreateWithMaxBurstSeconds_prefillsBucket`
- `testCreateWithMaxBurstSeconds_vsCreateWithoutPrefill`
- `testCreateWithMaxBurstSeconds_rateAfterBurstIsStable`
- `testCreateWithMaxBurstSeconds_accumulatesAfterIdle`
- `testCreateWithMaxBurstSeconds_parameterValidation`

RELNOTES=`RateLimiter`: added `create(double permitsPerSecond, double maxBurstSeconds)` factory method that creates a bursty rate limiter with a pre-filled token bucket for handling startup traffic surges.