### PR TITLE
Add MediaType.APPLICATION_GZIP for application/gzip

### DIFF
--- a/guava-tests/test/com/google/common/net/MediaTypeTest.java
+++ b/guava-tests/test/com/google/common/net/MediaTypeTest.java
@@ -158,6 +158,15 @@ public class MediaTypeTest extends TestCase {
     assertThat(newType.subtype()).isEqualTo("yams");
   }
 
+  public void testGzipMediaTypes() {
+    assertThat(MediaType.APPLICATION_GZIP.type()).isEqualTo("application");
+    assertThat(MediaType.APPLICATION_GZIP.subtype()).isEqualTo("gzip");
+    assertThat(MediaType.GZIP.type()).isEqualTo("application");
+    assertThat(MediaType.GZIP.subtype()).isEqualTo("x-gzip");
+    assertThat(MediaType.parse("application/gzip")).isSameInstanceAs(MediaType.APPLICATION_GZIP);
+    assertThat(MediaType.parse("application/x-gzip")).isSameInstanceAs(MediaType.GZIP);
+  }
+
   public void testCreateAudioType() {
     MediaType newType = MediaType.createAudioType("yams");
     assertThat(newType.type()).isEqualTo("audio");

--- a/guava/src/com/google/common/net/MediaType.java
+++ b/guava/src/com/google/common/net/MediaType.java
@@ -548,7 +548,23 @@ public final class MediaType {
    */
   public static final MediaType GEO_JSON = createConstant(APPLICATION_TYPE, "geo+json");
 
-  /** Gzip-compressed data. */
+  /**
+   * Gzip-compressed data, as registered in <a
+   * href="https://datatracker.ietf.org/doc/html/rfc6713">RFC 6713</a> ({@code application/gzip}).
+   *
+   * <p>Prefer this constant over {@link #GZIP}, which uses the legacy {@code application/x-gzip}
+   * type.
+   *
+   * @since 33.8.0
+   */
+  public static final MediaType APPLICATION_GZIP = createConstant(APPLICATION_TYPE, "gzip");
+
+  /**
+   * Gzip-compressed data using the legacy {@code application/x-gzip} type.
+   *
+   * <p>RFC 6713 registers {@code application/gzip} and says the {@code x-} prefixed form should no
+   * longer be used. Prefer {@link #APPLICATION_GZIP}.
+   */
   public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
   /**


### PR DESCRIPTION
`MediaType.GZIP` is still `application/x-gzip`. RFC 6713 registered `application/gzip` and discourages the `x-` form, so callers who want the IANA type have no constant and `parse("application/gzip")` is not interned.

This adds `MediaType.APPLICATION_GZIP` (`application/gzip`) and leaves `GZIP` as `application/x-gzip` so existing callers are unchanged.

Fixes #3946