### PR TITLE
Introduce ImmList interface as a supertype of ImmutableList

### DIFF
--- a/android/guava/src/com/google/common/collect/ImmList.java
+++ b/android/guava/src/com/google/common/collect/ImmList.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.List;
+
+/**
+ * A {@link List} whose contents will never change. {@code ImmList} is the interface counterpart of
+ * {@link ImmutableList}, allowing alternative implementations.
+ *
+ * <p>All mutation methods ({@link #add}, {@link #remove}, {@link #clear}, etc.) throw {@link
+ * UnsupportedOperationException}.
+ *
+ * @param <E> the element type
+ * @since 9999.0
+ */
+@GwtCompatible
+public interface ImmList<E> extends List<E> {}

--- a/android/guava/src/com/google/common/collect/ImmutableList.java
+++ b/android/guava/src/com/google/common/collect/ImmutableList.java
@@ -63,7 +63,7 @@ import org.jspecify.annotations.Nullable;
 @GwtCompatible
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new {@code

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
@@ -39,7 +39,7 @@ import org.jspecify.annotations.Nullable;
  */
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   ImmutableList() {}
 

--- a/guava/src/com/google/common/collect/ImmList.java
+++ b/guava/src/com/google/common/collect/ImmList.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.List;
+
+/**
+ * A {@link List} whose contents will never change. {@code ImmList} is the interface counterpart of
+ * {@link ImmutableList}, allowing alternative implementations.
+ *
+ * <p>All mutation methods ({@link #add}, {@link #remove}, {@link #clear}, etc.) throw {@link
+ * UnsupportedOperationException}.
+ *
+ * @param <E> the element type
+ * @since 9999.0
+ */
+@GwtCompatible
+public interface ImmList<E> extends List<E> {}

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -67,7 +67,7 @@ import org.jspecify.annotations.Nullable;
 @GwtCompatible
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new {@code


### PR DESCRIPTION
Introduce ImmList<E> interface (extending List<E>) as the interface counterpart of ImmutableList. This separates contract from implementation, allowing API designers to program to an interface.

This is a partial implementation of the idea discussed in #8421, starting with ImmList as a proof of concept.

RELNOTES=Add ImmList interface as a supertype of ImmutableList.