### PR TITLE
Fix Lists.transform and other collection views to preserve spliterato…

### DIFF
--- a/android/guava/src/com/google/common/collect/CollectSpliterators.java
+++ b/android/guava/src/com/google/common/collect/CollectSpliterators.java
@@ -199,11 +199,15 @@ final class CollectSpliterators {
 
       @Override
       public int characteristics() {
+        // IMMUTABLE and CONCURRENT describe the source, not the elements, so filtering
+        // does not invalidate them.  This matches JDK Stream.filter(), which only clears SIZED.
         return fromSpliterator.characteristics()
             & (Spliterator.DISTINCT
                 | Spliterator.NONNULL
                 | Spliterator.ORDERED
-                | Spliterator.SORTED);
+                | Spliterator.SORTED
+                | Spliterator.IMMUTABLE
+                | Spliterator.CONCURRENT);
       }
     }
     return new Splitr();

--- a/android/guava/src/com/google/common/collect/Lists.java
+++ b/android/guava/src/com/google/common/collect/Lists.java
@@ -51,6 +51,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.jspecify.annotations.Nullable;
 
@@ -355,6 +356,14 @@ public final class Lists {
       return (index == 0) ? first : rest[index - 1];
     }
 
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.SIZED, this::get);
+    }
+
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;
   }
 
@@ -391,6 +400,14 @@ public final class Lists {
           checkElementIndex(index, size());
           return rest[index - 2];
       }
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.SIZED, this::get);
     }
 
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;
@@ -815,6 +832,14 @@ public final class Lists {
     public int size() {
       return sequence.length();
     }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<Character> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.SIZED, this::get);
+    }
   }
 
   /**
@@ -1186,6 +1211,13 @@ public final class Lists {
     @Override
     public int size() {
       return backingList.size();
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return backingList.spliterator();
     }
   }
 

--- a/android/guava/src/com/google/common/collect/Maps.java
+++ b/android/guava/src/com/google/common/collect/Maps.java
@@ -80,6 +80,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.Spliterator;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -3751,6 +3752,14 @@ public final class Maps {
     public void clear() {
       map().clear();
     }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<K> spliterator() {
+      return CollectSpliterators.map(
+          map().entrySet().spliterator(), Entry::getKey);
+    }
   }
 
   static <K extends @Nullable Object> @Nullable K keyOrNull(@Nullable Entry<K, ?> entry) {
@@ -3972,6 +3981,14 @@ public final class Maps {
     @Override
     public void clear() {
       map().clear();
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<V> spliterator() {
+      return CollectSpliterators.map(
+          map().entrySet().spliterator(), Entry::getValue);
     }
   }
 

--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -979,5 +980,69 @@ public class ListsTest extends TestCase {
   @J2ktIncompatible // too slow
   public void testPartitionSize_2() {
     assertEquals(2, partition(nCopies(0x40000001, 1), 0x40000000).size());
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testAsListSpliteratorIsImmutable() {
+    List<String> list = Lists.asList("a", new String[] {"b", "c"});
+    int characteristics = list.spliterator().characteristics();
+    assertTrue("asList should report IMMUTABLE", (characteristics & Spliterator.IMMUTABLE) != 0);
+    assertTrue("asList should report ORDERED", (characteristics & Spliterator.ORDERED) != 0);
+    assertTrue("asList should report SIZED", (characteristics & Spliterator.SIZED) != 0);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testAsListSpliteratorIteration() {
+    List<String> list = Lists.asList("a", new String[] {"b", "c"});
+    List<String> collected = new ArrayList<>();
+    list.spliterator().forEachRemaining(collected::add);
+    assertEquals(asList("a", "b", "c"), collected);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testAsListTwoSpliteratorIsImmutable() {
+    List<String> list = Lists.asList("a", "b", new String[] {"c"});
+    int characteristics = list.spliterator().characteristics();
+    assertTrue(
+        "asList(2+) should report IMMUTABLE", (characteristics & Spliterator.IMMUTABLE) != 0);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testAsListTwoSpliteratorIteration() {
+    List<String> list = Lists.asList("a", "b", new String[] {"c"});
+    List<String> collected = new ArrayList<>();
+    list.spliterator().forEachRemaining(collected::add);
+    assertEquals(asList("a", "b", "c"), collected);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testCharactersOfSpliteratorCharacteristics() {
+    List<Character> chars = Lists.charactersOf("hello");
+    int characteristics = chars.spliterator().characteristics();
+    assertTrue("charactersOf should report ORDERED", (characteristics & Spliterator.ORDERED) != 0);
+    assertTrue("charactersOf should report NONNULL", (characteristics & Spliterator.NONNULL) != 0);
+    assertTrue("charactersOf should report SIZED", (characteristics & Spliterator.SIZED) != 0);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testCharactersOfSpliteratorIteration() {
+    List<Character> chars = Lists.charactersOf("hello");
+    List<Character> collected = new ArrayList<>();
+    chars.spliterator().forEachRemaining(collected::add);
+    assertEquals(asList('h', 'e', 'l', 'l', 'o'), collected);
+  }
+
+  @GwtIncompatible // CopyOnWriteArrayList
+  @J2ktIncompatible
+  public void testAbstractListWrapperSpliteratorDelegates() {
+    CopyOnWriteArrayList<String> cow = new CopyOnWriteArrayList<>(asList("a", "b", "c"));
+    int cowCharacteristics = cow.spliterator().characteristics();
+    assertTrue((cowCharacteristics & Spliterator.IMMUTABLE) != 0);
   }
 }

--- a/guava-tests/test/com/google/common/collect/MapsTest.java
+++ b/guava-tests/test/com/google/common/collect/MapsTest.java
@@ -70,6 +70,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.Spliterator;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentMap;
 import junit.framework.TestCase;
@@ -1571,5 +1572,32 @@ public class MapsTest extends TestCase {
     assertEquals(ImmutableSortedMap.of(8, 0, 10, 0), Maps.subMap(map, Range.atMost(8)));
     assertEquals(
         ImmutableSortedMap.of(2, 0, 4, 0, 6, 0, 8, 0, 10, 0), Maps.subMap(map, Range.all()));
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testKeySetSpliteratorIsDistinct() {
+    HashMap<String, Integer> map = new HashMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    int characteristics = map.keySet().spliterator().characteristics();
+    assertTrue(
+        "keySet spliterator should report DISTINCT",
+        (characteristics & Spliterator.DISTINCT) != 0);
+  }
+
+  @GwtIncompatible // Spliterator
+  @J2ktIncompatible
+  public void testValuesSpliteratorCharacteristics() {
+    HashMap<String, Integer> map = new HashMap<>();
+    map.put("a", 1);
+    map.put("b", 2);
+    Spliterator<Integer> valuesSpliterator = map.values().spliterator();
+    assertTrue(
+        "values spliterator should report SIZED",
+        (valuesSpliterator.characteristics() & Spliterator.SIZED) != 0);
+    assertFalse(
+        "values spliterator should NOT report DISTINCT",
+        (valuesSpliterator.characteristics() & Spliterator.DISTINCT) != 0);
   }
 }

--- a/guava/src/com/google/common/collect/CollectSpliterators.java
+++ b/guava/src/com/google/common/collect/CollectSpliterators.java
@@ -199,11 +199,15 @@ final class CollectSpliterators {
 
       @Override
       public int characteristics() {
+        // IMMUTABLE and CONCURRENT describe the source, not the elements, so filtering
+        // does not invalidate them.  This matches JDK Stream.filter(), which only clears SIZED.
         return fromSpliterator.characteristics()
             & (Spliterator.DISTINCT
                 | Spliterator.NONNULL
                 | Spliterator.ORDERED
-                | Spliterator.SORTED);
+                | Spliterator.SORTED
+                | Spliterator.IMMUTABLE
+                | Spliterator.CONCURRENT);
       }
     }
     return new Splitr();

--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -51,6 +51,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
@@ -356,6 +357,14 @@ public final class Lists {
       return (index == 0) ? first : rest[index - 1];
     }
 
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.SIZED, this::get);
+    }
+
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;
   }
 
@@ -392,6 +401,14 @@ public final class Lists {
           checkElementIndex(index, size());
           return rest[index - 2];
       }
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.SIZED, this::get);
     }
 
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;
@@ -829,6 +846,14 @@ public final class Lists {
     public int size() {
       return sequence.length();
     }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<Character> spliterator() {
+      return CollectSpliterators.indexed(
+          size(), Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.SIZED, this::get);
+    }
   }
 
   /**
@@ -1200,6 +1225,13 @@ public final class Lists {
     @Override
     public int size() {
       return backingList.size();
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<E> spliterator() {
+      return backingList.spliterator();
     }
   }
 

--- a/guava/src/com/google/common/collect/Maps.java
+++ b/guava/src/com/google/common/collect/Maps.java
@@ -3946,6 +3946,14 @@ public final class Maps {
     public void clear() {
       map().clear();
     }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<K> spliterator() {
+      return CollectSpliterators.map(
+          map().entrySet().spliterator(), Spliterator.DISTINCT, Entry::getKey);
+    }
   }
 
   static <K extends @Nullable Object> @Nullable K keyOrNull(@Nullable Entry<K, ?> entry) {
@@ -4174,6 +4182,13 @@ public final class Maps {
     @Override
     public void clear() {
       map().clear();
+    }
+
+    @Override
+    @GwtIncompatible
+    @J2ktIncompatible
+    public Spliterator<V> spliterator() {
+      return CollectSpliterators.map(map().entrySet().spliterator(), 0, Entry::getValue);
     }
   }
 


### PR DESCRIPTION
…r/iterator characteristics

- Update CollectSpliterators.filter() to preserve IMMUTABLE and CONCURRENT characteristics (they describe the source, not elements)
- Add spliterator() overrides to Lists.OnePlusArrayList, TwoPlusArrayList, StringAsList, and AbstractListWrapper (which fixes Lists.transform via TransformingRandomAccessList/SequentialList)
- Add spliterator() overrides to Maps.KeySet (with DISTINCT) and Maps.Values
- Apply same fixes to android variant copies

Fixes #8165

<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->
