### PR TITLE
Update actions/setup-java to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       # - 11 (sometimes) to *download* to support anyone who runs JDiff or our Gradle integration tests (including our doc snapshots and our Java 11 CI test run) but not to use directly
       # - 26 for running Javadoc and javac (to help people who build Guava locally and might not use a recent JDK to run Maven)
       - name: 'Set up JDKs'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: |
             ${{ matrix.java }}
@@ -69,7 +69,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'Set up JDKs'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         # For the usage of the JDK 11+17, see util/gradle_integration_tests.sh
         # And 26 is for running javac (as configured in the Maven build), as usual.
         with:
@@ -96,7 +96,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'Set up JDKs'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           # For discussion, see the first setup-java block.
           # The publish-snapshot workflow doesn't run tests, so we don't have to care which version Maven would select for that step.
@@ -125,7 +125,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'Set up JDKs'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           # For discussion, see the first setup-java block.
           # The generate-docs workflow doesn't run tests, so we don't have to care which version Maven would select for that step.


### PR DESCRIPTION
Updates all pinned `actions/setup-java` references in the CI workflow from v5.6.0 to the v6.0.0 commit.

Validation: verified all active workflow references use setup-java v6 and ran `git diff --check`.