### PR TITLE
fix: avoid stack overflow in MultiReader

### DIFF
--- a/guava-tests/test/com/google/common/io/MultiReaderTest.java
+++ b/guava-tests/test/com/google/common/io/MultiReaderTest.java
@@ -79,6 +79,16 @@ public class MultiReaderTest extends TestCase {
     assertThat(CharStreams.toString(joinedReader)).isEqualTo(expectedString);
   }
 
+  public void testReadWithManyEmptySourcesDoesNotOverflowStack() throws Exception {
+    ImmutableList.Builder<CharSource> sources = ImmutableList.builder();
+    for (int i = 0; i < 100_000; i++) {
+      sources.add(newCharSource(""));
+    }
+
+    Reader joinedReader = CharSource.concat(sources.build()).openStream();
+    assertEquals(-1, joinedReader.read());
+  }
+
   private static CharSource newCharSource(String text) {
     return new CharSource() {
       @Override

--- a/guava/src/com/google/common/io/MultiReader.java
+++ b/guava/src/com/google/common/io/MultiReader.java
@@ -52,15 +52,14 @@ final class MultiReader extends Reader {
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
     checkNotNull(cbuf);
-    if (current == null) {
-      return -1;
-    }
-    int result = current.read(cbuf, off, len);
-    if (result == -1) {
+    while (current != null) {
+      int result = current.read(cbuf, off, len);
+      if (result != -1) {
+        return result;
+      }
       advance();
-      return read(cbuf, off, len);
     }
-    return result;
+    return -1;
   }
 
   @Override


### PR DESCRIPTION
Fixes #8661

## Summary
- replace recursive empty-source traversal in `MultiReader.read` with an iterative loop
- add a regression test covering 100,000 empty sources

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./mvnw -pl guava-tests -DskipAndroid=true -Dcheckstyle.skip=true test`
- focused `MultiReaderTest` passed after the fix

The regression was reproduced before the fix as a `StackOverflowError` while reading the concatenated source.