### PR TITLE
Handle zero warmup periods in RateLimiter

### DIFF
--- a/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
+++ b/guava-tests/test/com/google/common/util/concurrent/RateLimiterTest.java
@@ -34,6 +34,7 @@ import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import com.google.common.util.concurrent.RateLimiter.SleepingStopwatch;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -152,6 +153,32 @@ public class RateLimiterTest extends TestCase {
     assertThrows(IllegalArgumentException.class, () -> RateLimiter.create(0.0, 1, NANOSECONDS));
 
     assertThrows(IllegalArgumentException.class, () -> RateLimiter.create(1.0, -1, NANOSECONDS));
+  }
+
+  public void testZeroWarmupIsEquivalentToNoWarmup() {
+    RateLimiter limiter = RateLimiter.create(5.0, 0, SECONDS, 3.0, stopwatch);
+    limiter.acquire();
+    limiter.acquire();
+    limiter.acquire();
+    assertEvents("R0.00", "R0.20", "R0.20");
+  }
+
+  public void testZeroDurationWarmupIsEquivalentToNoWarmup() {
+    RateLimiter limiter = RateLimiter.create(Double.MIN_VALUE, Duration.ZERO);
+    assertTrue(limiter.tryAcquire());
+    assertFalse(limiter.tryAcquire());
+  }
+
+  public void testSubMicrosecondWarmupIsEquivalentToNoWarmup() {
+    RateLimiter limiter = RateLimiter.create(Double.MIN_VALUE, 1, NANOSECONDS);
+    assertTrue(limiter.tryAcquire());
+    assertFalse(limiter.tryAcquire());
+  }
+
+  public void testSubMicrosecondDurationWarmupIsEquivalentToNoWarmup() {
+    RateLimiter limiter = RateLimiter.create(Double.MIN_VALUE, Duration.ofNanos(1));
+    assertTrue(limiter.tryAcquire());
+    assertFalse(limiter.tryAcquire());
   }
 
   @AndroidIncompatible // difference in String.format rounding?

--- a/guava/src/com/google/common/util/concurrent/RateLimiter.java
+++ b/guava/src/com/google/common/util/concurrent/RateLimiter.java
@@ -156,6 +156,8 @@ public abstract class RateLimiter {
    * <p>The returned {@code RateLimiter} starts in a "cold" state (i.e. the warmup period will
    * follow), and if it is left unused for long enough, it will return to that state.
    *
+   * <p>A {@code warmupPeriod} of zero is equivalent to {@link #create(double)}.
+   *
    * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
    *     permits become available per second
    * @param warmupPeriod the duration of the period where the {@code RateLimiter} ramps up its rate,
@@ -184,6 +186,8 @@ public abstract class RateLimiter {
    * <p>The returned {@code RateLimiter} starts in a "cold" state (i.e. the warmup period will
    * follow), and if it is left unused for long enough, it will return to that state.
    *
+   * <p>A {@code warmupPeriod} of zero is equivalent to {@link #create(double)}.
+   *
    * @param permitsPerSecond the rate of the returned {@code RateLimiter}, measured in how many
    *     permits become available per second
    * @param warmupPeriod the duration of the period where the {@code RateLimiter} ramps up its rate,
@@ -206,6 +210,11 @@ public abstract class RateLimiter {
       TimeUnit unit,
       double coldFactor,
       SleepingStopwatch stopwatch) {
+    checkNotNull(unit);
+    // SmoothWarmingUp operates in microseconds and cannot represent a shorter warmup period.
+    if (warmupPeriod >= 0 && unit.toMicros(warmupPeriod) == 0) {
+      return create(permitsPerSecond, stopwatch);
+    }
     RateLimiter rateLimiter = new SmoothWarmingUp(stopwatch, warmupPeriod, unit, coldFactor);
     rateLimiter.setRate(permitsPerSecond);
     return rateLimiter;


### PR DESCRIPTION
## Summary

When a `RateLimiter` is created with a zero warmup period, `SmoothWarmingUp` converts the period to zero microseconds and performs calculations that produce `NaN`. This can cause the limiter to stop throttling requests.

We encountered this in production: traffic bypassed the intended rate limit and overloaded downstream systems.

This change treats a nonnegative warmup period that converts to zero microseconds as equivalent to creating a limiter without warmup. Checking the converted value also covers sub-microsecond inputs such as `1 NANOSECOND` and `Duration.ofNanos(1)`.

## Tests

Added coverage for:

- zero warmup with a controllable stopwatch
- `Duration.ZERO`
- sub-microsecond `TimeUnit` values
- sub-microsecond `Duration` values

`RateLimiterTest`: 34 tests passed.

Fixes #2730.
Related to #3724.