### PR TITLE
fix(Splitter): throw IllegalStateException if trimmer already specified

### DIFF
--- a/android/guava/src/com/google/common/base/Splitter.java
+++ b/android/guava/src/com/google/common/base/Splitter.java
@@ -16,6 +16,7 @@ package com.google.common.base;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
@@ -349,10 +350,14 @@ public final class Splitter {
    * @param trimmer a {@link CharMatcher} that determines whether a character should be removed from
    *     the beginning/end of a subsequence
    * @return a splitter with the desired configuration
+   * @throws IllegalStateException if a trimmer was already specified on this splitter
    */
-  // TODO(kevinb): throw if a trimmer was already specified!
   public Splitter trimResults(CharMatcher trimmer) {
     checkNotNull(trimmer);
+    checkState(
+        this.trimmer == CharMatcher.none(),
+        "A trimmer was already specified: %s",
+        this.trimmer);
     return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
   }
 

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -16,6 +16,7 @@ package com.google.common.base;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
@@ -349,10 +350,14 @@ public final class Splitter {
    * @param trimmer a {@link CharMatcher} that determines whether a character should be removed from
    *     the beginning/end of a subsequence
    * @return a splitter with the desired configuration
+   * @throws IllegalStateException if a trimmer was already specified on this splitter
    */
-  // TODO(kevinb): throw if a trimmer was already specified!
   public Splitter trimResults(CharMatcher trimmer) {
     checkNotNull(trimmer);
+    checkState(
+        this.trimmer == CharMatcher.none(),
+        "A trimmer was already specified: %s",
+        this.trimmer);
     return new Splitter(strategy, omitEmptyStrings, trimmer, limit);
   }
 


### PR DESCRIPTION
## Summary

Implements TODO(kevinb) in Splitter.trimResults(CharMatcher) - adds a checkState guard that throws IllegalStateException when trimResults() is called on a Splitter that already has a non-default trimmer configured.

## Problem

Previously, calling trimResults() multiple times on a Splitter would silently override the previous trimmer setting. This could lead to subtle bugs where a developer accidentally configures two different trimmers and the first one is silently discarded.

## Solution

- Added checkState(this.trimmer == CharMatcher.none(), ...) guard in trimResults(CharMatcher) to detect duplicate trimmer specification
- - Added @throws IllegalStateException to the Javadoc
- - Added import static com.google.common.base.Preconditions.checkState
## Files Changed

- android/guava/src/com/google/common/base/Splitter.java
- - guava/src/com/google/common/base/Splitter.java
Both android and main guava source trees received identical changes.