### PR TITLE
Change exception type for large array size

### DIFF
--- a/guava/src/com/google/common/base/Strings.java
+++ b/guava/src/com/google/common/base/Strings.java
@@ -63,7 +63,7 @@ public final class Strings {
    * <p>Consider normalizing your string references with {@link #nullToEmpty}. If you do, you can
    * use {@link String#isEmpty()} instead of this method, and you won't need special null-safe forms
    * of methods like {@link String#toUpperCase} either. Or, if you'd like to normalize "in the other
-   * direction" (converting empty strings to {@code null}), you can use {@link #emptyToNull}.
+   * direction," converting empty strings to {@code null}, you can use {@link #emptyToNull}.
    *
    * @param string a string reference to check
    * @return {@code true} if the string is null or is the empty string
@@ -161,7 +161,7 @@ public final class Strings {
     long longSize = (long) len * (long) count;
     int size = (int) longSize;
     if (size != longSize) {
-      throw new ArrayIndexOutOfBoundsException("Required array size too large: " + longSize);
+      throw new IllegalArgumentException("string.length() * count is too large: " + longSize);
     }
 
     char[] array = new char[size];


### PR DESCRIPTION
This pull request fixes an inconsistent exception behavior in the 
`Strings.repeat()` method. When the calculated size of the resulting 
String causes an integer overflow, the method currently throws an 
`ArrayIndexOutOfBoundsException`. This PR replaces it with an 
`IllegalArgumentException`, accompanied by a descriptive error message.

`ArrayIndexOutOfBoundsException` is an implementation detail that leaks 
internal behavior to the caller. It does not communicate *why* the 
operation failed — it only signals that something went wrong internally.

The Guava API consistently uses `IllegalArgumentException` to signal 
that a caller passed an invalid argument. For example:
- `Preconditions.checkArgument()` throws `IllegalArgumentException`
- `Strings.padStart()` throws `IllegalArgumentException` for negative 
  padding sizes

Throwing `ArrayIndexOutOfBoundsException` in this case breaks that 
contract and forces callers to catch an unintuitive low-level exception 
when handling large repeat counts.


This fix was identified through an empirical static analysis of 
Google Guava across 20 releases (v10.0 to v29.0) using SpotBugs, 
which detected a consistent growth in the number of bugs, reaching 
851 total in v29.0. This case illustrates how static analysis can 
surface semantic inconsistencies beyond traditional bug patterns.
