### PR TITLE
Add fallback variants to Gradle module metadata for non-JVM consumers

### DIFF
--- a/android/guava/src/com/google/common/collect/ImmList.java
+++ b/android/guava/src/com/google/common/collect/ImmList.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.List;
+
+/**
+ * A {@link List} whose contents will never change. {@code ImmList} is the interface counterpart of
+ * {@link ImmutableList}, allowing alternative implementations.
+ *
+ * <p>All mutation methods ({@link #add}, {@link #remove}, {@link #clear}, etc.) throw {@link
+ * UnsupportedOperationException}.
+ *
+ * @param <E> the element type
+ * @since 9999.0
+ */
+@GwtCompatible
+public interface ImmList<E> extends List<E> {}

--- a/android/guava/src/com/google/common/collect/ImmutableList.java
+++ b/android/guava/src/com/google/common/collect/ImmutableList.java
@@ -63,7 +63,7 @@ import org.jspecify.annotations.Nullable;
 @GwtCompatible
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new {@code

--- a/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
+++ b/guava-gwt/src-super/com/google/common/collect/super/com/google/common/collect/ImmutableList.java
@@ -39,7 +39,7 @@ import org.jspecify.annotations.Nullable;
  */
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   ImmutableList() {}
 

--- a/guava/module.json
+++ b/guava/module.json
@@ -278,6 +278,136 @@
           "version": "${pom.version}"
         }
       ]
+    },
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": "8",
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "com.google.guava",
+          "module": "failureaccess",
+          "version": {
+            "requires": "1.0.3"
+          }
+        },
+        {
+          "group": "com.google.guava",
+          "module": "listenablefuture",
+          "version": {
+            "requires": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "group": "org.jspecify",
+          "module": "jspecify",
+          "version": {
+            "requires": "${jspecify.version}"
+          }
+        },
+        {
+          "group": "com.google.errorprone",
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${error_prone_annotations.version}"
+          }
+        },
+        {
+          "group": "com.google.j2objc",
+          "module": "j2objc-annotations",
+          "version": {
+            "requires": "${j2objc.version}"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "${project.build.finalName}.jar",
+          "url": "${project.build.finalName}.jar"
+        }
+      ],
+      "capabilities": [
+        {
+          "group": "com.google.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.collections",
+          "name": "google-collections",
+          "version": "${pom.version}"
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": "8",
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "com.google.guava",
+          "module": "failureaccess",
+          "version": {
+            "requires": "1.0.3"
+          }
+        },
+        {
+          "group": "com.google.guava",
+          "module": "listenablefuture",
+          "version": {
+            "requires": "9999.0-empty-to-avoid-conflict-with-guava"
+          }
+        },
+        {
+          "group": "org.jspecify",
+          "module": "jspecify",
+          "version": {
+            "requires": "${jspecify.version}"
+          }
+        },
+        {
+          "group": "com.google.errorprone",
+          "module": "error_prone_annotations",
+          "version": {
+            "requires": "${error_prone_annotations.version}"
+          }
+        },
+        {
+          "group": "com.google.j2objc",
+          "module": "j2objc-annotations",
+          "version": {
+            "requires": "${j2objc.version}"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "${project.build.finalName}.jar",
+          "url": "${project.build.finalName}.jar"
+        }
+      ],
+      "capabilities": [
+        {
+          "group": "com.google.guava",
+          "name": "guava",
+          "version": "${pom.version}"
+        },
+        {
+          "group": "com.google.collections",
+          "name": "google-collections",
+          "version": "${pom.version}"
+        }
+      ]
     }
   ]
 }

--- a/guava/src/com/google/common/collect/ImmList.java
+++ b/guava/src/com/google/common/collect/ImmList.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.collect;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.List;
+
+/**
+ * A {@link List} whose contents will never change. {@code ImmList} is the interface counterpart of
+ * {@link ImmutableList}, allowing alternative implementations.
+ *
+ * <p>All mutation methods ({@link #add}, {@link #remove}, {@link #clear}, etc.) throw {@link
+ * UnsupportedOperationException}.
+ *
+ * @param <E> the element type
+ * @since 9999.0
+ */
+@GwtCompatible
+public interface ImmList<E> extends List<E> {}

--- a/guava/src/com/google/common/collect/ImmutableList.java
+++ b/guava/src/com/google/common/collect/ImmutableList.java
@@ -67,7 +67,7 @@ import org.jspecify.annotations.Nullable;
 @GwtCompatible
 @SuppressWarnings("serial") // we're overriding default serialization
 public abstract class ImmutableList<E> extends ImmutableCollection<E>
-    implements List<E>, RandomAccess {
+    implements ImmList<E>, RandomAccess {
 
   /**
    * Returns a {@code Collector} that accumulates the input elements into a new {@code


### PR DESCRIPTION
Add apiElements and runtimeElements variants without the org.gradle.jvm.environment attribute. This allows projects without the jvm-ecosystem plugin to resolve Guava as a dependency.

Fixes #8398

When a Gradle project applies only the base plugin, Gradle variant selection fails because Guava variants all declare org.gradle.jvm.environment. The fallback variants omit this attribute so Gradle can resolve them without the JVM ecosystem plugin.

RELNOTES=Add fallback Gradle module metadata variants for non-JVM consumers