### PR TITLE
Make `Lists.transform()` delegate `spliterator()` to the backing list.

### DIFF
--- a/guava-tests/test/com/google/common/collect/ListsTest.java
+++ b/guava-tests/test/com/google/common/collect/ListsTest.java
@@ -61,7 +61,9 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -672,6 +674,57 @@ public class ListsTest extends TestCase {
   public void testTransformHashCodeSequential() {
     List<String> list = transform(SOME_SEQUENTIAL_LIST, SOME_FUNCTION);
     assertEquals(SOME_STRING_LIST.hashCode(), list.hashCode());
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testTransformSpliterator_delegatesCharacteristics_randomAccess() {
+    CopyOnWriteArrayList<Integer> cowList = new CopyOnWriteArrayList<>(asList(1, 2, 3));
+    assertEquals(
+        cowList.spliterator().characteristics(),
+        transform(cowList, i -> i).spliterator().characteristics());
+
+    ArrayList<Integer> arrayList = new ArrayList<>(asList(1, 2, 3));
+    assertEquals(
+        arrayList.spliterator().characteristics(),
+        transform(arrayList, i -> i).spliterator().characteristics());
+  }
+
+  @GwtIncompatible // Spliterator
+  public void testTransformSpliterator_delegatesCharacteristics_sequential() {
+    LinkedList<Integer> fromList = new LinkedList<>(asList(1, 2, 3));
+    Spliterator<Integer> spliterator = transform(fromList, i -> i).spliterator();
+    assertTrue(spliterator.hasCharacteristics(Spliterator.ORDERED));
+    assertTrue(spliterator.hasCharacteristics(Spliterator.SIZED));
+  }
+
+  @GwtIncompatible // Spliterator, CopyOnWriteArrayList
+  public void testTransformSpliterator_concurrentStreamDoesNotThrow() throws Exception {
+    CopyOnWriteArrayList<Integer> fromList = new CopyOnWriteArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      fromList.add(i);
+    }
+    List<Integer> view = transform(fromList, i -> i);
+    AtomicBoolean stop = new AtomicBoolean();
+    Thread mutator =
+        new Thread(
+            () -> {
+              while (!stop.get()) {
+                for (int i = 0; i < 1000; i++) {
+                  fromList.add(i);
+                }
+                fromList.clear();
+              }
+            });
+    mutator.setDaemon(true);
+    mutator.start();
+    try {
+      for (int i = 0; i < 100; i++) {
+        view.stream().forEach(x -> {});
+      }
+    } finally {
+      stop.set(true);
+      mutator.join(1000);
+    }
   }
 
   public void testTransformModifiableRandomAccess() {

--- a/guava/src/com/google/common/collect/Lists.java
+++ b/guava/src/com/google/common/collect/Lists.java
@@ -51,6 +51,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Spliterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
@@ -605,6 +606,12 @@ public final class Lists {
       return fromList.removeIf(element -> filter.test(function.apply(element)));
     }
 
+    @Override
+    @GwtIncompatible // Spliterator
+    public Spliterator<T> spliterator() {
+      return CollectSpliterators.map(fromList.spliterator(), 0, function::apply);
+    }
+
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;
   }
 
@@ -676,6 +683,12 @@ public final class Lists {
     @Override
     public int size() {
       return fromList.size();
+    }
+
+    @Override
+    @GwtIncompatible // Spliterator
+    public Spliterator<T> spliterator() {
+      return CollectSpliterators.map(fromList.spliterator(), 0, function::apply);
     }
 
     @GwtIncompatible @J2ktIncompatible private static final long serialVersionUID = 0;


### PR DESCRIPTION
## Problem

`Lists.transform()` list views did not override `spliterator()`. They inherited `AbstractList`/`AbstractSequentialList` spliterators that iterate via indexed access or list iterators on the transformed view. For backing lists with special spliterator behavior (notably `CopyOnWriteArrayList`, whose spliterator snapshots the array), streaming over the transformed view could throw `ConcurrentModificationException` while the backing list was being modified concurrently.

Example from the issue:

```java
var cow = new CopyOnWriteArrayList<Integer>();
// ... concurrent adds/clears in another thread ...
Lists.transform(cow, s -> s).stream().forEach(x -> {}); // CME
```

Fixes #8165

## Solution

Override `spliterator()` on both `TransformingRandomAccessList` and `TransformingSequentialList` to delegate through `CollectSpliterators.map(fromList.spliterator(), …)`, matching `Collections2.transform` and `Iterables.transform`.

## Testing

```
$ export JAVA_HOME=~/.m2/jdks/jdk-26.0.2+10/Contents/Home
$ ./mvnw -B -Dtoolchain.skip test -Dmaven.javadoc.skip=true \
    -Dsurefire.toolchain.version=17 \
    '-Dtest=com.google.common.collect.ListsTest#testTransformSpliterator*' \
    -DfailIfNoTests=false -pl guava-tests -am

[INFO] Tests run: 6002, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

New tests verify characteristic delegation for random-access and sequential transforms, and that streaming over `Lists.transform(copyOnWriteArrayList, …)` does not throw while the backing list is mutated concurrently.
