### PR TITLE
Short-circuit equals for same instance comparison

### DIFF
--- a/guava/src/com/google/common/reflect/Parameter.java
+++ b/guava/src/com/google/common/reflect/Parameter.java
@@ -138,6 +138,9 @@ public final class Parameter implements AnnotatedElement {
 
   @Override
   public boolean equals(@Nullable Object obj) {
+    if (obj == this) {
+      return true;
+    }
     if (obj instanceof Parameter) {
       Parameter that = (Parameter) obj;
       return position == that.position && declaration.equals(that.declaration);

--- a/guava/src/com/google/common/reflect/TypeParameter.java
+++ b/guava/src/com/google/common/reflect/TypeParameter.java
@@ -61,6 +61,9 @@ public abstract class TypeParameter<T> extends TypeCapture<T> {
 
   @Override
   public final boolean equals(@Nullable Object o) {
+    if (o == this) {
+      return true;
+    }
     if (o instanceof TypeParameter) {
       TypeParameter<?> that = (TypeParameter<?>) o;
       return typeVariable.equals(that.typeVariable);

--- a/guava/src/com/google/common/reflect/Types.java
+++ b/guava/src/com/google/common/reflect/Types.java
@@ -306,6 +306,9 @@ final class Types {
 
     @Override
     public boolean equals(@Nullable Object other) {
+      if (other == this) {
+        return true;
+      }
       if (!(other instanceof ParameterizedType)) {
         return false;
       }
@@ -506,6 +509,9 @@ final class Types {
 
     @Override
     public boolean equals(@Nullable Object obj) {
+      if (obj == this) {
+        return true;
+      }
       if (obj instanceof WildcardType) {
         WildcardType that = (WildcardType) obj;
         return lowerBounds.equals(asList(that.getLowerBounds()))


### PR DESCRIPTION
As a follow-up to the fix in #8427, add the short-circuit equals check more classes in the reflect package.
