### PR TITLE
Rename lenientToString to safeToString for improved readability

### DIFF
--- a/guava/src/com/google/common/base/Strings.java
+++ b/guava/src/com/google/common/base/Strings.java
@@ -280,7 +280,7 @@ public final class Strings {
         break;
       }
       builder.append(template, templateStart, placeholderStart);
-      builder.append(lenientToString(args[i++]));
+      builder.append(safeToString(args[i++]));
       templateStart = placeholderStart + 2;
     }
     builder.append(template, templateStart, template.length());
@@ -290,7 +290,7 @@ public final class Strings {
       String prefix = " [";
       for (; i < args.length; i++) {
         builder.append(prefix);
-        builder.append(lenientToString(args[i]));
+        builder.append(safeToString(args[i]));
         prefix = ", ";
       }
       builder.append(']');
@@ -300,7 +300,7 @@ public final class Strings {
   }
 
   @SuppressWarnings("CatchingUnchecked") // sneaky checked exception
-  private static String lenientToString(@Nullable Object o) {
+  private static String safeToString(@Nullable Object o) {
     if (o == null) {
       return "null";
     }


### PR DESCRIPTION
This pull request renames the private method `lenientToString` to  `safeToString` in `Strings.java` for improved readability and clarity. The name `lenientToString` does not clearly communicate the method's behavior. The term "lenient" is vague and requires the reader to inspect the implementation to understand what it does differently from a standard `toString()` call. The name `safeToString` better describes the actual behavior: it attempts to call `.toString()` on the object, and if an exception is thrown, it  returns a fallback string instead of propagating the error — making it a *safe* conversion.

This change was motivated by an empirical quality analysis of Google Guava across 20 releases (v10.0 to v29.0), in which `Rename Method` appeared among the top 10 most frequent refactoring types detected by RefactoringMiner. Improving method naming is a well-stablished refactoring practice [Fowler, 2018] that reduces cognitive overhead for readers and maintainers.
- Renamed `lenientToString` → `safeToString` in  `guava/src/com/google/common/base/Strings.java`
- Renamed the same method in  `android/guava/src/com/google/common/base/Strings.java`

