### PR TITLE
Fix JDiff previous-release selection for patch versions

### DIFF
--- a/_util/util.sh
+++ b/_util/util.sh
@@ -231,10 +231,14 @@ function major_version {
 readonly SNAPSHOT_CEILING="999.999.999"
 
 # Prints the highest non-rc release from the sorted list of releases produced
-# by sort_releases. If a release argument is provided, print the highest non-rc
-# release that has a major or minor version that is lower than the given
-# release. For example, given "16.0.1", return "15.0". Given "16.1", return
-# "16.0.1".
+# by sort_releases. If a release argument is provided, print the immediately
+# previous non-rc release (by full version order, including patch), so JDiff
+# and release-note labels agree. For example, given "33.4.6-jre", return
+# "33.4.5-jre". Given "16.0.1", return "16.0". Given "16.1", return "16.0.1".
+#
+# (Older logic skipped to a lower major/minor only, so patch releases like
+# 33.4.6-jre were compared against 33.3.1-jre while GitHub release notes said
+# "vs. 33.4.5-jre". See https://github.com/google/guava/issues/7765.)
 #
 # If the release argument is a "-android" release, only look at other
 # "-android" releases.
@@ -265,27 +269,22 @@ function latest_release {
   fi
 
   # Add the release we're looking for to the list, uniqueify, then sort
-  # according to our release sort order.
+  # according to our release sort order (greatest → least).
   local releases="$((echo "$non_rc_releases" && echo "$ceiling") | sort -u | sort_releases)"
 
-  ceiling_expanded="$(expand_release "$ceiling")"
-  ceiling_major="$(cut -d. -f1 <<< "$ceiling_expanded")"
-  ceiling_minor="$(cut -d. -f2 <<< "$ceiling_expanded")"
-
+  # Return the release immediately after the ceiling in that list (i.e. the
+  # highest non-rc strictly older than the ceiling). Using an explicit boolean
+  # avoids a long-standing bash pitfall: [[ "0" ]] is true, so the previous
+  # seen_ceiling=0 sentinel never actually flipped the branch.
   local release
-  local seen_ceiling=1
+  local seen_ceiling=false
   for release in $releases; do
-    if [[ "$seen_ceiling" ]]; then
-      release_expanded="$(expand_release "$release")"
-      release_major="$(cut -d. -f1 <<< "$release_expanded")"
-      release_minor="$(cut -d. -f2 <<< "$release_expanded")"
-
-      if (( release_major < ceiling_major || release_minor < ceiling_minor )); then
-        echo "$release"
-        return
-      fi
-    elif [[ "$release" == "$ceiling" ]]; then
-      seen_ceiling=0
+    if $seen_ceiling; then
+      echo "$release"
+      return
+    fi
+    if [[ "$release" == "$ceiling" ]]; then
+      seen_ceiling=true
     fi
   done
 }

--- a/updaterelease.sh
+++ b/updaterelease.sh
@@ -21,10 +21,12 @@
 # releases, though, it should always be the same as the <release>
 # argument).
 #
-# For all releases, JDiff compares the release to the previous non-rc
-# release. For example, snapshot is compared against 18.0 (even if there's
-# a 19.0-rc1 out) and 18.0 is compared against 17.0 (or 17.1 or 17.0.1 if
-# there were one of those).
+# For all releases, JDiff compares the release to the immediately previous
+# non-rc release (same flavor), by full version order including patch. For
+# example, snapshot is compared against the latest non-rc (even if there's
+# an rc out), 33.4.6-jre is compared against 33.4.5-jre, and 33.5.0-jre is
+# compared against 33.4.8-jre. Use that same previous version in GitHub
+# release-note "vs." labels so they match the JDiff page title.
 #
 #***************************************************************************
 


### PR DESCRIPTION
Fixes #7765

### Problem

GitHub release notes label JDiff as consecutive versions (e.g. `33.4.6-jre vs. 33.4.5-jre`), but `latest_release` skipped to a lower **major/minor** only, so the generated page was titled e.g. “Between Guava 33.3.1-jre and Guava 33.4.6-jre”.

That also left a latent bug: `seen_ceiling=0` never disabled the “seen” branch because `[[ "0" ]]` is true in bash, so regenerating docs for an older release while newer ones exist could pick the wrong baseline.

### Change

- `latest_release` returns the **immediately previous non-rc** release by full version order (including patch).
- Document the same policy in `updaterelease.sh`.
- Use a real boolean for `seen_ceiling`.

Verified locally against the published release name list:

| version | previous (new) |
|---------|----------------|
| 33.4.6-jre | 33.4.5-jre |
| 33.4.7-jre | 33.4.6-jre |
| 33.5.0-jre | 33.4.8-jre |
| 33.6.0-jre | 33.5.0-jre |
| 16.0.1 | 16.0 |
| 16.1 | 16.0.1 |

These match the “vs.” labels already used on recent GitHub releases.

### Notes for maintainers

- Existing published JDiff under `releases/*.tar.gz` is unchanged until `./updaterelease.sh <version>` is re-run for those versions (optional; new releases will be correct).
- Related prior attempt: #7798 (also targets `gh-pages` / `latest_release`; this PR is a smaller, full-version-order approach and references #7765).
- Happy to switch to “only fix release-note wording / omit patch JDiff links” if you prefer that direction from the issue thread instead.

### CLA

I will sign the Google CLA if the bot asks (individual CLA for `arimu1`).