### PR TITLE
Fixes #8426: Inline LinearCongruentialGenerator into consistentHash.

### DIFF
--- a/guava-tests/test/com/google/common/hash/HashingTest.java
+++ b/guava-tests/test/com/google/common/hash/HashingTest.java
@@ -257,6 +257,24 @@ public class HashingTest extends TestCase {
     assertEquals(Hashing.consistentHash(equivLong, 5555), Hashing.consistentHash(hashCode, 5555));
   }
 
+  @J2ktIncompatible
+  public void testConsistentHash_singleBucketAlwaysReturnsZero() {
+    for (long input = 0; input < 1000; input++) {
+      assertEquals(0, Hashing.consistentHash(input, 1));
+    }
+  }
+
+  @J2ktIncompatible
+  public void testConsistentHash_largeBucketCountResultInRange() {
+    Random rng = new Random(0);
+    int buckets = Integer.MAX_VALUE;
+    for (int i = 0; i < 10_000; i++) {
+      int result = Hashing.consistentHash(rng.nextLong(), buckets);
+      assertThat(result).isAtLeast(0);
+      assertThat(result).isLessThan(buckets);
+    }
+  }
+
   /**
    * Check a few "golden" values to see that implementations across languages are equivalent.
    *

--- a/guava/src/com/google/common/hash/Hashing.java
+++ b/guava/src/com/google/common/hash/Hashing.java
@@ -654,13 +654,15 @@ public final class Hashing {
   @J2ktIncompatible
   public static int consistentHash(long input, int buckets) {
     checkArgument(buckets > 0, "buckets must be positive: %s", buckets);
-    LinearCongruentialGenerator generator = new LinearCongruentialGenerator(input);
+    long state = input;
     int candidate = 0;
     int next;
 
     // Jump from bucket to bucket until we go out of range
     while (true) {
-      next = (int) ((candidate + 1) / generator.nextDouble());
+      state = 2862933555777941757L * state + 1;
+      double d = ((double) ((int) (state >>> 33) + 1)) / 0x1.0p31;
+      next = (int) ((candidate + 1) / d);
       if (next >= 0 && next < buckets) {
         candidate = next;
       } else {
@@ -815,23 +817,6 @@ public final class Hashing {
     @Override
     public int hashCode() {
       return Arrays.hashCode(functions);
-    }
-  }
-
-  /**
-   * Linear CongruentialGenerator to use for consistent hashing. See
-   * http://en.wikipedia.org/wiki/Linear_congruential_generator
-   */
-  private static final class LinearCongruentialGenerator {
-    private long state;
-
-    LinearCongruentialGenerator(long seed) {
-      this.state = seed;
-    }
-
-    double nextDouble() {
-      state = 2862933555777941757L * state + 1;
-      return ((double) ((int) (state >>> 33) + 1)) / 0x1.0p31;
     }
   }
 


### PR DESCRIPTION
**Summary**

This PR eliminates the per-call heap allocation in Hashing.consistentHash by inlining the LinearCongruentialGenerator inner class directly into the method body.

**Motivation**

Hashing.consistentHash(long, int) constructed a new LinearCongruentialGenerator object on every invocation. That class existed solely to hold one long field and perform two arithmetic steps — there was no behavioral complexity to encapsulate. Under high call frequency (e.g. thousands of calls per second in a load balancer hot path) this generates a continuous stream of short-lived objects, increasing minor GC pressure and producing measurable allocation noise in profiler traces.

Inlining the single field and the two arithmetic operations directly into the method as local variables eliminates the allocation entirely with zero behavioral change.

**Changes**

Hashing.java (JRE): replaces new LinearCongruentialGenerator(input) with a local long state variable; inlines the two arithmetic steps directly into the loop body; deletes the LinearCongruentialGenerator inner class entirely — it has no remaining callers.

HashingTest.java (JRE): adds two new test methods covering previously untested boundary conditions on consistentHash.

**Testing**

All existing HashingTest cases continue to pass. Two new test methods added:

testConsistentHash_singleBucketAlwaysReturnsZero
testConsistentHash_largeBucketCountResultInRange
Full ./mvnw clean install passes with 0 failures, 0 errors across the entire test suite.

RELNOTES=Hashing: eliminated per-call LinearCongruentialGenerator allocation in consistentHash; output is bit-for-bit identical to the previous implementation.
Fixes #8426