### PR TITLE
Make `BaseEncoding.encodingStream().close()` idempotent.

### DIFF
--- a/guava-tests/test/com/google/common/io/BaseEncodingTest.java
+++ b/guava-tests/test/com/google/common/io/BaseEncodingTest.java
@@ -558,6 +558,17 @@ public class BaseEncodingTest extends TestCase {
     }
   }
 
+  @GwtIncompatible // Writer
+  public void testEncodingStream_closeIsIdempotent() throws IOException {
+    StringWriter writer = new StringWriter();
+    OutputStream encodingStream = base64().encodingStream(writer);
+    encodingStream.write(0);
+    encodingStream.close();
+    assertThat(writer.toString()).isEqualTo("AA==");
+    encodingStream.close();
+    assertThat(writer.toString()).isEqualTo("AA==");
+  }
+
   public void testToString() {
     assertThat(base64().toString()).isEqualTo("BaseEncoding.base64().withPadChar('=')");
     assertThat(base32Hex().omitPadding().toString())

--- a/guava/src/com/google/common/io/BaseEncoding.java
+++ b/guava/src/com/google/common/io/BaseEncoding.java
@@ -646,6 +646,7 @@ public abstract class BaseEncoding {
         int bitBuffer = 0;
         int bitBufferLength = 0;
         int writtenChars = 0;
+        boolean closed = false;
 
         @Override
         public void write(int b) throws IOException {
@@ -667,6 +668,10 @@ public abstract class BaseEncoding {
 
         @Override
         public void close() throws IOException {
+          if (closed) {
+            return;
+          }
+          closed = true;
           if (bitBufferLength > 0) {
             int charIndex = (bitBuffer << (alphabet.bitsPerChar - bitBufferLength)) & alphabet.mask;
             out.write(alphabet.encode(charIndex));
@@ -677,6 +682,7 @@ public abstract class BaseEncoding {
                 writtenChars++;
               }
             }
+            bitBufferLength = 0;
           }
           out.close();
         }


### PR DESCRIPTION
## Problem

[`Closeable.close()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Closeable.html#close()) specifies that closing an already-closed stream must have no effect. Today, calling `close()` twice on a `BaseEncoding.encodingStream()` can write extra padding characters on the second call.

Reproduction:

```java
StringWriter w = new StringWriter();
OutputStream out = BaseEncoding.base64().encodingStream(w);
out.write(0);
out.close();
System.out.println(w); // AA==
out.close();
System.out.println(w); // AA==A=== (incorrect)
```

Fixes #5284

## Solution

Track a `closed` flag on the encoding stream and return immediately from subsequent `close()` calls. Reset `bitBufferLength` after flushing any remaining bits on the first close.

## Testing

```
$ export JAVA_HOME=~/.m2/jdks/jdk-26.0.2+10/Contents/Home
$ ./mvnw -B -Dtoolchain.skip -P!standard-with-extra-repos test \
    -Dmaven.javadoc.skip=true -Dsurefire.toolchain.version=17 \
    -Dtest=BaseEncodingTest#testEncodingStream_closeIsIdempotent \
    -DfailIfNoTests=false -pl guava-tests -am

[INFO] Running com.google.common.io.BaseEncodingTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```