### PR TITLE
Document the maximum size of a BloomFilter (fixes #2366)

### DIFF
--- a/android/guava/src/com/google/common/hash/BloomFilter.java
+++ b/android/guava/src/com/google/common/hash/BloomFilter.java
@@ -419,11 +419,19 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits. The number of bits required grows with {@code expectedInsertions}
+   * and as {@code fpp} approaches zero, so a sufficiently large {@code expectedInsertions} or small
+   * {@code fpp} will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @param fpp the desired false positive probability (must be positive and less than 1.0)
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries at the given {@code fpp} exceeds about {@code 64 *
+   *     Integer.MAX_VALUE}
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
       Funnel<? super T> funnel, int expectedInsertions, double fpp) {
@@ -444,11 +452,19 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits. The number of bits required grows with {@code expectedInsertions}
+   * and as {@code fpp} approaches zero, so a sufficiently large {@code expectedInsertions} or small
+   * {@code fpp} will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @param fpp the desired false positive probability (must be positive and less than 1.0)
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries at the given {@code fpp} exceeds about {@code 64 *
+   *     Integer.MAX_VALUE}
    * @since 19.0
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
@@ -497,10 +513,16 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits, which at the default 3% false positive probability is reached at
+   * roughly {@code 2e10} {@code expectedInsertions}; a larger value will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries exceeds about {@code 64 * Integer.MAX_VALUE}
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
       Funnel<? super T> funnel, int expectedInsertions) {
@@ -521,10 +543,16 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits, which at the default 3% false positive probability is reached at
+   * roughly {@code 2e10} {@code expectedInsertions}; a larger value will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries exceeds about {@code 64 * Integer.MAX_VALUE}
    * @since 19.0
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(

--- a/guava/src/com/google/common/hash/BloomFilter.java
+++ b/guava/src/com/google/common/hash/BloomFilter.java
@@ -429,11 +429,19 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits. The number of bits required grows with {@code expectedInsertions}
+   * and as {@code fpp} approaches zero, so a sufficiently large {@code expectedInsertions} or small
+   * {@code fpp} will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @param fpp the desired false positive probability (must be positive and less than 1.0)
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries at the given {@code fpp} exceeds about {@code 64 *
+   *     Integer.MAX_VALUE}
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
       Funnel<? super T> funnel, int expectedInsertions, double fpp) {
@@ -454,11 +462,19 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits. The number of bits required grows with {@code expectedInsertions}
+   * and as {@code fpp} approaches zero, so a sufficiently large {@code expectedInsertions} or small
+   * {@code fpp} will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @param fpp the desired false positive probability (must be positive and less than 1.0)
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries at the given {@code fpp} exceeds about {@code 64 *
+   *     Integer.MAX_VALUE}
    * @since 19.0
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
@@ -507,10 +523,16 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits, which at the default 3% false positive probability is reached at
+   * roughly {@code 2e10} {@code expectedInsertions}; a larger value will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries exceeds about {@code 64 * Integer.MAX_VALUE}
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(
       Funnel<? super T> funnel, int expectedInsertions) {
@@ -531,10 +553,16 @@ public final class BloomFilter<T extends @Nullable Object> implements Predicate<
    * ensuring proper serialization and deserialization, which is important since {@link #equals}
    * also relies on object identity of funnels.
    *
+   * <p>Because a {@code BloomFilter} is backed by a single array, it can hold at most about {@code
+   * 64 * Integer.MAX_VALUE} bits, which at the default 3% false positive probability is reached at
+   * roughly {@code 2e10} {@code expectedInsertions}; a larger value will exceed this limit.
+   *
    * @param funnel the funnel of T's that the constructed {@code BloomFilter} will use
    * @param expectedInsertions the number of expected insertions to the constructed {@code
    *     BloomFilter}; must be positive
    * @return a {@code BloomFilter}
+   * @throws IllegalArgumentException if the number of bits required to hold {@code
+   *     expectedInsertions} entries exceeds about {@code 64 * Integer.MAX_VALUE}
    * @since 19.0
    */
   public static <T extends @Nullable Object> BloomFilter<T> create(


### PR DESCRIPTION
Fixes #2366.

`BloomFilter` is backed by a single array, so it can hold at most about `64 * Integer.MAX_VALUE` bits. Asking for an `expectedInsertions`/`fpp` combination that would need more bits than that fails with an `IllegalArgumentException` ("Could not create BloomFilter of N bits"), thrown when `LockFreeBitArray` calls `Ints.checkedCast` on the backing-array length.

That limit and exception were undocumented — the `create(...)` Javadoc only said `expectedInsertions` "must be positive". As noted in #2366, this surprises users who try to hold very large numbers of elements.

This change adds, to all four public `create(...)` overloads:

- a short paragraph explaining the size cap (and, for the default-fpp overloads, the rough `~2e10` insertion point at 3%), and
- an `@throws IllegalArgumentException` tag.

Documentation only; no behavior change. The existing behavior is already covered by `BloomFilterTest` (which asserts the `IllegalArgumentException` for an over-large request). Both the JRE and Android sources are updated to stay in sync.