### PR TITLE
Saturate count() and entryIterator() in Multisets.sum() to avoid integer overflow

### DIFF
--- a/guava-tests/test/com/google/common/collect/MultisetsTest.java
+++ b/guava-tests/test/com/google/common/collect/MultisetsTest.java
@@ -161,6 +161,37 @@ public class MultisetsTest extends TestCase {
     assertThat(sum(ms1, ms2)).containsExactly("a", "b", "a");
   }
 
+  public void testSumEntryIteratorOverflow() {
+    // Counts in each multiset that sum to more than Integer.MAX_VALUE,
+    // causing integer overflow in sum's entryIterator().
+    int count = Integer.MAX_VALUE / 2 + 1;
+    Multiset<String> ms1 = HashMultiset.create();
+    ms1.add("a", count);
+    Multiset<String> ms2 = HashMultiset.create();
+    ms2.add("a", count);
+    Multiset<String> summed = sum(ms1, ms2);
+    // The entry iterator should produce a saturated count (Integer.MAX_VALUE)
+    // rather than overflowing to a negative value and throwing.
+    java.util.Iterator<Multiset.Entry<String>> it = summed.entrySet().iterator();
+    assertTrue("entry set should have an entry", it.hasNext());
+    Multiset.Entry<String> entry = it.next();
+    assertEquals("a", entry.getElement());
+    // The count should be Integer.MAX_VALUE (saturated), not negative.
+    assertTrue("count should be non-negative but was " + entry.getCount(), entry.getCount() > 0);
+  }
+
+  public void testSumCountOverflow() {
+    // count() on the sum view should also handle overflow.
+    int count = Integer.MAX_VALUE / 2 + 1;
+    Multiset<String> ms1 = HashMultiset.create();
+    ms1.add("a", count);
+    Multiset<String> ms2 = HashMultiset.create();
+    ms2.add("a", count);
+    Multiset<String> summed = sum(ms1, ms2);
+    // count("a") should saturate to Integer.MAX_VALUE, not overflow.
+    assertTrue("count should be positive but was " + summed.count("a"), summed.count("a") > 0);
+  }
+
   public void testDifferenceWithNoRemovedElements() {
     Multiset<String> ms1 = HashMultiset.create(asList("a", "b", "a"));
     Multiset<String> ms2 = HashMultiset.create(asList("a"));

--- a/guava/src/com/google/common/collect/Multisets.java
+++ b/guava/src/com/google/common/collect/Multisets.java
@@ -567,7 +567,7 @@ public final class Multisets {
 
       @Override
       public int count(@Nullable Object element) {
-        return multiset1.count(element) + multiset2.count(element);
+        return IntMath.saturatedAdd(multiset1.count(element), multiset2.count(element));
       }
 
       @Override
@@ -590,7 +590,7 @@ public final class Multisets {
             if (iterator1.hasNext()) {
               Entry<? extends E> entry1 = iterator1.next();
               E element = entry1.getElement();
-              int count = entry1.getCount() + multiset2.count(element);
+              int count = IntMath.saturatedAdd(entry1.getCount(), multiset2.count(element));
               return immutableEntry(element, count);
             }
             while (iterator2.hasNext()) {


### PR DESCRIPTION
`Multisets.sum(a, b)`'s `size()` already guards against overflow with `IntMath.saturatedAdd`, but `count()` and `entryIterator()` add the per-element counts with a plain `+`. When two multisets each hold close to `Integer.MAX_VALUE` of an element, the sum overflows to a **negative count** — which violates the `Multiset` contract (counts are non-negative) and makes `immutableEntry`'s `checkNonnegative` throw `IllegalArgumentException` (`count cannot be negative but was: -2147483648`).

This applies `IntMath.saturatedAdd` in `count()` and `entryIterator()`, matching what `size()` already does, so the count saturates at `Integer.MAX_VALUE`. Adds regression tests for both paths.
