### PR TITLE
Add guava-fuzzers module with Android immutable-collection hash-flooding harness

### DIFF
--- a/guava-fuzzers/pom.xml
+++ b/guava-fuzzers/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava-parent</artifactId>
+    <version>999.0.0-HEAD-jre-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>guava-fuzzers</artifactId>
+  <name>Guava Fuzz Harnesses</name>
+  <description>
+    Jazzer fuzz harnesses for Guava, built by OSS-Fuzz. This module is intentionally NOT
+    listed in the repo-root pom's modules, so ordinary Guava builds and releases do not
+    compile it, do not depend on Jazzer, and do not ship any harness. OSS-Fuzz builds the
+    harness directly (google/oss-fuzz#16117).
+  </description>
+
+  <properties>
+    <maven.install.skip>true</maven.install.skip>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.code-intelligence</groupId>
+      <artifactId>jazzer-api</artifactId>
+      <version>0.24.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/guava-fuzzers/src/main/java/AndroidImmutableCollectionsHashFloodingFuzzer.java
+++ b/guava-fuzzers/src/main/java/AndroidImmutableCollectionsHashFloodingFuzzer.java
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+/** Detects algorithmic-complexity hash flooding in Android-flavor immutable collections. */
+public final class AndroidImmutableCollectionsHashFloodingFuzzer {
+  // A magic prefix prevents ordinary random inputs from repeatedly exercising the maximum-cost
+  // case. Jazzer's comparison instrumentation can still discover this structured input.
+  private static final byte[] MAGIC = {'H', 'F', 'v', '1'};
+  private static final long MAX_REASONABLE_EQUALS = 1_000_000L;
+
+  private AndroidImmutableCollectionsHashFloodingFuzzer() {}
+
+  public static void fuzzerTestOneInput(byte[] input) {
+    if (input.length < MAGIC.length + 2 || !hasMagicPrefix(input)) {
+      return;
+    }
+
+    int collection = Byte.toUnsignedInt(input[MAGIC.length]) % 3;
+    int collisionBits = 6 + (Byte.toUnsignedInt(input[MAGIC.length + 1]) % 7);
+    int count = 1 << collisionBits;
+
+    CollisionKey.resetEqualsCalls();
+    switch (collection) {
+      case 0:
+        ImmutableMap.Builder<CollisionKey, Integer> map =
+            ImmutableMap.builderWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+          map.put(new CollisionKey(i, collisionBits), i);
+        }
+        map.buildOrThrow();
+        break;
+      case 1:
+        ImmutableSet.Builder<CollisionKey> set = ImmutableSet.builderWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+          set.add(new CollisionKey(i, collisionBits));
+        }
+        set.build();
+        break;
+      default:
+        ImmutableBiMap.Builder<CollisionKey, Integer> bimap = ImmutableBiMap.builder();
+        for (int i = 0; i < count; i++) {
+          bimap.put(new CollisionKey(i, collisionBits), i);
+        }
+        bimap.buildOrThrow();
+        break;
+    }
+
+    long equalsCalls = CollisionKey.equalsCalls();
+    if (equalsCalls > MAX_REASONABLE_EQUALS) {
+      throw new FuzzerSecurityIssueMedium(
+          "Probable hash-flooding algorithmic-complexity denial of service in "
+              + collectionName(collection)
+              + ": "
+              + count
+              + " distinct keys with one String hash required "
+              + equalsCalls
+              + " equals calls during construction (limit "
+              + MAX_REASONABLE_EQUALS
+              + ").");
+    }
+  }
+
+  private static boolean hasMagicPrefix(byte[] input) {
+    for (int i = 0; i < MAGIC.length; i++) {
+      if (input[i] != MAGIC[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String collectionName(int collection) {
+    switch (collection) {
+      case 0:
+        return "ImmutableMap";
+      case 1:
+        return "ImmutableSet";
+      default:
+        return "ImmutableBiMap";
+    }
+  }
+
+  /** Comparable wrapper around distinct strings from Java's Aa/BB collision family. */
+  private static final class CollisionKey implements Comparable<CollisionKey> {
+    private static long equalsCalls;
+    private final int id;
+    private final String value;
+
+    CollisionKey(int id, int bits) {
+      this.id = id;
+      StringBuilder result = new StringBuilder(bits * 2);
+      for (int bit = 0; bit < bits; bit++) {
+        result.append(((id >>> bit) & 1) == 0 ? "Aa" : "BB");
+      }
+      this.value = result.toString();
+    }
+
+    static void resetEqualsCalls() {
+      equalsCalls = 0;
+    }
+
+    static long equalsCalls() {
+      return equalsCalls;
+    }
+
+    @Override
+    public int hashCode() {
+      return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      equalsCalls++;
+      return other instanceof CollisionKey && value.equals(((CollisionKey) other).value);
+    }
+
+    @Override
+    public int compareTo(CollisionKey other) {
+      return Integer.compare(id, other.id);
+    }
+  }
+}


### PR DESCRIPTION
AndroidImmutableCollectionsHashFloodingFuzzer is a Jazzer harness that builds Android-flavor ImmutableMap/ImmutableSet/ImmutableBiMap from Aa/BB hash-colliding keys and flags quadratic equals() blow-up during construction. Uses only public construction APIs. Lives in a standalone guava-fuzzers module (not wired into the default reactor). Built by OSS-Fuzz from this checkout (google/oss-fuzz#16117); placement coordinated in #8669.

### What the harness does

It builds the **Android flavor** of `ImmutableMap`, `ImmutableSet` and
`ImmutableBiMap` from keys drawn from the classic `Aa`/`BB` String-hash-collision
family and counts `equals()` calls during construction. When construction of *N*
distinct-but-hash-colliding keys degrades to super-linear `equals()` work
(> 1,000,000 calls), it reports a `FuzzerSecurityIssueMedium`
(algorithmic-complexity / hash-flooding denial of service, availability only).

The harness uses **only public construction APIs** — no reflection, no internals.

### Module layout

```
guava-fuzzers/
  pom.xml
  src/main/java/AndroidImmutableCollectionsHashFloodingFuzzer.java
```

### Why a standalone module (not wired into the reactor)

The module intentionally is **not** listed in the root pom `<modules>`, so:

- normal `mvn install` / Guava releases do not build it,
- the main build graph gains no dependency on Jazzer,
- nothing ships a fuzz harness to users.

OSS-Fuzz compiles the harness directly with `javac` against base-builder-jvm's
Jazzer jar, so it never needs the module to be part of the reactor. The
`jazzer-api` dependency in `pom.xml` is only there so the module can be compiled
locally with Maven if desired.

Happy to wire it into `<modules>` instead if you'd prefer it built by CI — just
let me know.

### Testing

Verified end-to-end through OSS-Fuzz locally (`infra/helper.py build_fuzzers` +
`check_build` + `reproduce`): the target builds against the Android Guava jar and
the known hash-flooding input triggers the `FuzzerSecurityIssueMedium`. The
matching OSS-Fuzz build change (delete the harness copy there, repoint `build.sh`
to this module) is in google/oss-fuzz#16117 and will be landed after this merges.

Credit to OSS-Fuzz.