### PR TITLE
Short-circuit TypeToken#equals for same instance comparison

### DIFF
--- a/guava/src/com/google/common/reflect/TypeToken.java
+++ b/guava/src/com/google/common/reflect/TypeToken.java
@@ -836,6 +836,9 @@ public abstract class TypeToken<T> extends TypeCapture<T> implements Serializabl
    */
   @Override
   public boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
     if (o instanceof TypeToken) {
       TypeToken<?> that = (TypeToken<?>) o;
       return runtimeType.equals(that.runtimeType);


### PR DESCRIPTION
Avoid delegating to the runtime type's equals implementation in TypeToken#equals for identical instances of TypeTokens.

Depending on the implementation of `Type`, the equals method for `runtimeType` can be somewhat costly (e.g., triggering array cloning for `ParameterizedType`, etc). We actually have a scenario where cached `TypeToken` instances are often compared, and our equals implementation for `ParameterizedType` was less than ideal and showed up on some performance traces. I've fixed that as well, but TypeToken may as well avoid the call altogether if it can.