### PR TITLE
Avoid recursion when MultiReader advances past empty readers

### DIFF
--- a/guava-tests/test/com/google/common/io/MultiReaderTest.java
+++ b/guava-tests/test/com/google/common/io/MultiReaderTest.java
@@ -17,6 +17,7 @@
 package com.google.common.io;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.nCopies;
 
 import com.google.common.collect.ImmutableList;
 import java.io.FilterReader;
@@ -77,6 +78,13 @@ public class MultiReaderTest extends TestCase {
 
     String expectedString = testString + testString;
     assertThat(CharStreams.toString(joinedReader)).isEqualTo(expectedString);
+  }
+
+  public void testRead_noStackOverflow_manyEmptySources() throws IOException {
+    try (Reader joinedReader =
+        CharSource.concat(nCopies(100_000, CharSource.empty())).openStream()) {
+      assertEquals(-1, joinedReader.read());
+    }
   }
 
   private static CharSource newCharSource(String text) {

--- a/guava/src/com/google/common/io/MultiReader.java
+++ b/guava/src/com/google/common/io/MultiReader.java
@@ -52,15 +52,14 @@ final class MultiReader extends Reader {
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
     checkNotNull(cbuf);
-    if (current == null) {
-      return -1;
-    }
-    int result = current.read(cbuf, off, len);
-    if (result == -1) {
+    while (current != null) {
+      int result = current.read(cbuf, off, len);
+      if (result != -1) {
+        return result;
+      }
       advance();
-      return read(cbuf, off, len);
     }
-    return result;
+    return -1;
   }
 
   @Override


### PR DESCRIPTION
Addresses  https://github.com/google/guava/issues/8661

### Summary

- Replace recursive EOF advancement in `MultiReader.read(char[], int, int)` with an iterative loop.
- Add a regression test covering 100,000 consecutive empty `CharSource` instances.

This prevents `StackOverflowError` for valid concatenations containing many empty sources and matches the existing iterative behavior in `MultiInputStream`.

