### PR TITLE
Add Streams.forEachWithIndex

### DIFF
--- a/android/guava/src/com/google/common/collect/Streams.java
+++ b/android/guava/src/com/google/common/collect/Streams.java
@@ -44,6 +44,7 @@ import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.BaseStream;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -412,6 +413,48 @@ public final class Streams {
         consumer.accept(iterA.next(), iterB.next());
       }
     }
+  }
+
+  /**
+   * Invokes {@code consumer} once for each element of {@code stream} and its index in the stream.
+   * For example,
+   *
+   * {@snippet :
+   * Streams.forEachWithIndex(
+   *     Stream.of("a", "b", "c"),
+   *     (e, index) -> System.out.println(index + ": " + e))
+   * }
+   *
+   * <p>would print:
+   *
+   * {@snippet :
+   * 0: a
+   * 1: b
+   * 2: c
+   * }
+   *
+   * <p><b>Warning:</b> If {@code stream} is a parallel stream, the elements may be passed to the
+   * consumer in any order. The index assigned to each element reflects its position in the stream's
+   * <i>encounter order</i>. If the stream has no defined encounter order, the index assigned to
+   * each element is arbitrary.
+   *
+   * <p>This method behaves equivalently to applying {@link #mapWithIndex(Stream,
+   * FunctionWithIndex)} and then invoking {@link Stream#forEach} on the resulting stream.
+   *
+   * @since 33.6.0
+   */
+  @Beta
+  public static <T extends @Nullable Object> void forEachWithIndex(
+      Stream<T> stream, ObjLongConsumer<? super T> consumer) {
+    checkNotNull(stream);
+    checkNotNull(consumer);
+    mapWithIndex(
+            stream,
+            (element, index) -> {
+              consumer.accept(element, index);
+              return null;
+            })
+        .forEach(ignored -> {});
   }
 
   // Use this carefully - it doesn't implement value semantics

--- a/guava-tests/test/com/google/common/collect/StreamsTest.java
+++ b/guava-tests/test/com/google/common/collect/StreamsTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.DoubleStream;
@@ -506,6 +507,70 @@ public class StreamsTest extends TestCase {
     Streams.forEachPair(
         Stream.of("a", "b", "c"), Stream.iterate(1, i -> i + 1), (a, b) -> list.add(a + ":" + b));
     assertThat(list).containsExactly("a:1", "b:2", "c:3");
+  }
+
+  public void testForEachWithIndex() {
+    List<String> result = new ArrayList<>();
+    Streams.forEachWithIndex(Stream.of("a", "b", "c"), (e, i) -> result.add(i + ":" + e));
+    assertThat(result).containsExactly("0:a", "1:b", "2:c").inOrder();
+  }
+
+  public void testForEachWithIndex_emptyStream() {
+    List<String> result = new ArrayList<>();
+    Streams.forEachWithIndex(Stream.<String>of(), (e, i) -> result.add(i + ":" + e));
+    assertThat(result).isEmpty();
+  }
+
+  public void testForEachWithIndex_nullElement() {
+    List<@Nullable String> collected = new ArrayList<>();
+    List<Long> indices = new ArrayList<>();
+    Streams.forEachWithIndex(
+        Stream.<@Nullable String>of("a", null, "c"),
+        (e, i) -> {
+          collected.add(e);
+          indices.add(i);
+        });
+    assertThat(collected).containsExactly("a", null, "c").inOrder();
+    assertThat(indices).containsExactly(0L, 1L, 2L).inOrder();
+  }
+
+  public void testForEachWithIndex_nullChecks() {
+    try {
+      Streams.forEachWithIndex(null, (e, i) -> {});
+      fail();
+    } catch (NullPointerException expected) {
+    }
+
+    try {
+      Streams.forEachWithIndex(Stream.of("a"), null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  public void testForEachWithIndex_unsizedSource() {
+    List<String> result = new ArrayList<>();
+    Streams.forEachWithIndex(
+        Stream.<@Nullable Object>of((Object) null)
+            .flatMap(unused -> ImmutableList.of("a", "b", "c").stream()),
+        (e, i) -> result.add(i + ":" + e));
+    assertThat(result).containsExactly("0:a", "1:b", "2:c").inOrder();
+  }
+
+  public void testForEachWithIndex_parallelStream() {
+    int n = 200;
+    List<String> input = new ArrayList<>();
+    for (int j = 0; j < n; j++) {
+      input.add("e" + j);
+    }
+
+    ConcurrentHashMap<String, Long> result = new ConcurrentHashMap<>();
+    Streams.forEachWithIndex(input.stream().parallel(), (e, i) -> result.put(e, i));
+
+    assertThat(result).hasSize(n);
+    for (int j = 0; j < n; j++) {
+      assertThat(result).containsEntry("e" + j, (long) j);
+    }
   }
 
   public void testForEachPair_parallel() {

--- a/guava/src/com/google/common/collect/Streams.java
+++ b/guava/src/com/google/common/collect/Streams.java
@@ -44,6 +44,7 @@ import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.BaseStream;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -406,6 +407,48 @@ public final class Streams {
         consumer.accept(iterA.next(), iterB.next());
       }
     }
+  }
+
+  /**
+   * Invokes {@code consumer} once for each element of {@code stream} and its index in the stream.
+   * For example,
+   *
+   * {@snippet :
+   * Streams.forEachWithIndex(
+   *     Stream.of("a", "b", "c"),
+   *     (e, index) -> System.out.println(index + ": " + e))
+   * }
+   *
+   * <p>would print:
+   *
+   * {@snippet :
+   * 0: a
+   * 1: b
+   * 2: c
+   * }
+   *
+   * <p><b>Warning:</b> If {@code stream} is a parallel stream, the elements may be passed to the
+   * consumer in any order. The index assigned to each element reflects its position in the stream's
+   * <i>encounter order</i>. If the stream has no defined encounter order, the index assigned to
+   * each element is arbitrary.
+   *
+   * <p>This method behaves equivalently to applying {@link #mapWithIndex(Stream,
+   * FunctionWithIndex)} and then invoking {@link Stream#forEach} on the resulting stream.
+   *
+   * @since 33.6.0
+   */
+  @Beta
+  public static <T extends @Nullable Object> void forEachWithIndex(
+      Stream<T> stream, ObjLongConsumer<? super T> consumer) {
+    checkNotNull(stream);
+    checkNotNull(consumer);
+    mapWithIndex(
+            stream,
+            (element, index) -> {
+              consumer.accept(element, index);
+              return null;
+            })
+        .forEach(ignored -> {});
   }
 
   // Use this carefully - it doesn't implement value semantics


### PR DESCRIPTION
## Summary
- add `Streams.forEachWithIndex(Stream, ObjLongConsumer)` as the terminal counterpart to `mapWithIndex`
- delegate through `mapWithIndex` in both JRE and Android `Streams` implementations so indexed traversal stays in one code path
- add `StreamsTest` coverage for sequential, empty, null-element, null-check, unsized-source, and parallel index-correctness cases

## Intentional Non-Goals
- no primitive overloads in this PR
- no stronger parallel ordering guarantee than correct element-to-index correspondence
- no implicit closing of the source stream

## Test Plan
- [x] Added targeted `StreamsTest` coverage for the new API behavior
