### PR TITLE
Fix a/an grammar typos in comments

### DIFF
--- a/guava/src/com/google/common/cache/LocalCache.java
+++ b/guava/src/com/google/common/cache/LocalCache.java
@@ -4791,7 +4791,7 @@ final class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<
   }
 
   /**
-   * Serializes the configuration of a LocalCache, reconstituting it as an LoadingCache using
+   * Serializes the configuration of a LocalCache, reconstituting it as a LoadingCache using
    * CacheBuilder upon deserialization. An instance of this class is fit for use by the writeReplace
    * of LocalLoadingCache.
    *

--- a/guava/src/com/google/common/collect/MultimapBuilder.java
+++ b/guava/src/com/google/common/collect/MultimapBuilder.java
@@ -103,7 +103,7 @@ public abstract class MultimapBuilder<K0 extends @Nullable Object, V0 extends @N
   }
 
   /**
-   * Uses an hash table to map keys to value collections, initialized to expect the specified number
+   * Uses a hash table to map keys to value collections, initialized to expect the specified number
    * of keys.
    *
    * <p>The collections returned by {@link Multimap#keySet()}, {@link Multimap#keys()}, and {@link

--- a/guava/src/com/google/common/graph/NetworkBuilder.java
+++ b/guava/src/com/google/common/graph/NetworkBuilder.java
@@ -50,7 +50,7 @@ import org.jspecify.annotations.Nullable;
  * flightNetwork.addEdge("LAX", "ATL", 1598);
  * flightNetwork.addEdge("ATL", "LAX", 2450);
  *
- * // Building a immutable network
+ * // Building an immutable network
  * ImmutableNetwork<String, Integer> immutableNetwork =
  *     NetworkBuilder.directed()
  *         .allowsParallelEdges(true)

--- a/guava/src/com/google/common/primitives/Ints.java
+++ b/guava/src/com/google/common/primitives/Ints.java
@@ -75,7 +75,7 @@ public final class Ints extends IntsMethodsForWeb {
    */
   @InlineMe(replacement = "Integer.hashCode(value)")
   @InlineMeValidationDisabled(
-      "The hash code of a int is the int itself, so it's simplest to return that.")
+      "The hash code of an int is the int itself, so it's simplest to return that.")
   public static int hashCode(int value) {
     return value;
   }


### PR DESCRIPTION
Fix four a/an article typos in Javadoc/comments:

- NetworkBuilder: "a immutable" to "an immutable"
- Ints: "a int" to "an int"
- MultimapBuilder: "an hash table" to "a hash table"
- LocalCache: "an LoadingCache" to "a LoadingCache"

No API changes.
