### PR TITLE
Clarify AtomicDoubleArray get/set/lazySet Javadoc

### DIFF
--- a/guava/src/com/google/common/util/concurrent/AtomicDoubleArray.java
+++ b/guava/src/com/google/common/util/concurrent/AtomicDoubleArray.java
@@ -95,7 +95,10 @@ public class AtomicDoubleArray implements Serializable {
   }
 
   /**
-   * Gets the current value at position {@code i}.
+   * Returns the current value of the element at index {@code i}, with memory effects as specified
+   * by {@link java.lang.invoke.VarHandle#getVolatile VarHandle.getVolatile}. The returned value is
+   * the {@code double} whose bitwise representation was stored atomically as a single 64-bit
+   * value.
    *
    * @param i the index
    * @return the current value
@@ -105,7 +108,9 @@ public class AtomicDoubleArray implements Serializable {
   }
 
   /**
-   * Atomically sets the element at position {@code i} to the given value.
+   * Sets the element at index {@code i} to {@code newValue}, with memory effects as specified by
+   * {@link java.lang.invoke.VarHandle#setVolatile VarHandle.setVolatile}. The value is stored by
+   * atomically writing the 64-bit representation of {@code newValue}.
    *
    * @param i the index
    * @param newValue the new value
@@ -116,7 +121,10 @@ public class AtomicDoubleArray implements Serializable {
   }
 
   /**
-   * Eventually sets the element at position {@code i} to the given value.
+   * Sets the element at index {@code i} to {@code newValue}, with memory effects as specified by
+   * {@link java.lang.invoke.VarHandle#setRelease VarHandle.setRelease}. The value is stored by
+   * atomically writing the 64-bit representation of {@code newValue}; the store may be delayed and
+   * is ordered differently than {@link #set(int, double)}.
    *
    * @param i the index
    * @param newValue the new value


### PR DESCRIPTION
## Summary
- Aligns `AtomicDoubleArray.get`, `set`, and `lazySet` Javadoc with `AtomicLongArray`
- Documents volatile/release memory effects and atomic 64-bit representation

Fixes #1716

## Test plan
- [x] Javadoc-only change
- [x] `./mvnw -pl guava javadoc:javadoc` succeeds

Made with [Cursor](https://cursor.com)