### PR TITLE
Document Gradle base-plugin variant-resolution gotcha and its jvm-ecosystem workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ For more information on when to use `api` and when to use `implementation`,
 consult the
 [Gradle documentation on API and implementation separation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).
 
+If your Gradle project applies only the `base` plugin (not `java`,
+`java-library`, or `jvm-ecosystem`) and picks up Guava only transitively
+(through another dependency), you may see dependency resolution fail with
+`NoCompatibleVariantsFailure`. This happens because Guava's Gradle module
+metadata tags each variant with an `org.gradle.jvm.environment` attribute (to
+pick between `-jre` and `-android`), and only Java-aware plugins register the
+Gradle schema needed to interpret that attribute. Applying
+[`jvm-ecosystem`](https://docs.gradle.org/current/userguide/jvm_ecosystem_plugin.html)
+alongside `base` registers that schema, without adding any Java build tasks:
+
+```gradle
+plugins {
+  base
+  `jvm-ecosystem`
+}
+```
+
 ## Snapshots and Documentation
 
 Snapshots of Guava built from the `master` branch are available through Maven


### PR DESCRIPTION
## What

Adds a short note to the "Adding Guava to your build" section of README.md
explaining a Gradle dependency-resolution failure some users hit, and the
one-line fix.

## Why

Fixes #8398.

Projects that apply only Gradle's `base` plugin (not `java`, `java-library`,
or `jvm-ecosystem`) and depend on Guava only *transitively* (through another
library, e.g. javaparser) can hit `NoCompatibleVariantsFailure` when Gradle
tries to resolve Guava.

Root cause: Guava's Gradle Module Metadata tags every variant with an
`org.gradle.jvm.environment` attribute, used to disambiguate the `-jre` and
`-android` flavors. Only Java-aware plugins register the Gradle
`AttributesSchema` needed to interpret that attribute — `base` alone does
not, so resolution fails.

A verified one-line workaround exists: applying Gradle's built-in
`jvm-ecosystem` plugin alongside `base` registers the missing schema without
adding any Java build tasks. This was confirmed against the reporter's
minimal repro (https://github.com/Saxonica/guava-variant-problem) on Gradle
9.5 / Guava 33.6.0-jre.

A prior attempt at a code-level fix (#8442, adding fallback GMM variants
without the attribute) was reviewed and declined as unnecessarily invasive
given this workaround; the issue was relabeled `type=documentation`
accordingly. This PR is the suggested documentation-only fix.

## Testing

Docs-only change; no code affected. Verified the added Markdown renders
correctly and matches the surrounding section's formatting/line-wrap style.

RELNOTES=n/a
