### PR TITLE
Document that Closer is not thread-safe

### DIFF
--- a/android/guava/src/com/google/common/io/Closer.java
+++ b/android/guava/src/com/google/common/io/Closer.java
@@ -74,6 +74,8 @@ import org.jspecify.annotations.Nullable;
  * <p>An exception that is suppressed is added to the exception that <i>will</i> be thrown using
  * {@code Throwable.addSuppressed(Throwable)}.
  *
+ * <p>This class is not thread-safe.
+ *
  * @author Colin Decker
  * @since 14.0
  */

--- a/guava/src/com/google/common/io/Closer.java
+++ b/guava/src/com/google/common/io/Closer.java
@@ -74,6 +74,8 @@ import org.jspecify.annotations.Nullable;
  * <p>An exception that is suppressed is added to the exception that <i>will</i> be thrown using
  * {@code Throwable.addSuppressed(Throwable)}.
  *
+ * <p>This class is not thread-safe.
+ *
  * @author Colin Decker
  * @since 14.0
  */


### PR DESCRIPTION
[Fixes #3900](https://github.com/google/guava/issues/3900)

**Closer** uses a mutable ArrayDeque internally with no synchronization, 
making it **not thread-safe**. _This was undocumented_.

Added a **Javadoc** note to **both** the **JRE** and **Android versions** of Closer, 
following the existing pattern used by **[FileBackedOutputStream](https://github.com/google/guava/blob/master/guava/src/com/google/common/io/FileBackedOutputStream.java)**  
("This class is thread-safe.") — but stating the opposite.

Changes:
- guava/src/com/google/common/io/Closer.java
- android/guava/src/com/google/common/io/Closer.java
