### PR TITLE
Add tests for wrapper class behavior in DefaultsTest

### DIFF
--- a/guava-tests/test/com/google/common/base/DefaultsTest.java
+++ b/guava-tests/test/com/google/common/base/DefaultsTest.java
@@ -43,5 +43,11 @@ public class DefaultsTest extends TestCase {
     assertThat(Defaults.defaultValue(double.class).doubleValue()).isEqualTo(0.0d);
     assertThat(Defaults.defaultValue(void.class)).isNull();
     assertThat(Defaults.defaultValue(String.class)).isNull();
+
+    // Verifies that wrapper classes are treated as reference types and return null
+    assertThat(Defaults.defaultValue(Boolean.class)).isNull();
+    assertThat(Defaults.defaultValue(Character.class)).isNull();
+    assertThat(Defaults.defaultValue(Integer.class)).isNull();
+    assertThat(Defaults.defaultValue(Double.class)).isNull();
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines at
https://github.com/google/guava/wiki/HowToContribute#code-contributions
and
https://github.com/google/guava/blob/master/CONTRIBUTING.md
before sending a pull request.

We generally welcome PRs for fixing trivial bugs or typos, but please refrain
from sending a PR with significant changes unless explicitly requested.
--->

### **Description**

Adds assertions to `DefaultsTest` to explicitly verify that primitive wrapper classes (like `Integer.class` and `Boolean.class`) correctly return null when calling `Defaults.defaultValue()`.

While the test suite covered primitives (`int.class`), it lacked coverage for their wrapper counterparts. This change locks down that expected behavior and prevents future regressions.

### **Changes**

 Added null checks for Boolean, Character, Integer, and Double wrappers in `DefaultsTest.java`.
