### PR TITLE
hash: guard BloomFilter.readFrom() against corrupt dataLength

### DIFF
--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -653,6 +653,12 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
       strategyOrdinal = din.readByte();
       numHashFunctions = toUnsignedInt(din.readByte());
       dataLength = din.readInt();
+      checkArgument(dataLength >= 0, "Corrupt BloomFilter: dataLength (%s) must be >= 0", dataLength);
+      checkArgument(
+          dataLength <= Integer.MAX_VALUE / 64,
+          "Corrupt BloomFilter: dataLength (%s) is unreasonably large (max: %s)",
+          dataLength,
+          Integer.MAX_VALUE / 64);
 
       /*
        * We document in BloomFilterStrategies that we must not change the ordering, and we have a


### PR DESCRIPTION
## Problem

`BloomFilter.readFrom()` reads a signed 32-bit `dataLength` from the
stream and passes it directly to `Math.multiplyExact(dataLength, 64L)`
to size the backing `AtomicLongArray`, with no upper-bound validation.

A crafted stream can trigger two denial-of-service conditions:

**1. Large positive `dataLength`** — e.g. `Integer.MAX_VALUE` (7 bytes total):
```
0x01 0x01 0x7F 0xFF 0xFF 0xFF  (+ EOF)
```
`Math.multiplyExact(2147483647, 64L)` = 137 billion bits (fits in `long`, no exception).
`Ints.checkedCast(137438953408 / 64)` = 2,147,483,647 (fits in `int`, no exception).
`new AtomicLongArray(2147483647)` → allocates **~17.2 GB** → `OutOfMemoryError`.

**2. Negative `dataLength`** — e.g. `readInt()` returns `-1`:
`multiplyExact(-1, 64) = -64`. `LockFreeBitArray` constructor throws
`"data length is zero!"` instead of a clear corrupt-input message.

## Fix

Add two `checkArgument` guards immediately after `readInt()`:

```java
checkArgument(dataLength >= 0,
    "Corrupt BloomFilter: dataLength (%s) must be >= 0", dataLength);
checkArgument(dataLength <= Integer.MAX_VALUE / 64,
    "Corrupt BloomFilter: dataLength (%s) is unreasonably large (max: %s)",
    dataLength, Integer.MAX_VALUE / 64);
```

`checkArgument` is already statically imported. The thrown
`IllegalArgumentException` is caught by the existing `catch(Exception e)`
block and re-thrown as `IOException` with the
`"Unable to deserialize BloomFilter"` message — preserving the existing
API contract for callers.

The cap `Integer.MAX_VALUE / 64 = 33,554,431` limits the backing
`AtomicLongArray` to ~256 MB, which is sufficient for any realistic
Bloom filter use case.

## Impact

Any service that deserializes a `BloomFilter` from an untrusted source
(distributed cache, message queue, file upload, network protocol) is
vulnerable to a 7-byte payload that crashes the JVM process.