### PR TITLE
Clarify HostSpecifier URI parser compatibility

### DIFF
--- a/android/guava/src/com/google/common/net/HostSpecifier.java
+++ b/android/guava/src/com/google/common/net/HostSpecifier.java
@@ -30,6 +30,13 @@ import org.jspecify.annotations.Nullable;
  * URI, the domain name case is further restricted to include only those domain names which end in a
  * recognized public suffix; see {@link InternetDomainName#isPublicSuffix()} for details.
  *
+ * <p>In this context, "URI" is used in the general sense, and {@code HostSpecifier} does not
+ * guarantee that every URI or URL parser will accept the original input without additional
+ * normalization. {@code HostSpecifier} follows the syntactic rules of {@link InetAddresses} and
+ * {@link InternetDomainName}, including their documented acceptance of some inputs that particular
+ * URI implementations may reject, such as non-ASCII digits, non-ASCII domain names, or domain
+ * labels containing underscores.
+ *
  * <p>Note that no network lookups are performed by any {@code HostSpecifier} methods. No attempt is
  * made to verify that a provided specifier corresponds to a real or accessible host. Only syntactic
  * and pattern-based checks are performed.

--- a/guava/src/com/google/common/net/HostSpecifier.java
+++ b/guava/src/com/google/common/net/HostSpecifier.java
@@ -30,6 +30,13 @@ import org.jspecify.annotations.Nullable;
  * URI, the domain name case is further restricted to include only those domain names which end in a
  * recognized public suffix; see {@link InternetDomainName#isPublicSuffix()} for details.
  *
+ * <p>In this context, "URI" is used in the general sense, and {@code HostSpecifier} does not
+ * guarantee that every URI or URL parser will accept the original input without additional
+ * normalization. {@code HostSpecifier} follows the syntactic rules of {@link InetAddresses} and
+ * {@link InternetDomainName}, including their documented acceptance of some inputs that particular
+ * URI implementations may reject, such as non-ASCII digits, non-ASCII domain names, or domain
+ * labels containing underscores.
+ *
  * <p>Note that no network lookups are performed by any {@code HostSpecifier} methods. No attempt is
  * made to verify that a provided specifier corresponds to a real or accessible host. Only syntactic
  * and pattern-based checks are performed.


### PR DESCRIPTION
Clarifies the `HostSpecifier` class documentation after maintainer feedback.

`HostSpecifier` is documented as suitable for use in a URI, but it follows the syntactic rules of `InetAddresses` and `InternetDomainName`. Those classes intentionally accept some inputs that particular URI/URL parsers may reject unless callers normalize first, such as non-ASCII digits, non-ASCII domain names, or domain labels containing underscores.

This version keeps existing runtime behavior unchanged and documents that compatibility boundary instead of rejecting or canonicalizing additional inputs.

Tests:
- `git diff --check`
