### PR TITLE
Make Lists.transform() views delegate spliterator()/forEach() to the backing list

### DIFF
--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -820,6 +821,62 @@ public class ListsTest extends TestCase {
     List<Integer> fromList = new LinkedList<>(SOME_SEQUENTIAL_LIST);
     List<String> list = transform(fromList, SOME_FUNCTION);
     assertTransformIterator(list);
+  }
+
+  @GwtIncompatible // CopyOnWriteArrayList, Spliterator
+  public void testTransformSpliteratorDoesNotThrowConcurrentModificationException() {
+    // CopyOnWriteArrayList is documented to never throw ConcurrentModificationException; Lists
+    // .transform() is documented to return a threadsafe list when the input list and function are
+    // threadsafe. The spliterator of the transformed list must honor that by delegating to the
+    // backing list's own (snapshotting) spliterator, rather than falling back to the JDK's default
+    // index-based RandomAccessSpliterator, which translates concurrent structural changes into a
+    // ConcurrentModificationException.
+    CopyOnWriteArrayList<Integer> fromList = new CopyOnWriteArrayList<>(SOME_LIST);
+    List<String> transformed = transform(fromList, SOME_FUNCTION);
+
+    Spliterator<String> spliterator = transformed.spliterator();
+    List<String> results = new ArrayList<>();
+    assertTrue(spliterator.tryAdvance(results::add));
+
+    // Structurally mutate the backing list after the spliterator was created but before it has
+    // finished being consumed.
+    fromList.clear();
+
+    // Must not throw, and must still report the elements from the original snapshot, exactly as
+    // fromList.spliterator() itself would.
+    spliterator.forEachRemaining(results::add);
+    assertEquals(SOME_STRING_LIST, results);
+  }
+
+  @GwtIncompatible // CopyOnWriteArrayList, Spliterator
+  public void testTransformSpliteratorPropagatesBackingListCharacteristics() {
+    CopyOnWriteArrayList<Integer> fromList = new CopyOnWriteArrayList<>(SOME_LIST);
+    List<String> transformed = transform(fromList, SOME_FUNCTION);
+
+    // CopyOnWriteArrayList.spliterator() reports IMMUTABLE (among other bits); a spliterator that
+    // instead falls back to the default RandomAccessSpliterator would not, since that
+    // implementation has no way of knowing the backing list is safe to snapshot.
+    assertTrue(transformed.spliterator().hasCharacteristics(Spliterator.IMMUTABLE));
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testTransformSpliteratorRandomAccess() {
+    List<Integer> fromList = new ArrayList<>(SOME_LIST);
+    List<String> transformed = transform(fromList, SOME_FUNCTION);
+
+    List<String> results = new ArrayList<>();
+    transformed.spliterator().forEachRemaining(results::add);
+    assertEquals(SOME_STRING_LIST, results);
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testTransformForEachRandomAccess() {
+    List<Integer> fromList = new ArrayList<>(SOME_LIST);
+    List<String> transformed = transform(fromList, SOME_FUNCTION);
+
+    List<String> results = new ArrayList<>();
+    transformed.forEach(results::add);
+    assertEquals(SOME_STRING_LIST, results);
   }
 
   /**

--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -51,7 +51,9 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 
@@ -659,6 +661,18 @@ public final class Lists {
     @Override
     public boolean isEmpty() {
       return fromList.isEmpty();
+    }
+
+    @Override
+    @GwtIncompatible // Spliterator
+    public Spliterator<T> spliterator() {
+      return CollectSpliterators.map(fromList.spliterator(), 0, function);
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action) {
+      checkNotNull(action);
+      fromList.forEach((F f) -> action.accept(function.apply(f)));
     }
 
     @Override


### PR DESCRIPTION
Fixes #8165

## Problem

`Lists.transform()` returns a view backed by `TransformingRandomAccessList`
when the input list implements `RandomAccess`. That class didn't override
`spliterator()`, so it inherited the JDK's default `List.spliterator()`,
which for `RandomAccess` lists falls back to
`AbstractList.RandomAccessSpliterator`. That implementation is index-based
and translates concurrent structural changes into a
`ConcurrentModificationException` — even when the backing list is
documented to never throw one (e.g. `CopyOnWriteArrayList`).

As reported in #8165, streaming over `Lists.transform(coWriteArrayList, fn)`
while the backing list is concurrently mutated throws
`ConcurrentModificationException` from
`AbstractList$RandomAccessSpliterator.get`, even though
`CopyOnWriteArrayList` itself guarantees it never throws that exception.

## Fix

`TransformingRandomAccessList` now overrides:

- `spliterator()` — delegates to `fromList.spliterator()` via
  `CollectSpliterators.map()`, so the transformed view's spliterator
  inherits the backing list's actual splitting and concurrency behavior
  instead of falling back to the generic index-based one. This also fixes
  the transformed view's spliterator not reporting characteristics (e.g.
  `IMMUTABLE`) that the backing list's spliterator has.
- `forEach()` — delegates straight to `fromList.forEach(...)`, for the
  same reason.

`TransformingSequentialList` (the non-`RandomAccess` sibling) isn't
affected: it never falls back to the JDK's `RandomAccessSpliterator` in
the first place.

This is a behavioral bug fix only — no public API signatures change.

## Testing

Added tests to `ListsTest` covering: the reported
`ConcurrentModificationException` scenario against a
`CopyOnWriteArrayList`, spliterator-characteristics propagation from the
backing list, and baseline `spliterator()`/`forEach()` behavior on a plain
`RandomAccess` list. Ran the full build locally
(`./mvnw clean install -Dtest=ListsTest -Dsurefire.failIfNoSpecifiedTests=false`)
— all tests pass, including the GWT-compatible-libs module.
