### PR TITLE
Document how limit() interacts with omitEmptyStrings() in Splitter

### DIFF
--- a/android/guava/src/com/google/common/base/Splitter.java
+++ b/android/guava/src/com/google/common/base/Splitter.java
@@ -300,6 +300,8 @@ public final class Splitter {
    * iterable, but when using this option, it can (if the input sequence consists of nothing but
    * separators).
    *
+   * <p>If a limit is also specified, see {@link #limit} for how the two options interact.
+   *
    * @return a splitter with the desired configuration
    */
   public Splitter omitEmptyStrings() {
@@ -317,6 +319,13 @@ public final class Splitter {
    * an iterable containing {@code ["a", "b", "c,d"]}. When trim is requested, all entries are
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
+   *
+   * <p>Note that when empty strings are omitted, they do not count even in determining where the
+   * final element begins. The final element starts with the first piece that is not omitted, so
+   * separators that delimit omitted empty strings do not appear in it, even though later separators
+   * do. For example, {@code Splitter.on(',').limit(2).omitEmptyStrings().split("a,,b,c")} returns
+   * an iterable containing {@code ["a", "b,c"]}, not {@code ["a", ",b,c"]}: the second comma
+   * delimits an empty string, so it is not part of the final element.
    *
    * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration

--- a/guava/src/com/google/common/base/Splitter.java
+++ b/guava/src/com/google/common/base/Splitter.java
@@ -300,6 +300,8 @@ public final class Splitter {
    * iterable, but when using this option, it can (if the input sequence consists of nothing but
    * separators).
    *
+   * <p>If a limit is also specified, see {@link #limit} for how the two options interact.
+   *
    * @return a splitter with the desired configuration
    */
   public Splitter omitEmptyStrings() {
@@ -317,6 +319,13 @@ public final class Splitter {
    * an iterable containing {@code ["a", "b", "c,d"]}. When trim is requested, all entries are
    * trimmed, including the last. Hence {@code Splitter.on(',').limit(3).trimResults().split(" a , b
    * , c , d ")} results in {@code ["a", "b", "c , d"]}.
+   *
+   * <p>Note that when empty strings are omitted, they do not count even in determining where the
+   * final element begins. The final element starts with the first piece that is not omitted, so
+   * separators that delimit omitted empty strings do not appear in it, even though later separators
+   * do. For example, {@code Splitter.on(',').limit(2).omitEmptyStrings().split("a,,b,c")} returns
+   * an iterable containing {@code ["a", "b,c"]}, not {@code ["a", ",b,c"]}: the second comma
+   * delimits an empty string, so it is not part of the final element.
    *
    * @param maxItems the maximum number of items returned
    * @return a splitter with the desired configuration


### PR DESCRIPTION
Fixes #3910

When `limit()` and `omitEmptyStrings()` are combined, empty pieces are omitted even while determining where the final element begins: the final element starts with the first piece that is not omitted, so separators that delimit omitted empty strings are consumed rather than included in the final element, while later separators are preserved.

For example:

```java
Splitter.on(',').limit(2).omitEmptyStrings().split("a,,b,c")   // [a, b,c]
Splitter.on(',').limit(2).split("a,,b,c")                     // [a, ,b,c]
```

This surprised at least one user (https://stackoverflow.com/q/62026064, linked from the issue), because the `limit()` javadoc only explained that omitted strings do not count toward the limit — it said nothing about content being dropped from the final element. The behavior itself is long-standing and already pinned by `SplitterTest.testLimitExtraSeparatorsOmitEmpty`, and per the issue discussion, changing it is considered more dangerous than it's worth, so this PR documents it instead:

- Adds a paragraph to the `limit()` javadoc describing where the final element begins when empty strings are omitted, with a before/after example.
- Adds a cross-reference from `omitEmptyStrings()` to `limit()`, since readers of that method's docs otherwise have no hint about the interaction.

Both the `guava` and `android/guava` copies are updated identically. Javadoc-only change; the documented example output was verified against the current implementation.