### PR TITLE
ClassPath: Reject manifest Class-Path entries that escape the JAR's parent directory

### DIFF
--- a/guava-tests/test/com/google/common/reflect/ClassPathTest.java
+++ b/guava-tests/test/com/google/common/reflect/ClassPathTest.java
@@ -400,6 +400,27 @@ public class ClassPathTest extends TestCase {
         .containsExactly(fullpath("base/relative.jar"));
   }
 
+  public void testGetClassPathFromManifest_pathTraversalRejected() throws IOException {
+    File jarFile = new File("base/some.jar");
+    Manifest manifest = manifestClasspath("../outside.jar");
+    assertThat(ClassPath.getClassPathFromManifest(jarFile, manifest)).isEmpty();
+  }
+
+  public void testGetClassPathFromManifest_deepPathTraversalRejected() throws IOException {
+    File jarFile = new File("base/nested/some.jar");
+    Manifest manifest = manifestClasspath("../../outside.jar");
+    assertThat(ClassPath.getClassPathFromManifest(jarFile, manifest)).isEmpty();
+  }
+
+  public void testGetClassPathFromManifest_mixedValidAndTraversal() throws IOException {
+    if (isWindows()) {
+      return;
+    }
+    File jarFile = new File("base/some.jar");
+    Manifest manifest = manifestClasspath("valid.jar ../escape.jar");
+    assertThat(ClassPath.getClassPathFromManifest(jarFile, manifest))
+        .containsExactly(fullpath("base/valid.jar"));
+  }
   public void testGetClassName() {
     assertThat(ClassPath.getClassName("abc/d/Abc.class")).isEqualTo("abc.d.Abc");
   }

--- a/guava/src/com/google/common/reflect/ClassPath.java
+++ b/guava/src/com/google/common/reflect/ClassPath.java
@@ -593,13 +593,36 @@ public final class ClassPath {
           continue;
         }
         if (url.getProtocol().equals("file")) {
-          builder.add(toFile(url));
+          File resolved = toFile(url);
+          if (!path.contains(":") && !isWithinParentDirectory(jarFile, resolved)) {
+            logger.warning(
+                "Class-Path entry escapes the jar file's directory: "
+                    + path
+                    + " (resolved to "
+                    + resolved
+                    + ")");
+            continue;
+          }
+          builder.add(resolved);
         }
       }
     }
     return builder.build();
   }
-
+  private static boolean isWithinParentDirectory(File jarFile, File resolved) {
+    try {
+      File jarDir = jarFile.getCanonicalFile().getParentFile();
+      if (jarDir == null) {
+        return false;
+      }
+      String resolvedPath = resolved.getCanonicalPath();
+      String jarDirPath = jarDir.getCanonicalPath() + File.separator;
+      return resolvedPath.startsWith(jarDirPath)
+          || resolvedPath.equals(jarDir.getCanonicalPath());
+    } catch (IOException e) {
+      return false;
+    }
+  }
   @VisibleForTesting
   static ImmutableMap<File, ClassLoader> getClassPathEntries(ClassLoader classloader) {
     LinkedHashMap<File, ClassLoader> entries = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary

`getClassPathFromManifest()` resolves relative `Class-Path` manifest entries via `new URL(jarFile.toURI().toURL(), path)` without validating that the resolved path remains within the originating JAR's parent directory. This allows a manifest containing entries like `../sensitive.jar` to cause `ClassPath.from()` to recursively scan and expose resources from JARs outside the intended classpath scope.

Issue Tracker: 520917227

## Problem

The existing safeguards (protocol restriction to `file:` URLs, deduplication via canonical path) do not prevent relative path traversal. Resources from out-of-scope JARs can be discovered and read via `ResourceInfo.asByteSource()` without triggering classloader security mechanisms.

This is relevant in environments that process untrusted or semi-trusted JARs, such as plugin systems, build tools, or CI/CD pipelines.

## Fix

Added a containment check in `getClassPathFromManifest()` that validates the canonical path of each resolved relative Class-Path entry against the parent directory of the originating JAR file. Entries that escape the directory boundary are logged as warnings and skipped.

Absolute `file:` URLs (used by Maven surefire and similar tools) are not affected by this check.

## Tests

Added three test cases:
- `testGetClassPathFromManifest_pathTraversalRejected` — single `../` traversal
- `testGetClassPathFromManifest_deepPathTraversalRejected` — nested `../../` traversal
- `testGetClassPathFromManifest_mixedValidAndTraversal` — mix of valid and traversal entries

All 46 existing ClassPathTest cases pass with this change.

## Related

- #2648 — addressed symlink cycles in ClassPath scanning (different root cause, fixed deduplication only)
